### PR TITLE
[impl-senior] sync plugin.json version to 0.1.1 (fixes version drift from PR #106)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safer-by-default",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude Code plugin: modality-based skills that recalibrate agents toward compiler-grade craft and scope discipline. Thirteen skills across spec, architect, implement (junior/senior/staff), investigate, spike, research, review, verify, orchestrate, typescript-floor, setup. Composes with eslint-plugin-agent-code-guard (lint floor) and zapbot (GitHub publish).",
   "author": {
     "name": "Tapan Chugh"


### PR DESCRIPTION
## What changed

PR #106 bumped `VERSION` (0.1.0 → 0.1.1) and added a `CHANGELOG.md` entry for 0.1.1, but left `.claude-plugin/plugin.json` `"version"` field at `0.1.0`. This PR aligns the third source of truth.

All three version fields now agree on `0.1.1`:
- `VERSION`: 0.1.1 (set by PR #106)
- `CHANGELOG.md`: `## 0.1.1` entry (set by PR #106)
- `.claude-plugin/plugin.json` `"version"`: **0.1.1** (this PR)

## Plan anchors

| Change | Anchor |
|---|---|
| plugin.json version 0.1.0 → 0.1.1 | Review comment 4275052717 §"Secondary: version drift" |

## Scope

- Modules touched: `.claude-plugin/plugin.json`
- Tier: junior (single file, single field)
- New modules: 0
- New public signatures: 0
- New deps: 0

## Tests

- 73/73 sbd tests pass

## Simplify pass

No findings — single version-string change in JSON.

## Confidence

HIGH — one field, three sources now agree.

/safer:review-senior mandatory before merge. Primary fix in chughtapan/agent-code-guard PR #23.