### PR TITLE
[impl-junior] safer-vp: skip zero rows in in-flight counts

### DIFF
--- a/bin/safer-vp
+++ b/bin/safer-vp
@@ -67,11 +67,10 @@ if command -v gh >/dev/null 2>&1 && [ "$REPO" != "unknown" ]; then
   echo "In flight (open issues by state label)"
   HAD_ANY=0
   for LABEL in planning review plan-approved implementing verifying; do
-    # gh counts via JSON length
-    COUNT=$(gh issue list --repo "$REPO" --state=open --label "$LABEL" --json number --limit 100 2>/dev/null \
-      | grep -cE '"number"' || echo 0)
-    COUNT=$(echo "$COUNT" | tr -d ' ')
-    if [ "$COUNT" != "0" ]; then
+    COUNT=$(gh issue list --repo "$REPO" --state=open --label "$LABEL" --json number --jq 'length' --limit 100 2>/dev/null || echo 0)
+    COUNT=$(printf '%s' "$COUNT" | tr -cd '0-9')
+    [ -z "$COUNT" ] && COUNT=0
+    if [ "$COUNT" -gt 0 ]; then
       printf '  %-18s %s\n' "$LABEL:" "$COUNT"
       HAD_ANY=1
     fi

--- a/tests/test-bin/test-vp.sh
+++ b/tests/test-bin/test-vp.sh
@@ -34,6 +34,37 @@ test_shows_calibration_with_events() {
   assert_contains "$out" "spec" "modality row shown"
 }
 
+test_no_bare_zero_in_in_flight() {
+  local state fake_gh out
+  state=$(mktemp -d)
+  fake_gh=$(mktemp -d)
+  mkdir -p "$state/analytics"
+  : > "$state/analytics/events.jsonl"
+  # Stub gh so the In-flight loop runs with REPO != "unknown" but counts are 0.
+  cat > "$fake_gh/gh" <<'EOF'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = "nameWithOwner" ]; then
+    echo "fake/repo"; exit 0
+  fi
+done
+echo "[]"
+exit 0
+EOF
+  chmod +x "$fake_gh/gh"
+  out=$(PATH="$fake_gh:$PATH" SAFER_STATE_DIR="$state" "$BIN" 7d 2>&1)
+  rm -rf "$state" "$fake_gh"
+  assert_contains "$out" "In flight" "in-flight section runs"
+  # Fail if any line is just "0" with nothing else.
+  if printf '%s\n' "$out" | grep -qE '^0$'; then
+    echo "    FAIL (bare zero line present)"
+    printf '%s\n' "$out" | sed 's/^/      /'
+    return 1
+  fi
+  return 0
+}
+
 run_test "safer-vp runs without events or gh" test_runs_without_events
 run_test "safer-vp shows calibration rows when events exist" test_shows_calibration_with_events
+run_test "safer-vp emits no bare 0 line for zero counts" test_no_bare_zero_in_in_flight
 report


### PR DESCRIPTION
Closes #16

## What changed

`safer-vp` in-flight loop piped `gh issue list ... | grep -c` through `|| echo 0`. When grep matched zero times it printed `0` *and* exited non-zero (under `pipefail`), so `|| echo 0` fired and `COUNT` captured `"0\n0"`. The `!= "0"` gate passed, and printf emitted a padded label row followed by a bare `0` line. Switched to `gh --jq 'length'` for a single numeric string, sanitized to digits, and compared with `-gt 0` so zero rows are truly skipped.

## Scope

- Module: `bin/safer-vp` (one binary)
- Tier: junior (one-file internals fix + one new test)
- New exported signatures: none
- New deps: none (uses existing `gh --jq`)

## Tests

- Existing 31 tests still pass.
- New: `safer-vp emits no bare 0 line for zero counts` — stubs `gh` so `REPO != "unknown"` but counts are 0, asserts no line in output is the literal `0`.
- `tests/run-tests.sh` → 32/32.

## Confidence

HIGH — reproduced the bug by reverting `bin/safer-vp` and watching the new test fail with the exact `0` stutter from the tracker; fix makes it pass.