### PR TITLE
docs(principles): expand Principle 1 corollary with testing-as-craft (sbd#68)

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -74,7 +74,21 @@ Every principle below cost humans hours or days to apply consistently. It costs 
 
 **Example.** Instead of writing a test that asserts `orderId !== userId`, brand both: `type OrderId = string & { __brand: "OrderId" }`, `type UserId = string & { __brand: "UserId" }`. The compiler now rejects every site that would confuse them. The test is redundant because the confusion is unrepresentable.
 
-**Corollary.** *Tests exist for constraints the type system could not encode.* Move the encodable ones into types first; the residue is what testing is for.
+### Corollary: tests are the residual, and the residual has a shape
+
+*Tests exist for constraints the type system could not encode.* Move the encodable constraints into types first; the residue is what testing is for. That is the easy part. The shape of the residue is what doctrine has to name.
+
+**1. If the function has a nameable algebraic property, the residual is a property, not an example.** Roundtrip, idempotence, invariant, oracle agreement — these are the four shapes to look for. A `fast-check` property is cheap to write in the agent era; an example test that asserts one hand-picked input is a compression of the same information, with lower coverage. Default to the property when a property exists.
+
+**2. Coverage percentage is a diagnostic, never a CI gate.** Inozemtseva & Holmes (ICSE 2014) showed that coverage % correlates poorly with mutation-detection ability once you control for test count. Gating CI on 80% coverage is Goodhart-broken — it optimizes for line execution, not for the tests being tests. Report coverage as a comment or artifact; act on the *cause* of a gap (dead code, missing path, unreachable branch), not on the number.
+
+**3. Mutation testing is the meta-check on the residual.** Coverage answers "did any test touch this line." Mutation answers "does any test fail when this line's behavior changes." For a critical module (auth, billing, parsing, crypto, webhook signing), Stryker + `@stryker-mutator/typescript-checker` is the only check that distinguishes a test from a decoration. Gate CI on it for the critical glob. Scope outside that glob is a Principle 6 (compute budget) call per repo.
+
+**4. If tests exist, CI runs them.** A test file that CI never executes is decoration. A repo that runs `lint` in CI but not `test` is shipping a test suite that has not been verified to pass since the last developer ran it locally. The minimum floor for any repo with a test suite is a CI job that executes it.
+
+**5. Mocks at the integration boundary are a lie.** This is Principle 2 applied to the test layer. An integration test that mocks the database is asserting that your code works against your mock, not against the real thing. Use `testcontainers` or the real dependency; reserve mocks for unit tests where the dependency is outside the boundary under test.
+
+**Per-repo judgement, not universal default.** Installing every tool everywhere is the mirror-image error of installing nothing. A linter does not need `testcontainers`. A Docker-less CI does not need Playwright. Every repo with pure functions needs `fast-check`; every repo with a critical module needs Stryker gating CI; every repo with a DB/cache/queue needs `testcontainers` against the real client. The default is "ask what this repo actually has," not "install all five."
 
 ---
 

--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -113,10 +113,11 @@ Every row below is a fork where the agent will feel pulled toward the human-era 
 | Cross-service boundary where a consumer is external or under SLA | Best-effort schema doc in a README | `@pact-foundation/pact` (Pact V4) contract test published to the broker |
 | Critical UI flow (auth, checkout, primary CRUD) | "Unit test the React component" | Playwright E2E scoped to that flow; retry policy; screenshot diff off by default |
 | Non-critical UI surface | Broad Playwright coverage "to be safe" | Component-level tests; skip E2E (Principle 6: scope the ladder to <N critical flows) |
-| Coverage threshold as a CI gate | `jest --coverage --coverageThreshold` set to 80% | Report coverage as a diagnostic artifact; never gate CI on a percentage (Goodhart; Inozemtseva & Holmes ICSE 2014) |
+| Coverage threshold as a CI gate | `jest --coverage --coverageThreshold` set to 80% | Report coverage as a diagnostic artifact only; **never** gate CI on a percentage (Goodhart; Inozemtseva & Holmes ICSE 2014). Gate CI on mutation score for critical modules instead (see row 18). Coverage gaps are investigated for cause (dead code? missing path?), not chased with filler tests. |
 | Coverage report flags a gap in a module | Write tests until the number moves | Investigate: dead code? missing path? unreachable branch? Act on the cause, not the metric |
-| Mutation testing on a critical module (auth, billing, parsing) | Skip, or run it everywhere | `@stryker-mutator/core` + `@stryker-mutator/typescript-checker`, opt-in per glob of named critical modules |
-| Mutation testing repo-wide | Run Stryker over every file | Scope Stryker to the critical-module glob only; compute budget is a Principle 6 constraint |
+| Repo has a `test/**/*.test.ts` suite | `"lint"` job in CI, run tests locally | CI runs a `test` job that executes the full suite on every PR. A lint-only CI with tests on disk is Principle 1 corollary item 4 violation: tests that do not run are decoration. |
+| Mutation testing on a critical module (auth, billing, parsing, crypto, webhook signing) | Skip, or run it everywhere | `@stryker-mutator/core` + `@stryker-mutator/typescript-checker`, **required CI gate**; scope the mutate glob to the critical module(s). Thresholds: `{ high: 80, low: 60, break: 50 }` as a starting point. |
+| Mutation testing repo-wide | Run Stryker over every file | Scope the mutate glob to named critical modules. When no critical module is named, the fallback is `src/**` with `ignoreStatic: true` and incremental mode on; compute budget (Principle 6) still caps full-sweep to nightly. PR runs use incremental. |
 
 The compression math: each full version costs seconds more to type. Each one removes one class of runtime bug. The shortcut's savings compound into next-session debt; the full version's savings compound into no-bug-ever.
 


### PR DESCRIPTION
Closes sbd#68.

Applies `docs/specs/testing-as-craft-v1.md` §7.4 + §7.5 verbatim. Junior-orchestrate follow-ups (§8 per-repo backlog) are **out of scope** for this PR and route to `/safer:orchestrate` per the spec's Handoff section.

## What changed

**PRINCIPLES.md — §7.4 applied.** The one-line corollary at the bottom of Principle 1 is replaced with a `### Corollary: tests are the residual, and the residual has a shape` block carrying 5 numbered items:

1. Property-as-residual (roundtrip / idempotence / invariant / oracle agreement → `fast-check`).
2. Coverage-%-is-a-diagnostic-never-a-CI-gate (Inozemtseva & Holmes ICSE 2014).
3. Mutation-as-meta-check (Stryker + `typescript-checker` gating CI for critical-module globs).
4. If-tests-exist-CI-runs-them (names lint-only CI as a Principle 1 violation).
5. Mocks-at-the-integration-boundary-are-a-lie (Principle 2 applied to tests).

Plus a trailing **Per-repo judgement, not universal default** paragraph codifying the 2026-04-18 user clarification that aggressive installs are per-repo, not a setup-skill flip.

**skills/typescript/SKILL.md — §7.5 applied.** Four edits to the testing rows (lines 106-119 in the decision table):

- Row 16 (coverage threshold as CI gate) — strengthened with cross-reference to the mutation row.
- Row 18 (mutation testing on a critical module) — upgraded to "required CI gate"; critical-module list expanded to include crypto + webhook signing; starter thresholds `{ high: 80, low: 60, break: 50 }` named.
- Row 19 (mutation testing repo-wide) — fallback for unnamed-critical repos (`src/**` + `ignoreStatic` + incremental) added; nightly-vs-PR split named.
- **New row** inserted after row 17 (coverage-gap investigation): `Repo has a test/**/*.test.ts suite` → CI runs a `test` job that executes the full suite on every PR.

## What did NOT change

- The 11 other testing rows (14-15, 17, 20-21, plus rows 11-13 on Pact/Playwright/testcontainers) are untouched.
- `skills/setup/SKILL.md` is untouched (opt-in posture preserved per §7.6).
- No code changes. Markdown only.

## Verification

- `bash tests/run-tests.sh` → 72 passed, 0 failed (markdown-only change; tests pass as expected).
- Diffstat: 2 files, +19 / -4.

## Spec traceability

- §7.4 proposed text is applied verbatim; heading is `### Corollary: tests are the residual, and the residual has a shape` as specified.
- §7.5 row text is applied verbatim.
- §8 backlog items (sbd-T1, acg-T1..T3, ccj-T1..T4, zap-T1..T4) are explicitly NOT in this PR; they route to `/safer:orchestrate` per §8.5 dispatch order.

## Open questions from §10

Not resolved in this PR (they were flagged for user routing or for later implement-senior judgement). This PR takes the spec's **recommended defaults**:

- Q3 (name libraries vs tool-agnostic): spec's default B noted; applied text keeps `fast-check` / Stryker / `testcontainers` named for concreteness, matching the spec's §7.4 draft.
- Q4 (include item 5 on integration mocks): spec's default A applied — item 5 included.
- Q1 (sbd CI job) and Q2 (mutation-mandatory scope) route to user + orchestrator.

STATUS: `DONE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)