### PR TITLE
[impl-senior] PRINCIPLES: CC-time estimates subsection (sbd#104)

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -254,7 +254,7 @@ Up is legal. Forward is legal (when the upstream artifact is ready). Sideways is
 
 # Artifact discipline
 
-The eight principles govern the work. These three rules govern what you hand off when the work is done.
+The eight principles govern the work. These five rules govern what you hand off when the work is done.
 
 ## GitHub is the record
 
@@ -295,6 +295,44 @@ Artifacts are written for a reader who has none of your context. The agent picki
 The test: open the artifact in a new session with no prior context. Read it start to finish. Can you act on it? If no, rewrite before publish.
 
 Anti-patterns: *"See the plan" where the plan is in a scratchpad.* *"As discussed above" in a doc the reader is seeing for the first time.* *Function names whose meaning depends on a naming debate the next reader was not present for.*
+
+## Estimates are in CC-time, not human-time
+
+Effort estimates in all artifacts carry two scales. Decomposition and user expectation depend on the CC scale; a single "2 weeks" is unactionable when the work lands in 30 minutes.
+
+| Task type | Human team | CC + plugin | Compression |
+|---|---|---|---|
+| Boilerplate / scaffolding | 2 days | 15 min | ~100× |
+| Test writing | 1 day | 15 min | ~50× |
+| Feature implementation | 1 week | 30 min | ~30× |
+| Bug fix + regression test | 4 hours | 15 min | ~20× |
+| Architecture / design | 2 days | 4 hours | ~5× |
+| Research / exploration | 1 day | 3 hours | ~3× |
+
+*Source: gstack/ETHOS.md (in-tree mirror at `~/.claude/skills/gstack/ETHOS.md:20-27`); heuristic, not measured.*
+
+Every effort estimate is written as `(human: ~X / CC: ~Y)`.
+
+**Decomposition rule.** Pattern-match the task to its nearest row. Composite tasks (e.g., architect-plus-feature) sum components and report each sub-estimate separately: `(human: ~2 days / CC: ~4 hours)` for the architecture component plus `(human: ~1 week / CC: ~30 min)` for the feature component, not a single collapsed estimate.
+
+**Per-modality row.**
+
+| Modality | Compression | Row |
+|---|---|---|
+| `spec` | ~2× | below Research; purely thinking-bound |
+| `architect` | ~5× | Architecture / design |
+| `research` | ~3× | Research / exploration |
+| `investigate` | ~3× | Research / exploration |
+| `spike` | ~5× | Architecture / design |
+| `implement-junior` | ~30× | Feature implementation |
+| `implement-senior` | ~30× | Feature implementation |
+| `implement-staff` | ~20× | Feature + Architecture (cross-module amortizes) |
+| `review-senior` | ~50× | Test writing (mechanical reading) |
+| `verify` | ~50× | Test writing (mechanical) |
+| `orchestrate` | sum of children | per sub-task row, plus small overhead |
+| `stamina` | N × artifact-row | inherit the artifact's row, multiply by N |
+
+Anti-patterns: *"2 weeks" with no CC equivalent — both scales are required.* *Pattern-matching architect or research to the Feature row — the ~5× and ~3× rows exist for this reason; the gstack 4-row preamble subset dropped them, producing systematic underestimates.* *Collapsing a composite task to one row — report each component separately.*
 
 ## Durability — the stamina rule
 

--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -143,7 +143,7 @@ The following phrases signal that a human-era shortcut is about to happen. Catch
 
 When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
 
-> That is a two-week task for a human and a thirty-minute task for an agent. The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
 
 Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
 


### PR DESCRIPTION
Closes #104
Architect plan (spec): https://github.com/chughtapan/safer-by-default/issues/104
Spec doc: `docs/specs/cc-time-estimates-v1.md` on branch `spec/cc-time-estimates`

## What changed

Added `## Estimates are in CC-time, not human-time` subsection to `PRINCIPLES.md → Artifact discipline`, sibling to the four existing subsections. Updated the intro count from "three" to "five" (it was already wrong at four; now five with the new sibling). Applied the format rule to the one existing human-time estimate in `skills/typescript/SKILL.md:146`.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Add `## Estimates are in CC-time, not human-time` to PRINCIPLES.md after `## Write for the cold-start reader` | Spec goal #1, AC 5.1, dispatch scope |
| 6-row compression table (gstack values verbatim) | Spec AC 5.1, Invariant #1 |
| Format rule `(human: ~X / CC: ~Y)` | Spec AC 5.1 |
| Decomposition rule + worked example | Spec AC 5.1, Q3 = B (rule + example) |
| Per-modality row mapping (12 entries incl. stamina) | Spec AC 5.2 |
| Anti-patterns block (3 named failure modes) | Spec AC 5.3 |
| Update intro "three" → "five" rules | Consistency fix caused by adding 5th sibling |
| `skills/typescript/SKILL.md:146` estimate reframed | Spec format rule, dispatch codebase-grep scope |

## Recommended defaults applied (Q1/Q2/Q3)

- **Q1 = A (principle-only):** No per-skill preamble inject. Relies on Principle 0 once-per-session PRINCIPLES read. Per spec §7 Q1 recommended default.
- **Q2 = A (stamina row computed):** `stamina` mapped as `N × artifact-row`, not a fixed row. Per spec §7 Q2 recommended default.
- **Q3 = B (worked example):** Decomposition rule includes one inline example. Per spec §7 Q3 recommended default.

## Scope

- Modules touched: `PRINCIPLES.md`, `skills/typescript/SKILL.md`
- Tier (from safer-diff-scope): `senior` (files: 2, modules: 2, exports: 0, new_deps: 0)
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Simplify pass

Applied: em-dash in decomposition rule prose replaced with comma.

Simplify skips:
- Anti-pattern em-dashes kept: every sibling subsection's anti-patterns use em-dashes (lines 278, 289, 297). Changing only the new section creates inconsistency.
- One-sentence rationale kept: spec AC 5.1 mandates it.
- Per-modality table kept: spec AC 5.2 requires exhaustive mapping (11 modalities + stamina).
- `stamina` in per-modality table kept: spec AC 5.2 explicitly requires it as a named entry.

## Confidence

HIGH — every row in the plan-anchor table traces to a spec line; `safer-diff-scope` reports `senior`; no new exports or deps; simplify findings resolved or cited.

---

`/safer:review-senior` is mandatory before merge.