### PR TITLE
[impl-senior] bot-token routing: safer-publish broker + verify + fallback flags

### DIFF
--- a/bin/safer-publish
+++ b/bin/safer-publish
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
-# safer-publish — publish an artifact to GitHub. Composition:
-#   1. If zapbot is installed and --kind is epic or issue with a plan file,
-#      the skill invoking safer-publish should prefer /zapbot-publish directly.
-#      This binary is the mechanical path and always uses gh.
-#   2. Otherwise, use gh issue create / gh issue comment / gh pr comment.
+# safer-publish — publish an artifact to GitHub.
 #
-# Args:
+# Identity routing: when zapbot is detected on the host, route the single
+# inner `gh` call through zapbot's bot-token broker so the resulting
+# issue/PR/comment is authored by the GitHub App installation identity.
+# When zapbot is not detected, fall back silently to the user's gh auth.
+#
+# Strict mode is the default: any broker failure halts the invocation
+# unless --allow-pat-fallback is explicitly set.
+#
+# Args (existing):
 #   --kind <epic|issue|comment|pr-comment>    required
 #   --title <title>                           required for epic, issue
 #   --body-file <path>                        body source (for all kinds)
@@ -15,9 +19,229 @@
 #   --issue <n>                               target issue (comment)
 #   --pr <n>                                  target PR (pr-comment)
 #   --repo <o/r>                              override repo
-# Output: URL of the created/updated artifact.
-# Exit: 0 on success, 1 on gh/validation failure.
+#
+# Args (new, per spec #15 / design #19):
+#   --allow-pat-fallback                      if broker non-2xx, warn + use PAT
+#   --attribute-to-user                       skip broker + verify; use PAT
+#
+# Exit codes (see docs/arch/bot-token-routing.md §Errors):
+#   0   success
+#   1   validation / gh failure under user mode
+#   10  bridge TCP fail
+#   11  bridge 401
+#   12  bridge 409 app_not_configured
+#   13  bridge 5xx
+#   14  bridge schema-invalid
+#   20  attribution mismatch
+#   21  gh failure under bot mode
+#   22  flags conflict (--allow-pat-fallback + --attribute-to-user)
+
 set -uo pipefail
+
+# ── Identity helpers (new) ──────────────────────────────────────────
+
+SAFER_ALLOW_PAT_FALLBACK=0
+SAFER_ATTRIBUTE_TO_USER=0
+ZAPBOT_DETECTED=0
+
+# detect_zapbot — filesystem probe. Sets ZAPBOT_DETECTED. Always exits 0.
+detect_zapbot() {
+  if [ -f "$HOME/.zapbot/.env" ] || [ -f "$HOME/.zapbot/config.json" ]; then
+    ZAPBOT_DETECTED=1
+  else
+    ZAPBOT_DETECTED=0
+  fi
+  return 0
+}
+
+# resolve_bridge_url — yaml → env → default. Mirrors zapbot-publish.sh:11-20.
+# Echoes the URL. Exits non-zero only if yaml exists but parse produces empty.
+resolve_bridge_url() {
+  local url=""
+  if [ -f "agent-orchestrator.yaml" ]; then
+    url=$(grep -E '^bridge_url:[[:space:]]*' agent-orchestrator.yaml | awk '{print $2}')
+    if [ -z "$url" ] && grep -qE '^bridge_url:' agent-orchestrator.yaml; then
+      echo "safer-publish: agent-orchestrator.yaml bridge_url: is empty" >&2
+      return 1
+    fi
+  fi
+  if [ -z "$url" ]; then
+    url="${ZAPBOT_BRIDGE_URL:-http://localhost:3000}"
+  fi
+  echo "$url"
+}
+
+# handle_fallback_flags — parse --allow-pat-fallback, --attribute-to-user.
+# Sets SAFER_ALLOW_PAT_FALLBACK, SAFER_ATTRIBUTE_TO_USER. Populates the
+# SAFER_RESIDUAL_ARGS global array with positional args after the identity
+# flags have been stripped. Returns 22 on co-presence.
+handle_fallback_flags() {
+  SAFER_RESIDUAL_ARGS=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --allow-pat-fallback) SAFER_ALLOW_PAT_FALLBACK=1; shift ;;
+      --attribute-to-user)  SAFER_ATTRIBUTE_TO_USER=1; shift ;;
+      *) SAFER_RESIDUAL_ARGS+=("$1"); shift ;;
+    esac
+  done
+  if [ "$SAFER_ALLOW_PAT_FALLBACK" = "1" ] && [ "$SAFER_ATTRIBUTE_TO_USER" = "1" ]; then
+    echo "safer-publish: --allow-pat-fallback and --attribute-to-user are mutually exclusive" >&2
+    return 22
+  fi
+  return 0
+}
+
+# fetch_broker_token — GET <url>/api/tokens/installation with Bearer auth.
+# Echoes the bare token on stdout. Exit codes: 0 ok, 10 TCP, 11 401,
+# 12 409, 13 5xx, 14 schema-invalid.
+fetch_broker_token() {
+  local base="$1"
+  local url="${base%/}/api/tokens/installation"
+  local body status
+  local tmp
+  tmp=$(mktemp)
+  # -sS shows errors but not progress; -w writes status to stdout; body goes to tmp.
+  status=$(curl -sS -o "$tmp" -w '%{http_code}' \
+    -H "Authorization: Bearer ${ZAPBOT_API_KEY:-}" \
+    "$url" 2>/dev/null)
+  local rc=$?
+  if [ $rc -ne 0 ] || [ -z "$status" ] || [ "$status" = "000" ]; then
+    rm -f "$tmp"
+    echo "safer-publish: broker connection_refused at $url" >&2
+    return 10
+  fi
+  body=$(cat "$tmp")
+  rm -f "$tmp"
+  case "$status" in
+    200)
+      # Schema: require .token string AND .expires_at string. expires_at parsed
+      # then discarded (design §Architect-flagged).
+      if ! echo "$body" | jq -e '(.token | type == "string") and (.expires_at | type == "string")' >/dev/null 2>&1; then
+        echo "safer-publish: broker schema_invalid at $url" >&2
+        return 14
+      fi
+      echo "$body" | jq -r '.token'
+      return 0
+      ;;
+    401)
+      echo "safer-publish: broker unauthorized at $url" >&2
+      return 11
+      ;;
+    409)
+      echo "safer-publish: broker app_not_configured at $url" >&2
+      return 12
+      ;;
+    5??)
+      echo "safer-publish: broker server_error at $url" >&2
+      return 13
+      ;;
+    *)
+      # 404 from older zapbots without the endpoint, 4xx from misconfig, etc.
+      # Design §Migration order: these map to server_error.
+      echo "safer-publish: broker server_error at $url" >&2
+      return 13
+      ;;
+  esac
+}
+
+# verify_attribution — `gh api $RESOURCE --jq .user.type` == "Bot".
+# Emits stderr with the resource URL on mismatch.
+verify_attribution() {
+  local resource_url="$1"
+  # gh api accepts the full URL form (api.github.com) or owner/repo/issues/N;
+  # normalize by converting a browser URL into the API path.
+  local api_path
+  api_path=$(_resource_url_to_api_path "$resource_url")
+  local user_type
+  user_type=$(gh api "$api_path" --jq '.user.type' 2>/dev/null || echo "")
+  if [ "$user_type" = "Bot" ]; then
+    return 0
+  fi
+  echo "safer-publish: attribution verify failed $resource_url" >&2
+  return 20
+}
+
+# _resource_url_to_api_path — turn a browser URL into the gh api path.
+# Issue:   https://github.com/O/R/issues/N           -> repos/O/R/issues/N
+# PR:      https://github.com/O/R/pull/N             -> repos/O/R/pulls/N
+# Issue comment: https://github.com/O/R/issues/N#issuecomment-ID
+#                                                    -> repos/O/R/issues/comments/ID
+# PR comment:  https://github.com/O/R/pull/N#issuecomment-ID
+#                                                    -> repos/O/R/issues/comments/ID
+_resource_url_to_api_path() {
+  local u="$1"
+  # Strip https://github.com/
+  local path="${u#https://github.com/}"
+  # Comment anchor → comments path (issue + PR comments share /issues/comments/ID)
+  if [[ "$path" == *"#issuecomment-"* ]]; then
+    local owner_repo="${path%%/issues/*}"
+    owner_repo="${owner_repo%%/pull/*}"
+    local comment_id="${path##*#issuecomment-}"
+    echo "repos/$owner_repo/issues/comments/$comment_id"
+    return 0
+  fi
+  # Plain PR
+  if [[ "$path" == */pull/* ]]; then
+    echo "repos/${path/\/pull\//\/pulls\/}"
+    return 0
+  fi
+  # Plain issue
+  if [[ "$path" == */issues/* ]]; then
+    echo "repos/$path"
+    return 0
+  fi
+  # Unknown shape — fall through; let gh surface its own error.
+  echo "$u"
+}
+
+# resolve_identity_mode — echo bot | user | user-fallback.
+# Inputs: ZAPBOT_DETECTED, SAFER_ATTRIBUTE_TO_USER, SAFER_ALLOW_PAT_FALLBACK,
+#         and $1 = broker_outcome ("hit" | "miss" | "na").
+# Deterministic by the decision table in docs/arch/bot-token-routing.md.
+resolve_identity_mode() {
+  local broker="$1"
+  if [ "$ZAPBOT_DETECTED" = "0" ]; then
+    echo "user"
+    return 0
+  fi
+  if [ "$SAFER_ATTRIBUTE_TO_USER" = "1" ]; then
+    echo "user"
+    return 0
+  fi
+  if [ "$broker" = "hit" ]; then
+    echo "bot"
+    return 0
+  fi
+  # broker == miss (or na, which shouldn't occur in D=1 U=0); fallback decides.
+  if [ "$SAFER_ALLOW_PAT_FALLBACK" = "1" ]; then
+    echo "user-fallback"
+    return 0
+  fi
+  # Strict mode: hard fail; caller turns this into exit 10-14.
+  echo "strict-fail"
+  return 0
+}
+
+# run_gh_as_bot — invoke gh with GH_TOKEN=<token>, GITHUB_TOKEN unset.
+# Bounded to the child process; no parent-env leakage.
+run_gh_as_bot() {
+  local token="$1"
+  shift
+  env -u GITHUB_TOKEN GH_TOKEN="$token" gh "$@"
+}
+
+# ── Fallback-flag parse (must run before existing option parser) ────
+
+# Guard: when sourced by tests (SAFER_PUBLISH_SOURCE=1), do not parse argv
+# or run the dispatch. Tests call the functions directly.
+if [ "${SAFER_PUBLISH_SOURCE:-0}" = "1" ]; then
+  return 0 2>/dev/null || true
+fi
+
+handle_fallback_flags "$@" || exit $?
+set -- "${SAFER_RESIDUAL_ARGS[@]}"
+
+# ── Existing arg parser (unchanged below) ───────────────────────────
 
 KIND=""
 TITLE=""
@@ -59,7 +283,6 @@ fi
 REPO_FLAG=()
 [ -n "$REPO" ] && REPO_FLAG=(--repo "$REPO")
 
-# Build body arg array
 body_args=()
 if [ -n "$BODY_FILE" ]; then
   body_args=(--body-file "$BODY_FILE")
@@ -67,7 +290,6 @@ elif [ -n "$BODY" ]; then
   body_args=(--body "$BODY")
 fi
 
-# If this is an issue/epic with a --parent, prepend the parent reference to the body
 TMP_BODY=""
 if [ "$KIND" = "issue" ] && [ -n "$PARENT" ]; then
   TMP_BODY=$(mktemp)
@@ -90,20 +312,93 @@ if [ -n "$LABELS" ]; then
   for L in "${LBL_ARR[@]}"; do label_args+=(--label "$L"); done
 fi
 
+# ── Identity resolution ─────────────────────────────────────────────
+
+detect_zapbot
+
+BOT_TOKEN=""
+BROKER_OUTCOME="na"
+FETCH_RC=0
+BRIDGE_URL=""
+
+if [ "$ZAPBOT_DETECTED" = "1" ] && [ "$SAFER_ATTRIBUTE_TO_USER" = "0" ]; then
+  BRIDGE_URL=$(resolve_bridge_url) || exit 1
+  if BOT_TOKEN=$(fetch_broker_token "$BRIDGE_URL"); then
+    BROKER_OUTCOME="hit"
+  else
+    FETCH_RC=$?
+    BROKER_OUTCOME="miss"
+  fi
+fi
+
+IDENTITY_MODE=$(resolve_identity_mode "$BROKER_OUTCOME")
+
+case "$IDENTITY_MODE" in
+  strict-fail)
+    # fetch_broker_token already emitted the structured single-line error on
+    # stderr. Supplement with the multi-line UX block (design §Errors).
+    probe_desc=""
+    case "$FETCH_RC" in
+      10) probe_desc="connection_refused" ;;
+      11) probe_desc="401 unauthorized" ;;
+      12) probe_desc="409 app_not_configured" ;;
+      13) probe_desc="5xx server_error" ;;
+      14) probe_desc="schema_invalid" ;;
+      *)  probe_desc="unknown" ;;
+    esac
+    detected_path="$HOME/.zapbot/.env"
+    [ -f "$HOME/.zapbot/config.json" ] && [ ! -f "$HOME/.zapbot/.env" ] && detected_path="$HOME/.zapbot/config.json"
+    {
+      echo ""
+      echo "safer-publish: cannot reach zapbot token broker."
+      echo ""
+      echo "  Bridge:    $BRIDGE_URL"
+      echo "  Probe:     $probe_desc"
+      echo "  Detected:  $detected_path"
+      echo ""
+      echo "  Hint: re-run with --allow-pat-fallback to use your gh auth,"
+      echo "        or start the bridge: ~/.zapbot/start.sh"
+    } >&2
+    exit $FETCH_RC
+    ;;
+  user-fallback)
+    echo "safer-publish: broker unreachable ($FETCH_RC) at $BRIDGE_URL; falling back to gh default auth" >&2
+    ;;
+  user|bot)
+    : # handled below
+    ;;
+  *)
+    echo "safer-publish: internal error: unknown identity mode '$IDENTITY_MODE'" >&2
+    exit 1
+    ;;
+esac
+
+# ── Dispatch (existing gh commands, gated by identity mode) ─────────
+
+_run_gh() {
+  if [ "$IDENTITY_MODE" = "bot" ]; then
+    run_gh_as_bot "$BOT_TOKEN" "$@"
+  else
+    gh "$@"
+  fi
+}
+
+OUT=""
+RC=0
 case "$KIND" in
   epic|issue)
     [ -z "$TITLE" ] && { echo "ERROR: --title required for $KIND" >&2; exit 1; }
-    OUT=$(gh issue create "${REPO_FLAG[@]}" --title "$TITLE" "${body_args[@]}" "${label_args[@]}" 2>&1)
+    OUT=$(_run_gh issue create "${REPO_FLAG[@]}" --title "$TITLE" "${body_args[@]}" "${label_args[@]}" 2>&1)
     RC=$?
     ;;
   comment)
     [ -z "$ISSUE" ] && { echo "ERROR: --issue required for comment" >&2; exit 1; }
-    OUT=$(gh issue comment "$ISSUE" "${REPO_FLAG[@]}" "${body_args[@]}" 2>&1)
+    OUT=$(_run_gh issue comment "$ISSUE" "${REPO_FLAG[@]}" "${body_args[@]}" 2>&1)
     RC=$?
     ;;
   pr-comment)
     [ -z "$PR" ] && { echo "ERROR: --pr required for pr-comment" >&2; exit 1; }
-    OUT=$(gh pr comment "$PR" "${REPO_FLAG[@]}" "${body_args[@]}" 2>&1)
+    OUT=$(_run_gh pr comment "$PR" "${REPO_FLAG[@]}" "${body_args[@]}" 2>&1)
     RC=$?
     ;;
   *)
@@ -112,9 +407,27 @@ case "$KIND" in
     ;;
 esac
 
-if [ $RC -eq 0 ]; then
-  echo "$OUT"
-  exit 0
+if [ $RC -ne 0 ]; then
+  if [ "$IDENTITY_MODE" = "bot" ]; then
+    echo "$OUT" >&2
+    echo "safer-publish: gh failed under bot mode" >&2
+    exit 21
+  fi
+  echo "ERROR: gh command failed: $OUT" >&2
+  exit 1
 fi
-echo "ERROR: gh command failed: $OUT" >&2
-exit 1
+
+echo "$OUT"
+
+# ── Post-hoc attribution verify (bot mode only) ─────────────────────
+
+if [ "$IDENTITY_MODE" = "bot" ]; then
+  RESOURCE_URL=$(echo "$OUT" | grep -oE 'https://github\.com/[^ ]+' | head -1)
+  if [ -n "$RESOURCE_URL" ]; then
+    if ! verify_attribution "$RESOURCE_URL"; then
+      exit 20
+    fi
+  fi
+fi
+
+exit 0

--- a/tests/test-bin/test-publish-bot-routing.sh
+++ b/tests/test-bin/test-publish-bot-routing.sh
@@ -1,0 +1,490 @@
+#!/usr/bin/env bash
+# Unit tests for bin/safer-publish bot-token routing (spec #15, design #19).
+# Covers: detect_zapbot, resolve_bridge_url, fetch_broker_token,
+# verify_attribution, resolve_identity_mode, handle_fallback_flags, plus the
+# three integration branches (strict fail, user-fallback warn, bot success).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/../test-helpers.sh"
+
+PLUGIN_DIR="$(cd "$HERE/../.." && pwd)"
+BIN="$PLUGIN_DIR/bin/safer-publish"
+
+# ── Sandbox setup ───────────────────────────────────────────────────
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+export HOME="$SANDBOX/home"
+mkdir -p "$HOME"
+
+# Mock bin on PATH for curl + gh stubs. Preserve real PATH for jq, mktemp, etc.
+export MOCK_BIN="$SANDBOX/mock-bin"
+mkdir -p "$MOCK_BIN"
+ORIG_PATH="$PATH"
+export PATH="$MOCK_BIN:$PATH"
+
+# Scratchpad the mocks use to record calls.
+export MOCK_LOG="$SANDBOX/mock.log"
+
+_reset_sandbox() {
+  rm -rf "$HOME"
+  mkdir -p "$HOME"
+  rm -f "$MOCK_LOG"
+  rm -f "$MOCK_BIN/curl" "$MOCK_BIN/gh"
+  unset ZAPBOT_API_KEY ZAPBOT_BRIDGE_URL
+}
+
+# Install a curl stub. $1 = status code, $2 = body.
+_mock_curl() {
+  local status="$1" body="$2"
+  cat > "$MOCK_BIN/curl" <<EOF
+#!/usr/bin/env bash
+# Parse -o <outfile> so the caller gets the body.
+outfile=""
+args=("\$@")
+for i in "\${!args[@]}"; do
+  if [ "\${args[\$i]}" = "-o" ]; then
+    outfile="\${args[\$((i+1))]}"
+  fi
+done
+echo "curl \$*" >> "$MOCK_LOG"
+if [ -n "\$outfile" ]; then
+  printf '%s' '$body' > "\$outfile"
+fi
+printf '%s' '$status'
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/curl"
+}
+
+# Install a curl stub that simulates TCP failure (status "000", rc nonzero).
+_mock_curl_tcp_fail() {
+  cat > "$MOCK_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "curl $*" >> "$MOCK_LOG"
+printf '000'
+exit 7
+EOF
+  chmod +x "$MOCK_BIN/curl"
+}
+
+# Install a gh stub. $1 = stdout text to echo, $2 = exit code (default 0).
+_mock_gh() {
+  local out="$1" rc="${2:-0}"
+  cat > "$MOCK_BIN/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "$MOCK_LOG"
+# Pass-through for 'gh api <path> --jq .user.type' — echo whatever was staged
+# in MOCK_USER_TYPE (default: "Bot").
+for a in "\$@"; do
+  if [ "\$a" = "api" ]; then
+    echo "\${MOCK_USER_TYPE:-Bot}"
+    exit 0
+  fi
+done
+printf '%s\n' '$out'
+exit $rc
+EOF
+  chmod +x "$MOCK_BIN/gh"
+}
+
+_source_publish() {
+  # shellcheck disable=SC1090
+  SAFER_PUBLISH_SOURCE=1 source "$BIN"
+}
+
+# ── detect_zapbot ───────────────────────────────────────────────────
+
+test_detect_zapbot_env() {
+  _reset_sandbox
+  touch "$HOME/.zapbot/.env" 2>/dev/null || { mkdir -p "$HOME/.zapbot" && touch "$HOME/.zapbot/.env"; }
+  _source_publish
+  detect_zapbot
+  assert_equal "$ZAPBOT_DETECTED" "1" "detect .env"
+}
+
+test_detect_zapbot_config_json() {
+  _reset_sandbox
+  mkdir -p "$HOME/.zapbot"
+  echo '{}' > "$HOME/.zapbot/config.json"
+  _source_publish
+  detect_zapbot
+  assert_equal "$ZAPBOT_DETECTED" "1" "detect config.json"
+}
+
+test_detect_zapbot_absent() {
+  _reset_sandbox
+  _source_publish
+  detect_zapbot
+  assert_equal "$ZAPBOT_DETECTED" "0" "no zapbot → 0"
+}
+
+# ── resolve_bridge_url ──────────────────────────────────────────────
+
+test_resolve_bridge_default() {
+  _reset_sandbox
+  _source_publish
+  cd "$SANDBOX"
+  local url
+  url=$(resolve_bridge_url)
+  assert_equal "$url" "http://localhost:3000" "default URL"
+}
+
+test_resolve_bridge_env_override() {
+  _reset_sandbox
+  export ZAPBOT_BRIDGE_URL="http://otherhost:9000"
+  _source_publish
+  cd "$SANDBOX"
+  local url
+  url=$(resolve_bridge_url)
+  unset ZAPBOT_BRIDGE_URL
+  assert_equal "$url" "http://otherhost:9000" "env override"
+}
+
+test_resolve_bridge_yaml_beats_env() {
+  _reset_sandbox
+  export ZAPBOT_BRIDGE_URL="http://env-host:9000"
+  local dir="$SANDBOX/yaml-dir"
+  mkdir -p "$dir"
+  echo "bridge_url: http://yaml-host:8080" > "$dir/agent-orchestrator.yaml"
+  _source_publish
+  cd "$dir"
+  local url
+  url=$(resolve_bridge_url)
+  unset ZAPBOT_BRIDGE_URL
+  cd "$SANDBOX"
+  assert_equal "$url" "http://yaml-host:8080" "yaml beats env"
+}
+
+# ── fetch_broker_token ──────────────────────────────────────────────
+
+test_fetch_token_happy_path() {
+  _reset_sandbox
+  export ZAPBOT_API_KEY="test-key"
+  _mock_curl 200 '{"token":"ghs_abc123","expires_at":"2026-04-18T01:00:00Z"}'
+  _source_publish
+  local token rc
+  token=$(fetch_broker_token "http://localhost:3000"); rc=$?
+  assert_equal "$rc" "0" "ok rc" || return 1
+  assert_equal "$token" "ghs_abc123" "token extracted"
+}
+
+test_fetch_token_tcp_fail_returns_10() {
+  _reset_sandbox
+  export ZAPBOT_API_KEY="test-key"
+  _mock_curl_tcp_fail
+  _source_publish
+  local err rc
+  err=$(fetch_broker_token "http://localhost:3000" 2>&1 >/dev/null); rc=$?
+  assert_equal "$rc" "10" "TCP fail rc" || return 1
+  assert_contains "$err" "connection_refused" "TCP stderr"
+}
+
+test_fetch_token_401_returns_11() {
+  _reset_sandbox
+  export ZAPBOT_API_KEY="test-key"
+  _mock_curl 401 '{"error":{"type":"unauthorized","message":"x","status":401}}'
+  _source_publish
+  local rc
+  fetch_broker_token "http://localhost:3000" 2>/dev/null >/dev/null; rc=$?
+  assert_equal "$rc" "11" "401 rc"
+}
+
+test_fetch_token_409_returns_12() {
+  _reset_sandbox
+  export ZAPBOT_API_KEY="test-key"
+  _mock_curl 409 '{"error":"app_not_configured","message":"x"}'
+  _source_publish
+  local rc
+  fetch_broker_token "http://localhost:3000" 2>/dev/null >/dev/null; rc=$?
+  assert_equal "$rc" "12" "409 rc"
+}
+
+test_fetch_token_500_returns_13() {
+  _reset_sandbox
+  export ZAPBOT_API_KEY="test-key"
+  _mock_curl 503 '{"error":"internal_error","message":"x"}'
+  _source_publish
+  local rc
+  fetch_broker_token "http://localhost:3000" 2>/dev/null >/dev/null; rc=$?
+  assert_equal "$rc" "13" "5xx rc"
+}
+
+test_fetch_token_schema_invalid_returns_14() {
+  _reset_sandbox
+  export ZAPBOT_API_KEY="test-key"
+  _mock_curl 200 '{"wrong":"shape"}'
+  _source_publish
+  local err rc
+  err=$(fetch_broker_token "http://localhost:3000" 2>&1 >/dev/null); rc=$?
+  assert_equal "$rc" "14" "schema rc" || return 1
+  assert_contains "$err" "schema_invalid" "schema stderr"
+}
+
+# ── handle_fallback_flags ───────────────────────────────────────────
+
+test_flags_default_both_zero() {
+  _reset_sandbox
+  _source_publish
+  handle_fallback_flags --kind issue --title t
+  assert_equal "$SAFER_ALLOW_PAT_FALLBACK" "0" "default pat=0" || return 1
+  assert_equal "$SAFER_ATTRIBUTE_TO_USER" "0" "default user=0" || return 1
+  assert_equal "${SAFER_RESIDUAL_ARGS[0]}" "--kind" "residual[0]" || return 1
+  assert_equal "${SAFER_RESIDUAL_ARGS[1]}" "issue" "residual[1]" || return 1
+  assert_equal "${#SAFER_RESIDUAL_ARGS[@]}" "4" "4 residual"
+}
+
+test_flags_pat_consumed() {
+  _reset_sandbox
+  _source_publish
+  handle_fallback_flags --allow-pat-fallback --kind issue
+  assert_equal "$SAFER_ALLOW_PAT_FALLBACK" "1" "pat set" || return 1
+  assert_equal "${#SAFER_RESIDUAL_ARGS[@]}" "2" "flag stripped"
+}
+
+test_flags_attribute_consumed() {
+  _reset_sandbox
+  _source_publish
+  handle_fallback_flags --attribute-to-user --kind comment
+  assert_equal "$SAFER_ATTRIBUTE_TO_USER" "1" "user attr set"
+}
+
+test_flags_both_together_returns_22() {
+  _reset_sandbox
+  _source_publish
+  local rc err
+  err=$(handle_fallback_flags --allow-pat-fallback --attribute-to-user 2>&1); rc=$?
+  assert_equal "$rc" "22" "conflict rc" || return 1
+  assert_contains "$err" "mutually exclusive" "stderr"
+}
+
+# ── resolve_identity_mode ───────────────────────────────────────────
+
+test_mode_no_detection_user() {
+  _reset_sandbox
+  _source_publish
+  ZAPBOT_DETECTED=0
+  SAFER_ATTRIBUTE_TO_USER=0
+  SAFER_ALLOW_PAT_FALLBACK=0
+  local m
+  m=$(resolve_identity_mode "na")
+  assert_equal "$m" "user" "D=0 → user"
+}
+
+test_mode_detected_bot_hit() {
+  _reset_sandbox
+  _source_publish
+  ZAPBOT_DETECTED=1
+  SAFER_ATTRIBUTE_TO_USER=0
+  SAFER_ALLOW_PAT_FALLBACK=0
+  local m
+  m=$(resolve_identity_mode "hit")
+  assert_equal "$m" "bot" "D=1 hit → bot"
+}
+
+test_mode_detected_miss_strict_fail() {
+  _reset_sandbox
+  _source_publish
+  ZAPBOT_DETECTED=1
+  SAFER_ATTRIBUTE_TO_USER=0
+  SAFER_ALLOW_PAT_FALLBACK=0
+  local m
+  m=$(resolve_identity_mode "miss")
+  assert_equal "$m" "strict-fail" "D=1 miss strict → fail"
+}
+
+test_mode_detected_miss_allow_pat() {
+  _reset_sandbox
+  _source_publish
+  ZAPBOT_DETECTED=1
+  SAFER_ATTRIBUTE_TO_USER=0
+  SAFER_ALLOW_PAT_FALLBACK=1
+  local m
+  m=$(resolve_identity_mode "miss")
+  assert_equal "$m" "user-fallback" "D=1 miss + F=1 → user-fallback"
+}
+
+test_mode_attribute_to_user_forces_user() {
+  _reset_sandbox
+  _source_publish
+  ZAPBOT_DETECTED=1
+  SAFER_ATTRIBUTE_TO_USER=1
+  SAFER_ALLOW_PAT_FALLBACK=0
+  local m
+  m=$(resolve_identity_mode "hit")
+  assert_equal "$m" "user" "U=1 → user"
+}
+
+# ── verify_attribution ──────────────────────────────────────────────
+
+test_verify_attribution_bot_passes() {
+  _reset_sandbox
+  export MOCK_USER_TYPE="Bot"
+  _mock_gh "unused"
+  _source_publish
+  local rc
+  verify_attribution "https://github.com/o/r/issues/5" >/dev/null 2>&1; rc=$?
+  assert_equal "$rc" "0" "bot passes"
+}
+
+test_verify_attribution_user_fails_20() {
+  _reset_sandbox
+  export MOCK_USER_TYPE="User"
+  _mock_gh "unused"
+  _source_publish
+  local rc err
+  err=$(verify_attribution "https://github.com/o/r/issues/5" 2>&1); rc=$?
+  assert_equal "$rc" "20" "user type fails" || return 1
+  assert_contains "$err" "attribution verify failed" "stderr msg"
+}
+
+# ── End-to-end flow: no zapbot → runs gh directly, no broker call ───
+
+test_e2e_no_zapbot_user_silent() {
+  _reset_sandbox
+  _mock_gh "https://github.com/o/r/issues/42"
+  local out rc
+  out=$("$BIN" --kind comment --issue 42 --body "hi" 2>&1); rc=$?
+  assert_equal "$rc" "0" "exit ok" || return 1
+  assert_contains "$out" "https://github.com/o/r/issues/42" "resource url echoed" || return 1
+  # No curl should have been invoked (broker path skipped).
+  if [ -f "$MOCK_LOG" ] && grep -q "^curl" "$MOCK_LOG"; then
+    echo "    FAIL: unexpected broker call when zapbot absent"
+    return 1
+  fi
+  return 0
+}
+
+# ── End-to-end: zapbot detected + broker hit → bot mode + verify ────
+
+test_e2e_bot_success_exports_gh_token() {
+  _reset_sandbox
+  mkdir -p "$HOME/.zapbot"
+  touch "$HOME/.zapbot/.env"
+  export ZAPBOT_API_KEY="test-key"
+  export MOCK_USER_TYPE="Bot"
+  _mock_curl 200 '{"token":"ghs_botsecret","expires_at":"2026-04-18T01:00:00Z"}'
+  _mock_gh "https://github.com/o/r/issues/7"
+  local out rc
+  out=$("$BIN" --kind comment --issue 7 --body "hi" 2>&1); rc=$?
+  assert_equal "$rc" "0" "bot mode success" || return 1
+  # Broker was called.
+  assert_contains "$(cat "$MOCK_LOG")" "curl" "broker invoked" || return 1
+  # verify_attribution was called (gh api ...).
+  assert_contains "$(cat "$MOCK_LOG")" "api " "verify_attribution called" || return 1
+  return 0
+}
+
+# ── End-to-end: zapbot detected + broker TCP fail + strict → exit 10 ─
+
+test_e2e_strict_fail_exits_10_with_ux_block() {
+  _reset_sandbox
+  mkdir -p "$HOME/.zapbot"
+  touch "$HOME/.zapbot/.env"
+  export ZAPBOT_API_KEY="test-key"
+  _mock_curl_tcp_fail
+  _mock_gh "unused"
+  local out rc
+  out=$("$BIN" --kind comment --issue 7 --body "hi" 2>&1); rc=$?
+  assert_equal "$rc" "10" "strict exit 10" || return 1
+  assert_contains "$out" "cannot reach zapbot token broker" "UX header" || return 1
+  assert_contains "$out" "allow-pat-fallback" "hint mentions flag" || return 1
+  # gh must not have been invoked (strict failure halts before gh).
+  if [ -f "$MOCK_LOG" ] && grep -q "^gh " "$MOCK_LOG"; then
+    echo "    FAIL: gh was invoked during strict failure"
+    return 1
+  fi
+  return 0
+}
+
+# ── End-to-end: zapbot detected + broker 401 + --allow-pat-fallback ─
+
+test_e2e_user_fallback_warns_and_proceeds() {
+  _reset_sandbox
+  mkdir -p "$HOME/.zapbot"
+  touch "$HOME/.zapbot/.env"
+  export ZAPBOT_API_KEY="wrong-key"
+  _mock_curl 401 '{"error":{"type":"unauthorized","message":"x","status":401}}'
+  _mock_gh "https://github.com/o/r/issues/9"
+  local out rc
+  out=$("$BIN" --allow-pat-fallback --kind comment --issue 9 --body "hi" 2>&1); rc=$?
+  assert_equal "$rc" "0" "fallback proceeds" || return 1
+  assert_contains "$out" "falling back to gh default auth" "warn printed" || return 1
+  # gh was invoked.
+  assert_contains "$(cat "$MOCK_LOG")" "gh " "gh invoked"
+}
+
+# ── End-to-end: --attribute-to-user skips broker + verify ───────────
+
+test_e2e_attribute_to_user_skips_broker() {
+  _reset_sandbox
+  mkdir -p "$HOME/.zapbot"
+  touch "$HOME/.zapbot/.env"
+  export ZAPBOT_API_KEY="test-key"
+  # Curl should NOT be called; if it is, stub fails noisily.
+  cat > "$MOCK_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "UNEXPECTED CURL CALL: $*" >> "$MOCK_LOG"
+exit 99
+EOF
+  chmod +x "$MOCK_BIN/curl"
+  _mock_gh "https://github.com/o/r/issues/11"
+  local out rc
+  out=$("$BIN" --attribute-to-user --kind comment --issue 11 --body "hi" 2>&1); rc=$?
+  assert_equal "$rc" "0" "user attr success" || return 1
+  if grep -q "UNEXPECTED CURL CALL" "$MOCK_LOG" 2>/dev/null; then
+    echo "    FAIL: --attribute-to-user called the broker"
+    return 1
+  fi
+  return 0
+}
+
+# ── End-to-end: conflicting flags → exit 22 before any gh/curl ──────
+
+test_e2e_conflict_flags_exit_22() {
+  _reset_sandbox
+  local rc err
+  err=$("$BIN" --allow-pat-fallback --attribute-to-user --kind comment --issue 5 --body x 2>&1); rc=$?
+  assert_equal "$rc" "22" "conflict exit 22" || return 1
+  assert_contains "$err" "mutually exclusive" "error message"
+}
+
+run_test "detect_zapbot finds ~/.zapbot/.env"         test_detect_zapbot_env
+run_test "detect_zapbot finds ~/.zapbot/config.json"  test_detect_zapbot_config_json
+run_test "detect_zapbot returns 0 when absent"        test_detect_zapbot_absent
+
+run_test "resolve_bridge_url default"                  test_resolve_bridge_default
+run_test "resolve_bridge_url env override"             test_resolve_bridge_env_override
+run_test "resolve_bridge_url yaml beats env"           test_resolve_bridge_yaml_beats_env
+
+run_test "fetch_broker_token happy path"               test_fetch_token_happy_path
+run_test "fetch_broker_token TCP fail → 10"            test_fetch_token_tcp_fail_returns_10
+run_test "fetch_broker_token 401 → 11"                 test_fetch_token_401_returns_11
+run_test "fetch_broker_token 409 → 12"                 test_fetch_token_409_returns_12
+run_test "fetch_broker_token 5xx → 13"                 test_fetch_token_500_returns_13
+run_test "fetch_broker_token schema invalid → 14"      test_fetch_token_schema_invalid_returns_14
+
+run_test "handle_fallback_flags default zero"          test_flags_default_both_zero
+run_test "handle_fallback_flags consumes --pat"        test_flags_pat_consumed
+run_test "handle_fallback_flags consumes --attribute"  test_flags_attribute_consumed
+run_test "handle_fallback_flags rejects both → 22"     test_flags_both_together_returns_22
+
+run_test "resolve_identity_mode D=0 → user"            test_mode_no_detection_user
+run_test "resolve_identity_mode D=1 hit → bot"         test_mode_detected_bot_hit
+run_test "resolve_identity_mode D=1 miss → strict"     test_mode_detected_miss_strict_fail
+run_test "resolve_identity_mode D=1 miss F=1 → fbck"   test_mode_detected_miss_allow_pat
+run_test "resolve_identity_mode U=1 → user"            test_mode_attribute_to_user_forces_user
+
+run_test "verify_attribution Bot passes"               test_verify_attribution_bot_passes
+run_test "verify_attribution non-Bot → 20"             test_verify_attribution_user_fails_20
+
+run_test "e2e: no zapbot → user mode, no broker call"  test_e2e_no_zapbot_user_silent
+run_test "e2e: bot success exports GH_TOKEN + verify"  test_e2e_bot_success_exports_gh_token
+run_test "e2e: strict fail exits 10 with UX block"     test_e2e_strict_fail_exits_10_with_ux_block
+run_test "e2e: --allow-pat-fallback warns + proceeds"  test_e2e_user_fallback_warns_and_proceeds
+run_test "e2e: --attribute-to-user skips broker"       test_e2e_attribute_to_user_skips_broker
+run_test "e2e: conflict flags → exit 22"               test_e2e_conflict_flags_exit_22
+
+report


### PR DESCRIPTION
Closes #46.
Architect plan: #19 (plan-approved).
Spec: #15.
Design doc (merged): #44, committed to `docs/arch/bot-token-routing.md`.
Companion PR (zapbot): https://github.com/chughtapan/zapbot/pull/103.

## What changed

`bin/safer-publish` gains the seven bash functions named by the architect. Identity routing is now gated through `resolve_identity_mode` for every `--kind` path (epic, issue, comment, pr-comment). No `--kind` grammar changes. No new binaries, no shared helpers file — the script stays self-contained per Design §2 Rationale.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `detect_zapbot` (fs probe of `~/.zapbot/.env` OR `~/.zapbot/config.json`) | Design §3 Bash signatures + §7 row "Detection via..." |
| `resolve_bridge_url` (yaml → `$ZAPBOT_BRIDGE_URL` → `http://localhost:3000`) | Design §3 + mirrors `zapbot-publish.sh:11-20` |
| `fetch_broker_token` exit codes 10-14 (TCP / 401 / 409 / 5xx / schema) | Design §5 "safer-publish side" + §7 "Strict-mode hard failure shape" |
| `verify_attribution` uses `gh api <path> --jq .user.type == "Bot"`; exit 20 on mismatch; report-only (no auto-delete) | Design §7 + Q6 resolution (report-only) |
| `resolve_identity_mode` deterministic over (D, U, F, B); covers all 8 rows of the decision table | Design §4 "Identity-mode decision table" |
| `handle_fallback_flags` parses `--allow-pat-fallback` / `--attribute-to-user`; exits 22 on co-presence | Design §3 Bash signatures + §5 exit-code 22 row |
| `run_gh_as_bot` → `env -u GITHUB_TOKEN GH_TOKEN=<t> gh ...` (no parent env leakage) | Design §3 + Spec invariant 4 (outer env neutralized) |
| Multi-line UX error block on strict fail (Bridge / Probe / Detected / Hint) | Design §5 "Multi-line error UX for bridge-unreachable" |

## Scope

- Files touched: `bin/safer-publish` (additive; existing arg parser and dispatch shape unchanged), `tests/test-bin/test-publish-bot-routing.sh` (new).
- New modules: 0.
- New public signatures outside the plan: 0. Every new bash function is named in Design §3.
- New deps: 0. Uses `curl`, `jq`, `gh` — all pre-existing assumptions in this tree (see Design §Dependencies).
- Safe-sourcing guard: `SAFER_PUBLISH_SOURCE=1 source bin/safer-publish` exits before any dispatch, letting the test harness exercise individual functions.

## Tests

`tests/test-bin/test-publish-bot-routing.sh` — 29 cases with sandboxed `$HOME`, mocked `curl` and `gh` on `$PATH`:

- `detect_zapbot` — `.env` hit / `config.json` hit / absent.
- `resolve_bridge_url` — default / env / yaml-beats-env.
- `fetch_broker_token` — happy-path (token extracted); TCP fail → 10; 401 → 11; 409 → 12; 5xx → 13; schema_invalid → 14.
- `handle_fallback_flags` — both-zero default; PAT consumed; attribute consumed; both → 22.
- `resolve_identity_mode` — D=0→user; D=1 hit→bot; D=1 miss→strict-fail; D=1 miss F=1→user-fallback; U=1→user.
- `verify_attribution` — `.user.type == Bot` passes; anything else → 20.
- End-to-end: no zapbot → silent user mode (no broker call); bot success (broker + verify both invoked); strict fail exits 10 with UX block and no `gh` call; `--allow-pat-fallback` warns + proceeds; `--attribute-to-user` skips broker; conflict flags exit 22 before any I/O.

```
$ bash tests/run-tests.sh
TOTAL passed: 60
TOTAL failed: 0
```

## Confidence

HIGH — every decision-table row and every exit code has a paired test. Mocks are pinned to the exact shell contract (`curl -o <outfile> -w '%{http_code}'`) so behavior under the real broker matches the tested behavior.