### PR TITLE
[impl-junior] bump marketplace.json and plugin.json version to 0.1.1 (version drift fix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "safer-by-default",
       "source": "./",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "13 skills (orchestrate, spec, architect, implement-{junior,senior,staff}, investigate, spike, research, review-senior, verify, typescript, setup) plus 10 bin/ utilities. Composes with eslint-plugin-agent-code-guard (lint floor) and zapbot (publish).",
       "author": {
         "name": "Tapan Chugh"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "safer-by-default",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude Code plugin: modality-based skills that recalibrate agents toward compiler-grade craft and scope discipline. Thirteen skills across spec, architect, implement (junior/senior/staff), investigate, spike, research, review, verify, orchestrate, typescript-floor, setup. Composes with eslint-plugin-agent-code-guard (lint floor) and zapbot (GitHub publish).",
   "author": {
     "name": "Tapan Chugh"


### PR DESCRIPTION
Closes #115

## What changed
Bumped `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` from 0.1.0 → 0.1.1 to sync with VERSION file and CHANGELOG header.

## Scope
- Module: `.claude-plugin/`
- Tier (from safer-diff-scope): junior
- New exported signatures: none
- New deps: none

## Tests
- All four version sources now align (marketplace.json, plugin.json, VERSION, CHANGELOG)

## Confidence
HIGH — straightforward one-line version edits to fix documented drift.