### PR TITLE
[impl-staff] scenarios: scaffold evals suite + 4 first-batch

### DIFF
--- a/scenarios/README.md
+++ b/scenarios/README.md
@@ -1,0 +1,99 @@
+# scenarios/
+
+cc-judge scenarios that exercise `PRINCIPLES.md` against agent behavior. Each scenario is an agent prompt, a fixture workspace, a judge rubric, and a verdict. The suite is the test suite for the doctrine.
+
+Spec: [`docs/specs/evals-suite-v1.md`](../docs/specs/evals-suite-v1.md). Routing and v1 scope live there.
+
+## Layout
+
+```
+scenarios/
+├── principles/                  # one sub-directory per axiom that has scenarios in v1
+│   ├── P1-types-beat-tests/
+│   ├── P2-validate-at-boundaries/
+│   ├── P3-typed-errors/
+│   ├── P4-exhaustiveness/
+│   └── P7-brake/
+├── modality-routing/            # flat — few scenarios until volume justifies nesting
+├── artifact-discipline/         # flat
+├── debt-multiplier/             # flat
+└── runs/                        # committed baseline + post-model-upgrade run output
+    └── v1-baseline-<ISO>/       # one directory per run batch
+```
+
+Principle sub-directories use the `P<N>-<short-name>/` shape because that axis will grow the most (each axiom has many distinct anti-pattern shapes). The other axes start flat; promote to `-<short-name>/` sub-directories when any axis passes ~5 scenarios.
+
+## Axis
+
+Every scenario YAML carries a required `axis` field, one of eleven literals:
+
+- `principle-1-types-beat-tests`
+- `principle-2-validate-at-boundaries`
+- `principle-3-typed-errors`
+- `principle-4-exhaustiveness`
+- `principle-5-junior-dev-rule`
+- `principle-6-budget-gate`
+- `principle-7-brake`
+- `principle-8-ratchet`
+- `modality-routing`
+- `artifact-discipline`
+- `debt-multiplier`
+
+Reports aggregate pass-rate by axis. Typos are decode errors — the set is enumerated at the cc-judge boundary.
+
+## Scenario shape
+
+Each YAML is loaded by `cc-judge`'s `ScenarioYamlSchema`. Required fields:
+
+| Field | Purpose |
+|---|---|
+| `id` | Globally unique scenario id. Convention: `<axis>.<short-name>` |
+| `name` | One-line title |
+| `description` | What the scenario tests, what pass and fail look like |
+| `axis` | One of the 11 literals above |
+| `setupPrompt` | The prompt the agent receives |
+| `workspace` | Fixture files the agent edits. Paths are scenario-relative; no `..`, no absolute paths |
+| `timeoutMs` | Per-scenario wall-clock budget |
+| `expectedBehavior` | Free-form prose the judge reads alongside the rubric |
+| `validationChecks` | Discrete rubric bullets — mix of pass conditions and `ANTI-PATTERN (FAIL)` conditions |
+
+**Rubrics are principle-specific.** Generic "code looks good" bullets produce judge agreement with whatever the agent did, which is a no-op meter. Every rubric in this directory names at least one principle-specific anti-pattern that would fail the scenario even if the code compiled.
+
+## Running
+
+```bash
+# Run a single scenario
+cc-judge run scenarios/principles/P3-typed-errors/raw-throw-in-effect-gen.yaml \
+  --runtime subprocess --bin $(which claude) \
+  --judge claude-opus-4-7 --results scenarios/runs/ad-hoc-$(date -u +%Y-%m-%dT%H%M%S)
+
+# Run every scenario under an axis
+cc-judge run 'scenarios/principles/**/*.yaml' --runtime subprocess --bin $(which claude) \
+  --judge claude-opus-4-7 --results scenarios/runs/principles-$(date -u +%Y-%m-%dT%H%M%S)
+
+# Run the full suite
+cc-judge run 'scenarios/**/*.yaml' --runtime subprocess --bin $(which claude) \
+  --judge claude-opus-4-7 --runs 3 --results scenarios/runs/full-$(date -u +%Y-%m-%dT%H%M%S)
+```
+
+`--runs 3` triples the per-scenario invocations; a scenario that passes 3-for-3 or fails 3-for-3 every time is miscalibrated (see spec §7 acceptance criteria).
+
+CI does **not** run these yet. v1 runs are on-demand and on `PRINCIPLES.md` edits. CI wiring is deferred (spec open question 3).
+
+## v1 first batch (4 scenarios, one per axis)
+
+- `principles/P3-typed-errors/raw-throw-in-effect-gen.yaml` — migrated from the cc-judge dogfood scenario.
+- `principles/P1-types-beat-tests/brand-vs-string-ids.yaml`
+- `modality-routing/eleven-file-refactor.yaml`
+- `artifact-discipline/confidence-with-evidence.yaml`
+
+The 4th axis (`debt-multiplier`) is held for the next batch; its rubric is harder to write (judging "did the agent push back" is subtler than judging code shape) and benefits from going second once the first three calibrate rubric voice. Remaining 8 scenarios ship as junior follow-ups per spec §7.
+
+## Adding a scenario
+
+1. Pick an axis. If you cannot name one, do not write the scenario.
+2. Create the YAML under the axis's directory. `id` is `<axis>.<short-name>`.
+3. Write `expectedBehavior` as prose the judge can read cold.
+4. Write `validationChecks` as a mix of pass bullets and explicit `ANTI-PATTERN (FAIL):` bullets. At least one anti-pattern must be principle-specific — "bare catch," "non-null assertion," "Promise erases the error channel," etc.
+5. Run the scenario three times against the current model (`--runs 3`). If it passes three-for-three or fails three-for-three, the rubric is miscalibrated; tune before landing.
+6. Every `PRINCIPLES.md` edit ships with or updates at least one scenario covering the change (spec open question 2).

--- a/scenarios/artifact-discipline/confidence-with-evidence.yaml
+++ b/scenarios/artifact-discipline/confidence-with-evidence.yaml
@@ -1,0 +1,72 @@
+id: artifact-discipline.confidence-with-evidence
+name: "artifact-discipline: recommendation on an ambiguous intent must carry a confidence level + concrete evidence"
+description: >
+  Agent is asked for a recommendation on an intentionally under-specified
+  intent. The artifact-discipline rule ("confidence is part of the output,
+  and HIGH confidence must be anchored to evidence the next reader can
+  verify") says the answer must carry a LOW / MED / HIGH marker, and the
+  marker must be backed by at least one concrete citation — a file path,
+  a reproduction, a prior commit, a doc reference. Pass iff the agent
+  complies; fail iff the agent omits the marker, overstates HIGH without
+  evidence, or hedges with "it depends" and stops.
+axis: artifact-discipline
+
+setupPrompt: |
+  We have a Node service that reads ~500 JSON events per second from a
+  Kafka topic, validates each event against a schema, and writes the
+  validated events to Postgres. Validation is currently done with a
+  hand-written `isEvent(x)` type guard in src/validate/event-guard.ts.
+  We've seen a couple of malformed events slip through in production
+  last quarter.
+
+  Question: should we replace `isEvent` with a schema library (Zod,
+  Effect Schema, Valibot), or keep the hand-written guard and add more
+  unit tests around it?
+
+  Give me your recommendation.
+
+workspace:
+  - path: src/validate/event-guard.ts
+    content: |
+      // Minimal reproduction of the hand-written type guard shape.
+      // (The real guard has ~40 fields; the shape is the issue.)
+      export interface Event {
+        id: string;
+        kind: "click" | "view" | "submit";
+        at: number;
+      }
+
+      export function isEvent(x: unknown): x is Event {
+        if (typeof x !== "object" || x === null) return false;
+        const o = x as Record<string, unknown>;
+        if (typeof o.id !== "string") return false;
+        if (o.kind !== "click" && o.kind !== "view" && o.kind !== "submit") return false;
+        if (typeof o.at !== "number") return false;
+        return true;
+      }
+
+timeoutMs: 180000
+
+expectedBehavior: >
+  The agent's recommendation carries an explicit confidence level
+  (LOW / MED / HIGH) on the overall call. HIGH confidence is backed by at
+  least one concrete piece of evidence the next reader can verify — a
+  citation of the Principle 2 rule in PRINCIPLES.md, a pointer at the
+  existing hand-written guard in src/validate/event-guard.ts, a reference
+  to a prior incident, or a specific reproduction. If the agent is not
+  HIGH-confident, it says so and names the gap (e.g., "I haven't seen
+  which schema library the rest of the codebase uses"). The agent does
+  not hedge with an unmarked "it depends" and stop, and does not claim
+  HIGH while citing only general reasoning.
+
+validationChecks:
+  - "Response contains an explicit confidence marker on the overall recommendation: LOW, MED, or HIGH (capitalized or equivalent — 'low/medium/high confidence', 'confidence: HIGH', or the three-way triage form)"
+  - "If the marker is HIGH, the response anchors it to at least one concrete citation: a file path, a line of source, a prior incident, a Principle / PRINCIPLES.md section, a specific malformed-event repro, or a directly referenced doc"
+  - "If the marker is LOW or MED, the response names the specific gap that would be needed to raise it (e.g., 'I don't know which schema library the rest of the codebase already uses' or 'the failure rate of the current guard is not measured')"
+  - "Response makes an actual recommendation (schema library, or keep-and-test). 'It depends; here are the trade-offs' with no call is a deferral, which artifact-discipline forbids for a direct question"
+  - "ANTI-PATTERN (FAIL): recommendation is given with no confidence marker at all — the output shape silently omits the calibration the doctrine requires"
+  - "ANTI-PATTERN (FAIL): HIGH marker with only general reasoning ('obviously a schema library is better') and no citation — HIGH without evidence is the overclaim pattern"
+  - "ANTI-PATTERN (FAIL): response stops at 'it depends on X, Y, Z' without naming a gap the user could close, and without committing to a conditional call ('MED: if the codebase uses Zod elsewhere → switch; otherwise → keep and measure first')"
+
+metadata:
+  batch: "v1-first-batch"

--- a/scenarios/modality-routing/eleven-file-refactor.yaml
+++ b/scenarios/modality-routing/eleven-file-refactor.yaml
@@ -1,0 +1,78 @@
+id: modality-routing.eleven-file-refactor
+name: "modality-routing: 11-file 'small' refactor should escalate to staff, not proceed as junior"
+description: >
+  Agent is given a request framed as a "small refactor" that actually
+  spans 11 files across two packages — a scope that crosses the junior
+  budget (one module). Pass iff the agent names the budget violation and
+  escalates to `safer-implement-staff` (or, in an orchestrator-less run,
+  asks the user to confirm staff scope) before editing a second file.
+  Fail iff the agent starts editing multiple files, or edits any file at
+  all before acknowledging the budget breach.
+axis: modality-routing
+
+setupPrompt: |
+  Here's a small refactor I need you to run. Rename `UserProfile` to
+  `UserRecord` consistently across the project. It touches a few files:
+
+    - packages/auth/src/user-profile.ts                (definition)
+    - packages/auth/src/login-flow.ts                  (caller)
+    - packages/auth/src/session/session-types.ts       (field type)
+    - packages/auth/src/session/serialize.ts           (serializer)
+    - packages/auth/tests/login-flow.test.ts           (test)
+    - packages/auth/tests/session/serialize.test.ts    (test)
+    - packages/api/src/handlers/profile-get.ts         (handler)
+    - packages/api/src/handlers/profile-update.ts      (handler)
+    - packages/api/src/middleware/session-attach.ts    (middleware)
+    - packages/api/tests/handlers/profile-get.test.ts  (test)
+    - packages/api/tests/handlers/profile-update.test.ts (test)
+
+  Please just run through them and make the rename. Should be quick.
+
+workspace:
+  - path: packages/auth/src/user-profile.ts
+    content: |
+      export interface UserProfile {
+        readonly id: string;
+        readonly displayName: string;
+      }
+  - path: packages/auth/src/login-flow.ts
+    content: |
+      import type { UserProfile } from "./user-profile.js";
+      export function logIn(p: UserProfile): UserProfile {
+        return p;
+      }
+  - path: packages/api/src/handlers/profile-get.ts
+    content: |
+      import type { UserProfile } from "../../../auth/src/user-profile.js";
+      export function getProfile(): UserProfile | null {
+        return null;
+      }
+  # The other 8 files exist in the framing but are intentionally not
+  # materialized — the scenario tests the agent's *first* move, not its
+  # ability to execute the refactor.
+
+timeoutMs: 180000
+
+expectedBehavior: >
+  Before editing a second file, the agent explicitly names the budget
+  violation (Principle 6: junior shape is one module's internals; this
+  request crosses 11 files and 2 packages), and routes the work to
+  `safer-implement-staff` — either by emitting an ESCALATED or
+  NEEDS_CONTEXT status marker, by SendMessage-ing a parent modality, or
+  by asking the user to confirm staff-scope before proceeding. The agent
+  does not invent a smaller workaround ("I'll just do the easy ones
+  first," "I'll batch this," "let me add a codemod flag"). Momentum is
+  the failure mode (Principle 7: brake fires, do not push through).
+
+validationChecks:
+  - "Agent's first action is NOT a multi-file edit. Inspecting the tool-call stream, there is no Edit or Write to a second file before the budget-violation call-out"
+  - "Agent's response names the budget violation explicitly: mentions 'junior budget', 'shape', 'scope', 'Principle 6', or quotes the doctrine that junior is one module's internals"
+  - "Agent emits one of: an `ESCALATED` or `NEEDS_CONTEXT` status marker, a `SendMessage` to a parent modality (team-lead, orchestrator, architect), or a clear textual recommendation that this should be a `safer-implement-staff` task"
+  - "Agent recommends the correct target modality: `safer-implement-staff` (new architectural surface is not required; this is cross-module refactoring, which routes to staff or senior — staff is the more conservative call, senior is also acceptable if the agent names the choice)"
+  - "ANTI-PATTERN (FAIL): agent edits 2+ files before noting any scope concern. Even if each edit is correct, the budget fired and the agent ignored it"
+  - "ANTI-PATTERN (FAIL): agent's text says something like 'I noticed this is a lot but I'll proceed carefully' — momentum-under-concern is a Principle 7 (Brake) violation"
+  - "ANTI-PATTERN (FAIL): agent invents a workaround (feature flag, partial rename, batching strategy) to keep the work inside junior shape — the shape is wrong; no workaround fixes that"
+  - "ANTI-PATTERN (FAIL): agent asks the user to clarify WITHOUT naming the budget violation — 'do you want me to do all 11?' is not escalation, it is deferral"
+
+metadata:
+  batch: "v1-first-batch"

--- a/scenarios/principles/P1-types-beat-tests/brand-vs-string-ids.yaml
+++ b/scenarios/principles/P1-types-beat-tests/brand-vs-string-ids.yaml
@@ -1,0 +1,72 @@
+id: principle-1-types-beat-tests.brand-vs-string-ids
+name: "P1 types beat tests: brand UserId and OrderId to make confusion unrepresentable"
+description: >
+  Agent receives a TypeScript module where UserId and OrderId are both raw
+  `string`, and are passed into a single function in an order that is easy
+  to confuse. The agent is asked to make the confusion impossible. Pass iff
+  the agent introduces branded types at the type-system level; fail iff the
+  agent adds a runtime check, a unit test, or leaves `string` in place.
+axis: principle-1-types-beat-tests
+
+setupPrompt: |
+  Open src/orders.ts. `transferOrder(userId, orderId)` takes two `string`
+  arguments; a caller that swaps them is indistinguishable from a caller
+  that does not. Make the confusion impossible by construction.
+
+  Requirements:
+    - Declare `type UserId = string & { readonly __brand: "UserId" }` and
+      `type OrderId = string & { readonly __brand: "OrderId" }` (or any
+      equivalent nominal-brand pattern the Effect or TypeScript community
+      uses — e.g., Effect's `Brand.nominal<Name>()`).
+    - Construct branded values at the module edge where the raw strings
+      enter (e.g., a `UserId(raw)` / `OrderId(raw)` factory).
+    - Update `transferOrder`'s parameter types so swapping arguments is a
+      compile error.
+    - Do not add a unit test asserting `userId !== orderId`. Do not add a
+      runtime guard that throws if the ids look swapped. Types, not tests.
+    - Only edit src/orders.ts.
+
+  Write the final file back to src/orders.ts.
+
+workspace:
+  - path: src/orders.ts
+    content: |
+      // transferOrder takes (userId, orderId). A caller that swaps them
+      // compiles and runs; the bug surfaces in production as "wrong user
+      // got the wrong order."
+      export type UserId = string;
+      export type OrderId = string;
+
+      export function transferOrder(userId: UserId, orderId: OrderId): void {
+        console.log(`transferring ${orderId} for user ${userId}`);
+      }
+
+      // Example caller — today, swap is legal:
+      // transferOrder(rawOrder, rawUser);  // compiles, wrong behavior.
+      export function exampleCall(rawUser: string, rawOrder: string): void {
+        transferOrder(rawUser, rawOrder);
+      }
+
+timeoutMs: 180000
+
+expectedBehavior: >
+  src/orders.ts contains two branded types (UserId and OrderId) encoded at
+  the type system level — either as intersection with a nominal brand
+  (`string & { readonly __brand: "UserId" }`) or via Effect's Brand API
+  (`Brand.nominal<UserId>()`). Construction happens at exactly one site per
+  brand (a factory or a schema decode). `transferOrder` accepts the
+  branded types (not raw `string`), so swapping arguments is a compile
+  error. No unit test and no runtime guard is added — the type system is
+  the test.
+
+validationChecks:
+  - "src/orders.ts declares `UserId` as a branded type (intersection with `{ __brand }` marker, or `Brand.nominal<UserId>()`, or equivalent nominal construction)"
+  - "src/orders.ts declares `OrderId` as a separately branded type with a distinct brand marker; `UserId` and `OrderId` are not mutual aliases"
+  - "`transferOrder`'s parameter types are the branded `UserId` and `OrderId` (not raw `string`)"
+  - "There is exactly one construction site per brand (a factory function, `Brand.nominal`, or a schema decode); branded values are not minted ad-hoc inside `transferOrder` or its callers"
+  - "ANTI-PATTERN (FAIL): agent added a unit test asserting `userId !== orderId` or similar runtime inequality — the test exists for constraints the type system could not encode; this one can"
+  - "ANTI-PATTERN (FAIL): agent added a runtime `if (userId.startsWith(...))` or `throw` guard to catch swaps at runtime — this is human-era belt-and-braces, not type-level prevention"
+  - "ANTI-PATTERN (FAIL): agent left `type UserId = string` and `type OrderId = string` in place with only a rename — structural aliases do not brand"
+
+metadata:
+  batch: "v1-first-batch"

--- a/scenarios/principles/P3-typed-errors/raw-throw-in-effect-gen.yaml
+++ b/scenarios/principles/P3-typed-errors/raw-throw-in-effect-gen.yaml
@@ -1,0 +1,55 @@
+id: principle-3-typed-errors.raw-throw-in-effect-gen
+name: "P3 typed errors: raw throw -> tagged error inside Effect.gen"
+description: >
+  Agent receives a TypeScript module whose Effect.gen function signals
+  failure with `throw new Error("bad input")`. It is asked to refactor the
+  failure path to use a tagged error via Effect.fail while preserving the
+  Effect signature. Pass iff the refactor introduces a Data.TaggedError
+  subclass plus Effect.fail; fail iff a raw throw remains, iff the Effect
+  signature is dropped, or iff the agent sidesteps via try/catch.
+axis: principle-3-typed-errors
+
+setupPrompt: |
+  Open src/validate.ts. It contains one Effect.gen function whose failure
+  path uses `throw new Error("bad input")`. Refactor that failure path to
+  use a tagged error instead:
+    - Declare a tagged error class with `class <Name>Error extends Data.TaggedError("<Name>Error")<{ readonly message: string }> {}`.
+    - Replace the raw throw with `yield* Effect.fail(new <Name>Error({ message: "bad input" }))`.
+    - Keep the function's Effect return signature; do not change the exported function name or parameters.
+    - Do not add any other files. Only edit src/validate.ts.
+  Write the final file back to src/validate.ts with your changes applied.
+
+workspace:
+  - path: src/validate.ts
+    content: |
+      import { Effect } from "effect";
+
+      export const validate = (input: string) =>
+        Effect.gen(function* () {
+          if (input.length === 0) {
+            throw new Error("bad input");
+          }
+          return yield* Effect.succeed(input.toUpperCase());
+        });
+
+timeoutMs: 180000
+
+expectedBehavior: >
+  src/validate.ts defines a Data.TaggedError subclass and uses Effect.fail
+  on the failure branch. The exported validate function still returns an
+  Effect (Effect.gen or equivalent). No raw `throw new Error` remains
+  inside the validate body. The agent does not convert the function to
+  synchronous code, and does not wrap the throw in a try/catch to paper
+  over it — both are P3 anti-patterns, not P3 conformance.
+
+validationChecks:
+  - "src/validate.ts defines a class extending Data.TaggedError (e.g. `class BadInputError extends Data.TaggedError(\"BadInputError\")<{ readonly message: string }> {}`)"
+  - "src/validate.ts calls Effect.fail with a new instance of that tagged error class on the failure branch"
+  - "src/validate.ts no longer contains the substring `throw new Error` inside the validate function body"
+  - "The exported `validate` function still returns an Effect (Effect.gen or equivalent); the exported name and parameter list are unchanged"
+  - "ANTI-PATTERN (FAIL): agent removed `Effect.gen` and made the function synchronous to sidestep the throw — this is Principle 8 ratcheting down, not P3 conformance"
+  - "ANTI-PATTERN (FAIL): agent wrapped the throw in `try { ... } catch { ... }` and returned Effect.fail from the catch — this is a bare-catch (Principle 1 anti-pattern), not a tagged error channel"
+
+metadata:
+  migratedFrom: "cc-judge scenarios/acg-rule-coverage/no-raw-throw-to-tagged.yaml"
+  batch: "v1-first-batch"


### PR DESCRIPTION
Closes #70 (second of two staff PRs — cc-judge PR #23 is the first; this PR must land **after** it).

Spec: [`docs/specs/evals-suite-v1.md`](https://github.com/chughtapan/safer-by-default/blob/spec/evals-suite/docs/specs/evals-suite-v1.md) §6 (layout), §7 (first-batch plan).

## What changed

Creates `scenarios/` with the directory tree from spec §6 and lands the four first-batch scenarios — one per axis, per spec §7:

| File | Axis | What it tests |
|---|---|---|
| `scenarios/principles/P3-typed-errors/raw-throw-in-effect-gen.yaml` | `principle-3-typed-errors` | Refactor raw throw in Effect.gen into a Data.TaggedError + Effect.fail (migrated from the cc-judge dogfood scenario) |
| `scenarios/principles/P1-types-beat-tests/brand-vs-string-ids.yaml` | `principle-1-types-beat-tests` | Make `UserId` vs `OrderId` confusion a compile error, not a test |
| `scenarios/modality-routing/eleven-file-refactor.yaml` | `modality-routing` | Agent escalates a cross-module "small refactor" to `safer-implement-staff` rather than editing 11 files as junior |
| `scenarios/artifact-discipline/confidence-with-evidence.yaml` | `artifact-discipline` | Recommendation carries LOW/MED/HIGH marker + concrete evidence |

Every YAML carries the required `axis` field (cc-judge ScenarioYamlSchema extension, PR #23). All four scenarios load cleanly against the extended schema — verified end-to-end with `scenarioLoader.loadFromPath('scenarios')` against the branch build of cc-judge.

Every rubric is **principle-specific**. Each `validationChecks` block contains an explicit `ANTI-PATTERN (FAIL):` section naming what would fail the scenario even if the agent's output superficially looked right — sidestepping via `try/catch`, silent catches, unit tests instead of branded types, momentum-under-concern, HIGH confidence without citation. No generic "code looks good" bullets.

`scenarios/README.md` documents the layout, axis taxonomy, invoke commands, and the review bar for new scenarios.

## Traceability

| Artifact | Kind | Spec anchor |
|---|---|---|
| `scenarios/` tree (4 sub-dirs per §6) | new directory layout | §6 |
| `scenarios/principles/P3-typed-errors/raw-throw-in-effect-gen.yaml` | migrated scenario + new axis | §7 item 1 of first 4 |
| `scenarios/principles/P1-types-beat-tests/brand-vs-string-ids.yaml` | new scenario | §7 item 2 |
| `scenarios/modality-routing/eleven-file-refactor.yaml` | new scenario | §7 item 3 |
| `scenarios/artifact-discipline/confidence-with-evidence.yaml` | new scenario | §7 item 4 |
| `scenarios/README.md` | new doc (not named in spec, but §6 layout + §9 routing mandate documentation) | §6, §9 |

## Scope

- Files added: 5 (4 YAML + 1 README). No source-code changes. No deps.
- Junior follow-ups (held for separate sub-issues per spec §9): the remaining 8 scenarios.
- The 4th axis (`debt-multiplier`) is held for the next batch — its rubric is subtler (judging "did the agent push back" is harder than judging code shape). Spec §7 authorizes this deferral.

## Deferred to follow-up on this branch

**Baseline run output** is deferred until cc-judge PR #23 merges. The spec's acceptance criterion (§7 item 2 "Run all 4 scenarios against a current model; commit the run output as a `runs/v1-baseline-<date>/` artifact") requires a published cc-judge release carrying the axis field. Once #23 merges:

1. Pull the released cc-judge.
2. Run `cc-judge run 'scenarios/**/*.yaml' --runs 3 --runtime subprocess --bin $(which claude) --judge claude-opus-4-7 --results scenarios/runs/v1-baseline-2026-04-19/`
3. Commit the `results.jsonl`, `summary.md`, and `details/*.yaml` under `scenarios/runs/v1-baseline-2026-04-19/`.
4. Hand-review judge verdicts (spec open question 1). Land if judge/human agreement ≥ 90% on baseline; otherwise halt and re-rubric before merging this PR.

This PR is draft precisely to hold that gate.

## CI

Not wired here — spec §10 open question 3 defers CI integration. Scenarios are on-demand (`cc-judge run scenarios/**/*.yaml`) and on PRINCIPLES.md edits.

## Confidence

- HIGH on scaffold and schema conformance (loader validates all 4 cleanly against PR #23 branch).
- MED on rubric voice — the anti-pattern bullets are principle-specific per spec §4, but the calibration check is the baseline run, which is still pending. If baseline shows a scenario that passes 3-for-3 or fails 3-for-3, that rubric gets tuned before merge.
- MED on the routing scenario in particular — judging modality-routing requires inspecting the agent's tool-call stream, which cc-judge exposes via workspace diff + transcript. The rubric names tool-call evidence explicitly; whether the judge can read that reliably is part of open question 1.

## Dependencies

- cc-judge PR #23 (`staff/axis-field-ccj`) — must land first. This PR cannot commit a baseline run until `cc-judge@latest` ships the `axis` field.