### PR TITLE
[impl-junior] orchestrate: epic body template — Linear-project line

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -189,6 +189,7 @@ Epic body template:
 ## Context
 
 - **Project:** <name> (<https://github.com/OWNER/REPO>)
+- **Linear project:** <name>   <!-- one of the projects in the MOL team; required if Linear sync is desired -->
 - **Motivation:** <one sentence, in the user's own words if they stated it — why this matters now>
 - **Prior artifacts:** <bullet list of full URLs to every spec, issue, comment, PR, or doc this epic depends on. If none, write "none.">
 
@@ -228,6 +229,7 @@ Record the parent epic's issue number.
 2. **Every acceptance cell answers "what artifact, in what state, makes this row done."** One-line stubs like "tests green" are insufficient. Name the artifact type (PR, comment, sub-issue body, label), the location, and the state transition that closes the row.
 3. **Every external reference is a full URL.** `#5`, `PR #12`, "see the spec" are all invalid. Write `<https://github.com/OWNER/REPO/issues/5>`. This applies to sub-issues, prior artifacts, linked PRs, and any other cross-reference in the body. A bare `#N` breaks the moment the reader is in a different repo or session.
 4. **The `## Next step` section is mandatory.** The epic is only useful if the next action is explicit. Name the first sub-issue to dispatch (by URL), its modality, and the teammate (or `TBD`) that will pick it up.
+5. **The `Linear project` line is mandatory if Linear sync is enabled for this repo.** Pick the project from the live Linear `MOL` team list. If the epic is genuinely cross-project, name the dominant project and add a comment cross-link rather than splitting the epic.
 
 ### Phase 4 — Create sub-issues
 

--- a/tests/test-bin/test-orchestrate-auto-dispatch.sh
+++ b/tests/test-bin/test-orchestrate-auto-dispatch.sh
@@ -176,6 +176,17 @@ test_skill_md_has_all_seven_templates() {
   return 0
 }
 
+test_epic_body_template_includes_linear_project_line() {
+  # Phase 3 epic body template must include the Linear project context line
+  # for Linear sync integration. Extract the template from SKILL.md and verify
+  # the expected line is present.
+  sed -n '/^Epic body template:/,/^```$/p' "$SKILL_MD" | \
+    grep -q 'Linear project:' || {
+      echo "Linear project line missing from epic body template";
+      return 1;
+    }
+}
+
 # ---------------------------------------------------------------------------
 
 echo "── orchestrate-auto-dispatch unit tests ──"
@@ -192,5 +203,6 @@ run_test "per-tick cap limits dispatch to 3"                    test_per_tick_ca
 run_test "SKILL.md pins per_tick_cap=3"                         test_skill_md_pins_per_tick_cap_to_three
 run_test "SKILL.md pins pane_ceiling=20"                        test_skill_md_pins_pane_ceiling_to_twenty
 run_test "SKILL.md has one template per dispatchable modality"  test_skill_md_has_all_seven_templates
+run_test "epic body template includes Linear project line"      test_epic_body_template_includes_linear_project_line
 
 report


### PR DESCRIPTION
## Summary

Per spec sbd#97 Q2, add the Linear-project context line to the orchestrate Phase 3 epic body template, plus one body-rule and one test.

- Add `- **Linear project:** <name>` line to the Context section
- Add rule #5 to the body-rules list  
- Add unit test to validate the template includes the Linear project line
- Tests pass

Closes #99.