### PR TITLE
[junior] Aggressive testing: flip deps from opt-in to default-install

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -74,7 +74,7 @@ Every principle below cost humans hours or days to apply consistently. It costs 
 
 **Example.** Instead of writing a test that asserts `orderId !== userId`, brand both: `type OrderId = string & { __brand: "OrderId" }`, `type UserId = string & { __brand: "UserId" }`. The compiler now rejects every site that would confuse them. The test is redundant because the confusion is unrepresentable.
 
-**Corollary.** *Tests exist for constraints the type system could not encode.* Move the encodable ones into types first; the residue is what testing is for.
+**Corollary.** *Tests exist for constraints the type system could not encode.* Move the encodable ones into types first; the residue is what testing is for. The testing *tooling* (fast-check, testcontainers, Stryker, Playwright) is installed by default at setup time; the residual question is *what* to test with each, not *whether* to install the tool.
 
 ---
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -239,59 +239,63 @@ Regardless of the answers, these four rules stay on: `bare-catch`, `record-cast`
 
 Testing is a craft dimension of the principles, not a separate modality. Principle 1's corollary: *tests exist for constraints the type system could not encode.* The right test shape depends on what the code does. This step installs the libraries that match the shapes this repo actually has, and records the choices in the setup log.
 
-Ask four `AskUserQuestion` prompts, in order. Record each answer (A/B/C) and the resulting install command (or "skipped") for the Step 11 receipt.
+Install all four testing layers unconditionally. No `AskUserQuestion` prompts. The question is never *whether* to install the tool; it is *what* to test with it, and that question belongs to the craft skill, not setup. Record each install command for the Step 11 receipt.
 
-**Question 1 — fast-check (always recommended).**
+**Install 1 — fast-check.**
 
-> `fast-check` is the TypeScript property-based tester. It is the default tool when a function has a nameable algebraic property (roundtrip, idempotence, invariant, oracle agreement). Install as a dev dependency?
-> - A) Yes, install now. (Recommended default.)
-> - B) Skip; already installed or I will install later.
-
-If A: `$PM add -D fast-check`. If B: record skipped.
-
-**Question 2 — testcontainers-node (ask when DB/cache/queue present).**
-
-Detect DB/cache/queue clients in `package.json` to pre-answer the prompt:
+`fast-check` is the TypeScript property-based tester. It is the default tool when a function has a nameable algebraic property (roundtrip, idempotence, invariant, oracle agreement). Install unconditionally:
 
 ```bash
-TC_HINT=""
-for dep in pg postgres mysql2 mongodb redis ioredis kafkajs amqplib; do
-  grep -q "\"$dep\"" package.json 2>/dev/null && TC_HINT="$TC_HINT $dep"
-done
-echo "TC_HINT:$TC_HINT"
+$PM add -D fast-check
 ```
 
-> `testcontainers-node` runs a real Postgres/Redis/Kafka in Docker for integration tests (principle 2: mocks at the integration boundary are a lie). Detected clients:$TC_HINT. Install?
-> - A) Yes, install `testcontainers` + `@testcontainers/postgresql` (or `-redis`, `-mongodb`, `-kafka` to match detected clients).
-> - B) No; Docker is unavailable in CI, or I use a different harness.
-> - C) No such dependency in this repo.
+**Install 2 — testcontainers.**
 
-If A: install `testcontainers` plus the specific `@testcontainers/<service>` modules that match detected clients (one `$PM add -D` command). If B or C: record skipped.
+`testcontainers` runs a real Postgres/Redis/Kafka in Docker for integration tests (principle 2: mocks at the integration boundary are a lie). Detect DB/cache/queue clients in `package.json` to decide which `@testcontainers/<service>` modules to include:
 
-**Question 3 — Stryker mutation testing (ask when critical modules exist).**
+```bash
+TC_MODULES=""
+declare -A TC_MAP=( [pg]=postgresql [postgres]=postgresql [mysql2]=mysql [mongodb]=mongodb [redis]=redis [ioredis]=redis [kafkajs]=kafka [amqplib]=rabbitmq )
+for dep in "${!TC_MAP[@]}"; do
+  grep -q "\"$dep\"" package.json 2>/dev/null && TC_MODULES="$TC_MODULES @testcontainers/${TC_MAP[$dep]}"
+done
+echo "TC_MODULES:$TC_MODULES"
+```
 
-> Stryker runs mutation tests; `@stryker-mutator/typescript-checker` filters type-ill-formed mutants via `tsc` (direct synergy with principle 1). Recommended only for critical modules (auth, billing, parsing, crypto). Does this repo have such a module?
-> - A) Yes; install `@stryker-mutator/core` + `@stryker-mutator/typescript-checker` and I will scope it to a glob later.
-> - B) No; skip.
-> - C) Already installed.
+Install the core package plus every detected module in one command:
 
-If A: `$PM add -D @stryker-mutator/core @stryker-mutator/typescript-checker`. If B or C: record skipped.
+```bash
+$PM add -D testcontainers$TC_MODULES
+```
 
-**Question 4 — Playwright (ask when a critical UI flow exists).**
+If `$TC_MODULES` is empty (no DB/cache/queue clients detected), still install `testcontainers` core so the harness is ready the day one is added; record it as `ready-for-later` in the Step 11 receipt.
 
-> Playwright runs end-to-end browser tests. Recommended only for critical UI flows (signup, checkout, main workflow). Does this repo own such a flow?
-> - A) Yes; install `@playwright/test`.
-> - B) No UI, or UI is tested elsewhere; skip.
-> - C) Already installed.
+**Install 3 — Stryker mutation testing.**
 
-If A: `$PM add -D @playwright/test`. If B or C: record skipped.
+Stryker runs mutation tests; `@stryker-mutator/typescript-checker` filters type-ill-formed mutants via `tsc` (direct synergy with principle 1); `@stryker-mutator/vitest-runner` wires it to the default test runner. Install unconditionally:
 
-**Record.** Carry the four answers into the Step 11 receipt under a `Testing deps:` line. Every answer is either an install command that ran, or the word `skipped`.
+```bash
+$PM add -D @stryker-mutator/core @stryker-mutator/vitest-runner @stryker-mutator/typescript-checker
+```
+
+Scoping the mutation glob to a named critical module (or to full `src/**`) is a craft-skill decision, not a setup decision.
+
+**Install 4 — Playwright.**
+
+Playwright runs end-to-end browser tests. Install unconditionally:
+
+```bash
+$PM add -D @playwright/test
+```
+
+Whether the repo has a critical UI flow today is not the question; whether to *scope* the Playwright config to an existing flow is a craft-skill decision.
+
+**Record.** Carry the four install outcomes into the Step 11 receipt under a `Testing deps:` line. Each entry is either `installed` (with detected modules, where relevant) or `ready-for-later` (testcontainers with zero detected clients). There is no `skipped`.
 
 **Anti-patterns.**
-- *"I'll install all four to save the user a step."* No. Stryker and Playwright have real install-time cost (browsers, mutation engine) and are opt-in.
-- *"I'll skip fast-check if the user does not ask."* No. fast-check is the default; the prompt exists so the user can override, not so you can omit.
-- *"I'll pick `@testcontainers/postgresql` without detecting."* No. Install only the modules that match detected clients.
+- *"I'll skip an install because a teammate thinks it might not be needed."* No. The cost of an unused dev dependency is bytes on disk; the cost of a missing harness is an entire class of test that nobody writes because the tool isn't there. Install all four.
+- *"I'll pick testcontainers modules the user didn't name."* No. Modules are derived from the `package.json` client detection above, not from guesses.
+- *"I'll ask the user to confirm before installing."* No. This step has no prompts. If the user wants to remove one later, they can `$PM remove` it — a reversible action.
 
 ### Step 5: Plan the configuration shape
 
@@ -509,10 +513,10 @@ End with a bordered block naming every decision and outcome. This is the user's 
   Effect rules:           on | off
   Kysely rules:           on | off
   Companion rules:        no-magic-numbers, no-unused-vars, no-duplicate-string
-  Testing deps:           fast-check=<installed|skipped>
-                          testcontainers=<installed <modules>|skipped>
-                          stryker=<installed|skipped>
-                          playwright=<installed|skipped>
+  Testing deps:           fast-check=installed
+                          testcontainers=<installed <modules>|ready-for-later>
+                          stryker=installed
+                          playwright=installed
   tsconfig strict:        N errors before, M errors after
   Probe:                  passed
   Lint baseline:          V violations across R rules

--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -115,8 +115,8 @@ Every row below is a fork where the agent will feel pulled toward the human-era 
 | Non-critical UI surface | Broad Playwright coverage "to be safe" | Component-level tests; skip E2E (Principle 6: scope the ladder to <N critical flows) |
 | Coverage threshold as a CI gate | `jest --coverage --coverageThreshold` set to 80% | Report coverage as a diagnostic artifact; never gate CI on a percentage (Goodhart; Inozemtseva & Holmes ICSE 2014) |
 | Coverage report flags a gap in a module | Write tests until the number moves | Investigate: dead code? missing path? unreachable branch? Act on the cause, not the metric |
-| Mutation testing on a critical module (auth, billing, parsing) | Skip, or run it everywhere | `@stryker-mutator/core` + `@stryker-mutator/typescript-checker`, opt-in per glob of named critical modules |
-| Mutation testing repo-wide | Run Stryker over every file | Scope Stryker to the critical-module glob only; compute budget is a Principle 6 constraint |
+| Mutation testing on a critical module (auth, billing, parsing) | Skip, or treat the tool as opt-in | Stryker is installed by default at setup time; scope its glob to the named critical modules (or to full `src/**` if none is named yet) |
+| Mutation testing repo-wide | Run Stryker over every file without filter | Scope Stryker to the critical-module glob when one exists; fall back to full `src/**` only when no critical module has been named — compute budget is a Principle 6 constraint |
 
 The compression math: each full version costs seconds more to type. Each one removes one class of runtime bug. The shortcut's savings compound into next-session debt; the full version's savings compound into no-bug-ever.
 


### PR DESCRIPTION
## Why

User direction (team-lead relay): *"nothing is opt-in. be super aggressive with testing."*

Issue #59 traced the gap: research sbd#32 recommended fast-check + testcontainers + Stryker; sbd#42 + sbd#43 wired them in as *prompted* setup steps; then nobody ran `/safer:setup` interactively, so three downstream repos (acg, zap, ccj) ship with zero fast-check / zero testcontainers / zero Stryker. Asking politely at setup time has a failure mode: the user never shows up. Default-install does not.

## What flipped

**`skills/setup/SKILL.md` — testing section (~lines 241-294):**
- Removed all four `AskUserQuestion` prompts.
- `fast-check` → installs unconditionally.
- `testcontainers` → installs core package + every `@testcontainers/<service>` module the `package.json` client-grep detects. Zero detected clients still installs core; receipt records it as `ready-for-later`.
- Stryker → installs `@stryker-mutator/core` + `@stryker-mutator/vitest-runner` + `@stryker-mutator/typescript-checker` unconditionally.
- Playwright → installs `@playwright/test` unconditionally.
- Anti-patterns block inverted. Old: *"I'll install all four to save the user a step."* New: *"I'll skip an install because a teammate thinks it might not be needed."* The reversibility argument (`$PM remove` is cheap; missing harness is an invisible class of missing tests) is spelled out.
- Step 11 receipt line format updated: no more `skipped` state. Each of the four is `installed`; testcontainers may alternatively be `ready-for-later`.

**`skills/typescript/SKILL.md` — mutation-testing decision rows (~lines 118-119):**
- "opt-in per glob of named critical modules" → "installed by default; scope the glob to named critical modules (or to full `src/**` if none is named yet)."
- Second row clarified: repo-wide fallback is allowed only when no critical module has been named. Compute budget (principle 6) still constrains the glob.

**`PRINCIPLES.md` — principle 1 corollary (line 77):**
- Extended the "testing is residual" one-liner with the tooling/use distinction: *the tooling is installed by default; the residual question is what to test with each, not whether to install.*

## Scope guardrails

- 3 files changed. No JS/TS. No plugin code. Markdown only.
- No other "opt-in" language in typescript/SKILL.md matches the shape the team-lead named — fast-check, testcontainers, Playwright rows are already phrased as applied advice ("use X when Y"), not as tool-install gates.

## Test plan

- [x] `bash tests/run-tests.sh` before: 60/60 pass.
- [x] `bash tests/run-tests.sh` after edits: 60/60 pass.
- [ ] Dogfood follow-up (out of scope for this junior PR, tracked on #59): run `/safer:setup` against acg, zapbot, cc-judge and confirm all four deps install without prompting.

Closes part of #59 (setup-skill side). Downstream dogfood tickets still need to run.