### PR TITLE
[impl-senior] orchestrate routing doctrine v1: model + codex + simplify gates

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -221,10 +221,24 @@ else
     --labels "safer:architect,review")
 fi
 
-safer-transition-label --issue "$ARCH_SUB_ISSUE" --from planning --to review
 echo "Design: $DOC_URL"
 echo "Stubs PR: $PR_URL"
 rm -f "$TMP"
+```
+
+**Codex review-after (upstream-stage gate).** Before transitioning to `review`, run `/codex` on the published design doc:
+
+```
+/codex --mode review --artifact "$DOC_URL"
+```
+
+- `approve` → proceed to `review`.
+- `changes-requested` → revise the design doc (one round); re-publish; re-run codex.
+- `reject` → escalate to the user with codex's reasoning; do NOT transition.
+- Unavailable → log the skip on the sub-issue; transition without the codex pass.
+
+```bash
+safer-transition-label --issue "$ARCH_SUB_ISSUE" --from planning --to review
 ```
 
 ### Phase 8 — Close out

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -192,6 +192,16 @@ Expected output: `tier: senior`. Failure modes:
 - `tier: junior` → the plan was smaller than senior-tier. Not a stop-rule violation, but note it in the PR body and suggest the sub-issue be relabeled next time.
 - `tier: staff` → the diff crossed into staff territory (new module, new public surface). Stop rule fired. Escalate.
 
+### Phase 6a — Pre-PR simplify pass (mandatory)
+
+Before opening the PR, run `/simplify` on the diff:
+
+```
+/simplify
+```
+
+Apply all findings unless a finding would conflict with a plan-approved architect decision. For each skipped finding, cite the plan line in the PR body under "Simplify skips." An empty result (no findings) is a valid outcome — note "simplify: no findings" in the PR body. If `/simplify` errors, note "simplify: errored — skipped" in the PR body and proceed; the reviewer decides whether to block.
+
 ### Phase 7 — Open the PR
 
 ```bash
@@ -341,7 +351,9 @@ Post on the sub-issue; leave the branch in place; revert any speculative cross-m
 - [ ] Every package-boundary decode uses a schema.
 - [ ] Tests cover each cross-module path the plan names.
 - [ ] Lint, typecheck, and tests pass across touched packages.
+- [ ] Pre-PR `/simplify` pass run; findings applied or cited with skip reason in PR body.
 - [ ] Draft PR opened with title prefixed `[impl-senior]` and plan-anchor table in body.
+- [ ] `/safer:review-senior` is mandatory before this PR merges (noted in PR body or enforced by orchestrate Phase 5c).
 - [ ] Sub-issue label transitioned `implementing` → `review`.
 - [ ] `safer.skill_end` event emitted.
 - [ ] Status marker on the last line of your response.

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -229,6 +229,28 @@ Expected: `tier: staff`. Other classifications are signals:
 - `tier: junior` or `tier: senior` → the sub-issue was mislabeled, or the spec did not actually require new architectural surface. Note in PR body; not a stop.
 - No classification or tool error → escalate via `NEEDS_CONTEXT` rather than guessing.
 
+### Phase 8a — Pre-PR simplify pass (mandatory, stricter than senior)
+
+Before opening the PR, run `/simplify` on the diff:
+
+```
+/simplify
+```
+
+Apply **every** finding unless it conflicts with a plan-approved architect decision. For each skipped finding, cite the specific plan line in the PR body under "Simplify skips." Skipping a finding without a plan citation is a stop-rule-adjacent signal; escalate if uncertain. An empty result (no findings) is a valid outcome — note "simplify: no findings" in the PR body. If `/simplify` errors, note "simplify: errored — skipped" and the reviewer decides whether to block.
+
+### Phase 8b — Codex diff review (mandatory)
+
+After committing, run `/codex` on the PR diff as an independent cross-model review pass:
+
+```
+/codex --mode review --diff HEAD
+```
+
+Post the codex verdict as a comment on the sub-issue before opening the PR (the reviewer and `/safer:review-senior` pass will see it). This counts as one independent pass toward the stamina N budget (PRINCIPLES.md → Durability — independent roles: mechanical/cross-model vs human-style).
+
+If `/codex` is unavailable, log "codex diff review: unavailable — skipped" on the sub-issue and proceed.
+
 ### Phase 9 — Open the PR
 
 ```bash
@@ -262,6 +284,12 @@ Architect plan: <URL or 'none'>
 
 ## Tests
 - <bullet per test file / path>
+
+## Simplify skips
+- <plan line> — <reason finding was skipped> (or "none")
+
+## Codex diff review
+- <codex verdict summary> (or "unavailable — skipped")
 
 ## Confidence
 <LOW|MED|HIGH> — <evidence>
@@ -389,7 +417,10 @@ Post on the sub-issue; leave the branch in place with the anchored work committe
 - [ ] Every switch over a union ends in `absurd`.
 - [ ] Tests cover success, each error tag, and each named invariant.
 - [ ] Lint, typecheck, and tests pass across touched packages.
+- [ ] Pre-PR `/simplify` pass run; all findings applied or each skip cites the plan line in PR body.
+- [ ] `/codex` diff review run; verdict posted on sub-issue (or "unavailable — skipped" logged).
 - [ ] Draft PR opened with title prefixed `[impl-staff]` and tables in body; sub-issue label transitioned `implementing` → `review`.
+- [ ] `/safer:review-senior` is mandatory before this PR merges (noted in PR body or enforced by orchestrate Phase 5c).
 - [ ] `safer.skill_end` event emitted.
 - [ ] Status marker on the last line of your response.
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -623,6 +623,30 @@ The `Agent` call in Step 6d includes the `model` parameter per the table below. 
 
 > **Dogfood-on-haiku is an acid test.** Upgrading dogfood to opus masks portability debt. Keep dogfood on haiku.
 
+### Codex dispatch pattern
+
+Three modes mirror gstack `/codex`. Invoke via the gstack `/codex` skill — do NOT call `codex` binary or `@openai/sdk` raw; the harness CLI is the routing boundary.
+
+1. **Review mode (spec, architect upstream stages):** claude drafts; codex reviews the published artifact before `review → plan-approved`. Verdict: `approve` / `changes-requested` / `reject`. `changes-requested` routes back to the drafting modality as one revision round; `reject` escalates to the user with codex's reasoning. Opus stays the primary author — the SDS paper's independent-hypothesis claim motivates independent *evaluation*, not independent *generation*.
+2. **Supervisor mode (research):** per-round. Researcher output lands as a comment; codex reads and stamps `continue` / `hold` / `escalate` before the next round's dispatch. Breaks single-model groupthink on multi-round reasoning.
+3. **Diff review mode (implement-staff mandatory; implement-senior optional):** codex reads the PR diff, independent of `/safer:review-senior`. Verdict posted as a PR comment before the human review fires. Counts as one independent pass toward the stamina N budget (PRINCIPLES.md → Durability).
+
+**Budget.** One codex pass per artifact for spec/architect; one per research round for supervisor; one per staff PR for diff review. No over-calling — over-calling defeats the cost model.
+
+**Fallthrough.** If `/codex` is not installed or fails, proceed without the codex pass and log the skip on the sub-issue. Cross-model coverage is durability-additive, not a hard blocker.
+
+### Conflict resolution
+
+When routing rules conflict, this order governs. Earlier rules dominate.
+
+1. **User override wins.** User explicitly names a model, skips a gate, or routes differently → follow. Log override on sub-issue.
+2. **Scope discipline wins over capability upgrades.** If a scenario needs opus reasoning but the modality is junior, re-triage to senior. Never silently upgrade the junior's model — that hides scope drift.
+3. **Dogfood-on-haiku overrides artifact's model hint.** Dogfood IS the small-model test. If haiku cannot cold-read the artifact, fix the artifact, not the test.
+4. **Codex unavailable falls through to claude-only.** Log the skip. Blocking all spec work on a third-party CLI failure is worse than missing one cross-model pass.
+5. **Simplify finding conflicts with plan-approved architect decision.** Plan wins; skip finding; cite plan line in PR body.
+6. **Stamina N budget overlaps with codex + review-senior.** A codex diff-review pass and a `/safer:review-senior` pass count as N=2 (independent roles: mechanical/cross-model vs human-style). They do not double-count as N=1.
+7. **Gate failures are never silent.** Simplify errored, codex unreachable, review-senior did not fire: post a gate-skip comment on the sub-issue with the reason.
+
 ### Per-modality dispatch prompt templates
 
 Step 6d dispatches by filling the template that matches the sub-issue's `safer:<modality>` label. Every template is a copy-pasteable block. Every template carries the `source: orchestrate-auto-dispatch` header so a post-hoc audit can separate auto-dispatched work from human-driven dispatches. Every template ends with the mandatory status-marker instruction.
@@ -662,9 +686,11 @@ Read the sub-issue and parent epic before touching code.
 Acceptance: {ACCEPTANCE}
 
 Scope is ONE module. If you need to touch a second module, stop and escalate.
-Open a draft PR titled `[impl-junior] ...`. Move the sub-issue to `review`.
-Emit a status marker (DONE / DONE_WITH_CONCERNS / ESCALATED / BLOCKED / NEEDS_CONTEXT)
-on your final output and SendMessage the team lead with the PR URL.
+If the diff exceeds 50 LOC or introduces shared helpers, consider running /simplify
+before opening the PR. Open a draft PR titled `[impl-junior] ...`. Move the
+sub-issue to `review`. Emit a status marker (DONE / DONE_WITH_CONCERNS /
+ESCALATED / BLOCKED / NEEDS_CONTEXT) on your final output and SendMessage the
+team lead with the PR URL.
 ```
 
 #### implement-senior
@@ -685,7 +711,10 @@ Acceptance: {ACCEPTANCE}
 
 Scope is cross-module WITHIN the plan. Do not introduce new modules, new public
 surface outside the plan, or new deps. `safer-diff-scope --head HEAD` must report
-`senior`. Open a draft PR titled `[impl-senior] ...` with a plan-anchor table.
+`senior`. Before opening the PR, run /simplify on the diff (mandatory); apply
+findings unless a finding conflicts with a plan-approved decision (cite the plan
+line in the PR body). Open a draft PR titled `[impl-senior] ...` with a
+plan-anchor table. /safer:review-senior is mandatory before merge.
 Status marker + SendMessage the team lead with the PR URL.
 ```
 
@@ -709,8 +738,15 @@ Read the approved spec + architect plan the parent epic references.
 Acceptance: {ACCEPTANCE}
 
 You may introduce new modules, new public interfaces, and new deps — all of
-which must trace to the approved plan. Open a draft PR titled `[impl-staff] ...`.
-Status marker + SendMessage the team lead with the PR URL.
+which must trace to the approved plan. Before opening the PR:
+1. Run /simplify on the diff (mandatory, stricter than senior — apply every
+   finding unless it conflicts with a plan-approved architect decision; cite the
+   plan line in the PR body for any skipped finding).
+2. Run /codex on the PR diff (mandatory): post the codex verdict as a PR comment
+   before /safer:review-senior fires. This counts as one independent pass toward
+   the stamina N budget. If /codex is unavailable, log the skip on the sub-issue.
+Open a draft PR titled `[impl-staff] ...`. /safer:review-senior is mandatory
+before merge. Status marker + SendMessage the team lead with the PR URL.
 ```
 
 #### verify
@@ -759,7 +795,7 @@ writeup as a sub-issue comment. The branch stays unmerged. Status marker
 
 ```
 source: orchestrate-auto-dispatch
-Dispatch with: `model: opus` per orchestrate Model routing table.
+Dispatch with: `model: opus` (Researcher); Supervisor role uses codex.
 You are a teammate on team `{TEAM}` invoking `/safer:research`.
 
 Sub-issue: {ISSUE_URL}
@@ -770,8 +806,11 @@ Read PRINCIPLES.md and skills/research/SKILL.md at the plugin root.
 Acceptance: {ACCEPTANCE}
 
 Run an iterative hypothesis loop; post one comment per iteration on the
-sub-issue as your research ledger. Produce no code. Status marker +
-SendMessage the team lead with the ledger URL when the loop converges
+sub-issue as your research ledger. Produce no code. The Supervisor role
+for each round is codex (run /codex --mode supervisor on the Researcher
+output before advancing to the next round). If /codex is unavailable,
+log the skip and continue with the internal Supervisor turn. Status marker
++ SendMessage the team lead with the ledger URL when the loop converges
 or the budget runs out.
 ```
 
@@ -792,6 +831,11 @@ Acceptance: {ACCEPTANCE}
 Produce a spec with goals, non-goals, invariants, and explicit acceptance
 criteria. No architecture, no libraries, no code. Publish as a comment on
 the parent epic (or sub-issue body per the skill's publication rule).
+After publishing, run /codex --mode review on the published artifact. The
+codex verdict must be `approve` before transitioning to `review`. If
+`changes-requested`, revise and re-run (one revision round). If `reject`,
+escalate to the user with codex's reasoning. If /codex is unavailable, log
+the skip and transition to `review` without the codex pass.
 Transition the sub-issue to `review`. Status marker + SendMessage the
 team lead with the spec URL.
 ```

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -179,12 +179,15 @@ Transition the label: `safer-transition-label --issue "$ISSUE" --from planning -
 
 ### Phase 2: The loop
 
-For each round, do the following four steps:
+The Supervisor role is **codex** (cross-model independent evaluation). Run `/codex --mode supervisor` on the Researcher turn output before writing the Supervisor turn. If `/codex` is unavailable, fall back to the internal Supervisor turn and log the skip on the sub-issue.
+
+For each round, do the following five steps:
 
 1. **Researcher turn.** Write the four-part turn (CLAIM, EVIDENCE, EXPERIMENT, EXPECTED) to a scratch file, run the experiment, then fill in INSIGHT, IMPLICATIONS, CONFIDENCE.
-2. **Supervisor turn.** Write QUESTIONS, RATING, GUIDANCE.
-3. **Publish the round.** Post the concatenated Researcher + Supervisor turns as a comment on the research issue. Each round is one comment; comments are the ledger.
-4. **Check exit conditions.** If Supervisor rated EXCELLENT and Researcher confidence is at least 0.8, exit the loop. If round count equals 20, exit with `DONE_WITH_CONCERNS`. Else, increment round and continue.
+2. **Codex supervisor gate.** Run `/codex --mode supervisor` on the Researcher output. Codex stamps `continue` / `hold` / `escalate`. `hold` → Researcher revises the same round before advancing. `escalate` → treat as a POOR round and emit `NEEDS_CONTEXT` to the caller. `continue` → proceed.
+3. **Supervisor turn.** Write QUESTIONS, RATING, GUIDANCE (informed by the codex stamp).
+4. **Publish the round.** Post the concatenated Researcher + codex stamp + Supervisor turns as a comment on the research issue. Each round is one comment; comments are the ledger.
+5. **Check exit conditions.** If Supervisor rated EXCELLENT and Researcher confidence is at least 0.8, exit the loop. If round count equals 20, exit with `DONE_WITH_CONCERNS`. Else, increment round and continue.
 
 Comment template for a round:
 
@@ -202,6 +205,10 @@ Comment template for a round:
 **INSIGHT.** <one or two sentences>
 **IMPLICATIONS.** <what this changes>
 **CONFIDENCE.** <0.0 to 1.0> ; <justification>
+
+### Codex supervisor
+**STAMP.** <continue | hold | escalate>
+**NOTE.** <one sentence from codex, or "unavailable — skipped" if /codex not installed>
 
 ### Supervisor
 **QUESTIONS.**

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -157,6 +157,17 @@ echo "$URL"
 rm -f "$TMP"
 ```
 
+**Codex review-after (upstream-stage gate).** Before transitioning to `review`, run `/codex` on the published spec artifact:
+
+```
+/codex --mode review --artifact "$URL"
+```
+
+- `approve` → proceed to `review`.
+- `changes-requested` → revise the spec (one round); re-publish; re-run codex.
+- `reject` → escalate to the user with codex's reasoning; do NOT transition.
+- Unavailable → log the skip on the sub-issue; transition without the codex pass.
+
 Transition the sub-issue (or the spec issue) from `planning` to `review`:
 
 ```bash


### PR DESCRIPTION
Closes #87
Spec: https://github.com/chughtapan/safer-by-default/blob/spec/routing-doctrine/docs/specs/orchestrate-routing-doctrine-v1.md

## What changed

Applied the sbd#87 plan-approved routing doctrine across 6 skill files. Additive-only markdown edits (~133 LOC added, 14 changed). Tests: 72/72 passed. Simplify pass: no findings.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Orchestrate: Codex dispatch pattern section | Spec §3b — upstream-stage review-after + supervisor + diff-review modes |
| Orchestrate: Conflict resolution section | Spec §4 — 7-rule precedence order |
| Orchestrate: implement-junior template optional simplify note | Spec §5, §3c |
| Orchestrate: implement-senior template — /simplify mandatory + review-senior mandatory | Spec §5, §3c |
| Orchestrate: implement-staff template — /simplify + /codex diff review mandatory | Spec §5, §3b.3, §3c |
| Orchestrate: research template — Supervisor role is codex | Spec §5, §3b.2 |
| Orchestrate: spec template — codex review-after before `review` | Spec §5, §3b.1 |
| skills/spec/SKILL.md — Phase 5 codex gate | Spec §3b.1, §5 |
| skills/architect/SKILL.md — Phase 7 codex gate + transition moved after codex | Spec §3b.1, §5 |
| skills/research/SKILL.md — Phase 2 loop: codex supervisor step added, round template updated | Spec §3b.2, §5 |
| skills/implement-senior/SKILL.md — Phase 6a simplify step + checklist items | Spec §3c, §5 |
| skills/implement-staff/SKILL.md — Phase 8a simplify + Phase 8b codex diff review + PR body sections + checklist | Spec §3b.3, §3c, §5 |

## Scope

- Files touched: 6 skill files, all named in spec §6
- Tier: senior (cross-module within approved spec; no new public surface)
- New modules: 0
- New deps: 0
- Model routing table: kept as-is (sbd#78 merged, canonical at orchestrate:607)

## Sub-doctrine verification

| Sub-doctrine | Applied? | Location |
|---|---|---|
| **Model routing (8.1 sbd#78 table)** | Kept verbatim; no revision | `skills/orchestrate/SKILL.md` Model routing section |
| **Codex routing review-after (user-approved 8.1 = review-after, not draft-first)** | Yes — spec/architect gate codex AFTER draft, opus stays primary author | orchestrate Codex dispatch pattern §1; spec Phase 5; architect Phase 7 |
| **Codex as research supervisor (user-approved 8.4 = codex)** | Yes — codex (not opus-with-different-prompt) per PRINCIPLES.md Durability → Independence | orchestrate Codex dispatch pattern §2; research Phase 2 loop |
| **/simplify mandatory for senior+staff, optional note for junior** | Yes | orchestrate templates; implement-senior Phase 6a; implement-staff Phase 8a |
| **review-senior mandatory on every implement-* PR** | Yes — in templates + checklists | orchestrate implement-senior/staff templates; implement-senior/staff checklists |

## Ambiguities flagged

None in the spec or implementation. The four user-approved answers (8.1 review-after, 8.4 codex) were applied verbatim per the task setup instructions. The conflict-resolution table (7 rules) was applied directly from spec §4.

## Tests

- `bash tests/run-tests.sh` → 72 passed, 0 failed

## Confidence

HIGH — spec is complete and unambiguous; all 4 sub-doctrines have explicit user approval; no plan gaps encountered; tests green.