### PR TITLE
skills: mandatory 2-min auto-monitor + communication discipline across modality skills

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -327,6 +327,23 @@ Nothing architect produces lives outside GitHub. No local-only design files. No 
 - [ ] `safer.skill_end` event emitted.
 - [ ] Status marker on the last line of your response.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md → Voice`. Architect's output is terse and structural. The design doc is a contract, not an essay. Your reply to the caller confirms publication; the design doc is the artifact.

--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -454,6 +454,23 @@ Nothing dogfood produces lives outside GitHub unless the input is a local file a
 
 If any box is unchecked, the status is not final; reopen the phase.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md` to Voice. The subagent's report is terse, concrete, and evidence-first. Every score is a number with a quoted phrase or a location. Every friction entry is a specific location and a specific reason. No "this might be improved by," no "I think the clarity could be higher."

--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -328,6 +328,23 @@ Post on the sub-issue; leave the branch in place with no cross-module edits comm
 - [ ] `safer.skill_end` event emitted.
 - [ ] Status marker on the last line of your response.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md → Voice`. Your PR body is terse and concrete: one paragraph of what changed, a scope summary, a confidence level with evidence. No prose about the journey.

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -346,6 +346,23 @@ Post on the sub-issue; leave the branch in place; revert any speculative cross-m
 - [ ] `safer.skill_end` event emitted.
 - [ ] Status marker on the last line of your response.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md → Voice`. Your PR body is terse, concrete, and plan-anchored. The plan-anchor table is the reviewer's fastest path to confidence; do not bury it.

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -393,6 +393,23 @@ Post on the sub-issue; leave the branch in place with the anchored work committe
 - [ ] `safer.skill_end` event emitted.
 - [ ] Status marker on the last line of your response.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md → Voice`. Staff PRs are the largest in the pipeline and the most dangerous to read as prose. Keep the PR body structural: tables, lists, anchors. The reviewer and verify both need to find anchors fast.

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -354,6 +354,23 @@ Every code-review output is a comment on the bug issue or the sub-issue. Nothing
 
 If any box is unchecked, you are not `DONE`.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md` to Voice. Write for the cold-start reader. The next agent applying the fix has none of your context. Every `file:line` pointer, every isolation row, every bit of evidence is what lets them pick up the work without asking you.

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -412,17 +412,19 @@ If rejected:
 - Transition `review` → `planning` (the modality revises).
 - Do not revise the artifact yourself.
 
-### Step 5d — Auto-monitor loop
+### Step 5d — Auto-monitor loop (MANDATORY)
 
-Teammates complete asynchronously. Polling every sub-issue by hand is how orchestrate drifts into idle sit-and-wait. Install a recurring check instead.
+**This step is mandatory for every orchestrate run that dispatches more than one teammate.** Skipping it is a stop-rule violation: orchestrate sitting idle between user prompts defeats the entire point of async dispatch.
+
+Teammates complete asynchronously. Polling every sub-issue by hand is how orchestrate drifts into idle sit-and-wait. The loop runs the sweep for you.
 
 **Why.** Without a loop, the team lead either spins waiting for prompts or wakes up only when the user nudges. Both defeat the point of orchestration. The loop is how orchestrate earns the "scrum master who reads `gh issue list`" framing at runtime.
 
-**Install.** Use `CronCreate` with a session-only job (`recurring: true`, `durable: false`). Default cadence is every 5 minutes:
+**Install.** Run `CronCreate` **before your first dispatch**, not after. Session-only job (`recurring: true`, `durable: false`). Mandatory cadence is every 2 minutes:
 
 ```
 CronCreate({
-  schedule: "*/5 * * * *",
+  schedule: "*/2 * * * *",
   recurring: true,
   durable: false,
   prompt: "<loop body — see below>"
@@ -473,10 +475,11 @@ If any check above is ambiguous, the loop skips that action and leaves it for th
 
 **Tuning the interval.**
 
+Default is `*/2 * * * *` (every 2 minutes) and you should not change it without a specific reason. Slower intervals make idle-teammate and merge-ready PR detection lag by multiple minutes and re-introduce the exact "orchestrate sits idle" failure this step exists to prevent.
+
 | Epic shape | Interval |
 |---|---|
-| Active epic, multiple teammates in flight | `*/5 * * * *` (5 min) |
-| Low-churn epic, mostly waiting on CI | `*/30 * * * *` (30 min) or hourly |
+| Any active epic with teammates dispatched | `*/2 * * * *` (2 min — mandatory default) |
 | Single-modality task | no loop; orchestrate is the wrong skill |
 
 **Cancel.** Keep the job id from `CronCreate`. To stop the loop: `CronDelete({ jobId: "<id>" })`. Also run this in Phase 7 at close-out (see below).

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -356,6 +356,23 @@ The probe scripts are never merged. They can be deleted after the final report i
 
 If any box is unchecked, the status is not `DONE`.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md` voice section. The ledger is dense. Numbers over adjectives. Named sources over gestures. The Researcher voice is confident; the Supervisor voice is adversarial. Both are direct. The next agent reading the ledger wants the CLAIM / RATING structure, not prose narration. Give them the structure.

--- a/skills/review-senior/SKILL.md
+++ b/skills/review-senior/SKILL.md
@@ -344,6 +344,23 @@ Nothing review-senior produces lives outside GitHub.
 - [ ] `safer.skill_end` event emitted.
 - [ ] Status marker on the last line of your reply.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md` to Voice. Review comments are terse, concrete, and end with what to do. Not "this might be improved by..." but "move this check to the schema at `src/api/body.ts:18`; the runtime check at line 42 becomes unnecessary."

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -222,6 +222,23 @@ Every invocation ends with exactly one status marker on the last line of your re
 - [ ] `safer.skill_end` event emitted with outcome and issue number.
 - [ ] Status marker on the last line of your response.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md → Voice`. The spec itself is terse and concrete. Your reply to the user is a confirmation of publication, not a re-statement of the spec content. The user will read the spec from GitHub, not from your chat output.

--- a/skills/spike/SKILL.md
+++ b/skills/spike/SKILL.md
@@ -348,6 +348,23 @@ The branch is not a PR. Do not open a PR. PRs signal intent to merge; spike bran
 
 If any box is unchecked, the status is not `DONE`.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md` voice section. The verdict is terse. Numbers over adjectives. The evidence block speaks for the code. No AI filler. End with the status marker.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -334,6 +334,23 @@ Nothing verify produces lives outside GitHub.
 
 If any box is unchecked, you are not `DONE`.
 
+## Communication discipline
+
+Before you post a status marker or close your turn, **SendMessage to `team-lead` immediately** with a one-line summary and the artifact URL. The team-lead is coordinating other teammates and cannot gate your handoff until it receives a push notification. Do not make the team-lead poll.
+
+```
+SendMessage({
+  to: "team-lead",
+  summary: "<3-8 word summary>",
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+})
+```
+
+Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
+
+If you were invoked outside an orchestrate context (no team), skip this step.
+
+
 ## Voice (reminder)
 
 See `PRINCIPLES.md` to Voice. The verdict is terse, mechanical, and evidence-backed. Not "looks good to me" but "SHIP: lint 0, typecheck 0, test 142/142; criteria 1-3 met with evidence at `src/foo.ts:18`, `src/foo.test.ts:42`."


### PR DESCRIPTION
Per user direct override:
1. /safer:orchestrate auto-monitor loop is now MANDATORY (was optional) and runs every 2 min (was 5).
2. All 11 workflow modality skills get a new 'Communication discipline' section requiring immediate SendMessage to team-lead on completion.

No back-compat shims needed; per PRINCIPLES.md corollary.