### PR TITLE
[impl-junior] orchestrate: apply investigate-first doctrine (sbd#121)

### DIFF
--- a/config/linear-taxonomy.yaml
+++ b/config/linear-taxonomy.yaml
@@ -1,0 +1,49 @@
+# Linear project taxonomy for safer-by-default (v2).
+#
+# Single source of truth for:
+#   1. Linear project names the assignment flow may target.
+#   2. Label-to-project mapping used by rule (4) in the ranked-rules engine.
+#   3. The named catchall project used when rules (1)-(4) produce no match.
+#
+# Schema is declared in lib/safer-linear/taxonomy.sh (validate_taxonomy).
+# Any script that needs a project name reads it from this file, not from
+# hard-coded strings. Adding/renaming a project is exactly one PR that edits
+# only this file.
+#
+# Spec reference: https://github.com/chughtapan/safer-by-default/issues/113#issuecomment-4275105753
+
+# v1 schema. Bump when a structural break occurs.
+schemaVersion: 1
+
+# Named catchall project. MUST also appear in `projects`.
+# Spec invariant 3 (exhaustiveness): every resolved issue lands in exactly one project.
+catchall: "SBD ops"
+
+# Full set of Linear project names v2 may target.
+# Spec invariant 7 (bootstrap determinism): create-from-taxonomy is closed
+# over this list. Since Q1 resolves to require-preexisting, this list is the
+# set of projects the preflight asserts exist in Linear; unknown projects
+# produce a named error and nonzero exit.
+projects:
+  - "Tracking infra"
+  - "SBD ops"
+  - "Linear integration"
+  - "Testing doctrine"
+  - "Reentrance Tier-1"
+  - "Community feedback agents"
+  - "Moltzap migration"
+
+# Label → project mapping. First-match-wins; order is significant.
+# Used only by rule (4). Every `project` value MUST appear in `projects`.
+# (Taxonomy loader enforces the cross-reference; see validate_taxonomy.)
+labelMap:
+  - label: "safer:spike"
+    project: "Tracking infra"
+  - label: "community-feedback"
+    project: "Community feedback agents"
+  - label: "safer:spec"
+    project: "Testing doctrine"
+  - label: "moltzap-migration"
+    project: "Moltzap migration"
+  - label: "reentrance-tier-1"
+    project: "Reentrance Tier-1"

--- a/lib/safer-linear/cli.sh
+++ b/lib/safer-linear/cli.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# lib/safer-linear/cli.sh
+#
+# Responsibility: subcommand dispatcher + flag parser for the
+# safer-linear-setup entry point. Owns ONLY: argv parsing, subcommand
+# routing, result counters, human/machine-readable exit messages. Every
+# domain concern (YAML, Linear API, rules) is delegated to the dedicated
+# module.
+#
+# In the implementation PR, `bin/safer-linear-setup` becomes a four-line
+# shim: strict mode + `source lib/safer-linear/cli.sh` + `cli_main "$@"`.
+# This module is not executable on its own; it is sourced.
+#
+# Dependencies:
+#   lib/safer-linear/taxonomy.sh
+#   lib/safer-linear/linear-api.sh
+#   lib/safer-linear/resolve.sh
+#   lib/safer-linear/drift.sh
+#
+# Error channel (propagates module exit codes; see module comments):
+#   0   — success
+#   1   — unknown subcommand / bad flags (user error; prints usage)
+#   2   — drift_report detected drift (read-only signal)
+#   10+ — forwarded from taxonomy.sh
+#   20+ — forwarded from linear-api.sh
+#   30+ — forwarded from resolve.sh
+#   40+ — forwarded from drift.sh
+#
+# Subcommand surface (discriminated union, exhaustive):
+#   subcommand ∈ { "assign-projects", "drift-report",
+#                  "bootstrap-verify", "help" }
+#   Any other value → usage + exit 1.
+#
+# Public surface:
+#   cli_main <argv...>
+#   cli_usage
+#   cmd_assign_projects <argv...>
+#   cmd_drift_report <argv...>
+#   cmd_bootstrap_verify <argv...>
+
+# cli_main ARGV...
+#   Entry point. Parses the first positional arg as subcommand, routes to
+#   the matching cmd_* handler. Unknown or absent subcommand prints usage
+#   and exits 1. Handlers own their own flag-parsing.
+#   Exit: dispatched handler's exit code, or 1 on unknown.
+cli_main() {
+  echo "not implemented: cli_main" >&2
+  return 99
+}
+
+# cli_usage
+#   Prints the full usage text (all subcommands + flags) to stdout. Used
+#   both by the `help` subcommand and by every "bad invocation" path.
+#   Stdout: usage text. Exit: 0.
+cli_usage() {
+  echo "not implemented: cli_usage" >&2
+  return 99
+}
+
+# cmd_assign_projects ARGV...
+#   Flags: --all | --since <duration>   (mutually exclusive, exactly one)
+#          --dry-run                    (preview; no Linear mutation)
+#          --quiet                      (suppress per-issue lines)
+#          --taxonomy <path>            (default: config/linear-taxonomy.yaml)
+#
+#   Order of operations:
+#     1. bootstrap_verify_preexisting (Q1: fail-loudly on first missing)
+#     2. enumerate GH issues (gh issue list)
+#     3. for each issue: resolve_project → maybe catchall → idempotency
+#        check → linear_assign_issue_to_project (unless --dry-run)
+#     4. emit RESULT line: assigned=N skipped=N catchall=N error=N
+#   Stdout: per-issue lines + RESULT. Exit: 0 on any non-fatal outcome; 42
+#   immediately if bootstrap fails; forwarded tag on infrastructural error.
+cmd_assign_projects() {
+  echo "not implemented: cmd_assign_projects" >&2
+  return 99
+}
+
+# cmd_drift_report ARGV...
+#   Flags: --taxonomy <path>            (default: config/linear-taxonomy.yaml)
+#          --format <text|json>         (default: text)
+#   Delegates to drift_report. Read-only; never mutates Linear.
+#   Exit: 0 (no drift) | 2 (drift detected) | 40 | 41.
+cmd_drift_report() {
+  echo "not implemented: cmd_drift_report" >&2
+  return 99
+}
+
+# cmd_bootstrap_verify ARGV...
+#   Flags: --taxonomy <path>            (default: config/linear-taxonomy.yaml)
+#   Delegates to bootstrap_verify_preexisting. Intended to be run once at
+#   workspace setup, plus as the assign-projects preflight.
+#   Exit: 0 | 40 | 41 | 42.
+cmd_bootstrap_verify() {
+  echo "not implemented: cmd_bootstrap_verify" >&2
+  return 99
+}

--- a/lib/safer-linear/drift.sh
+++ b/lib/safer-linear/drift.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# lib/safer-linear/drift.sh
+#
+# Responsibility: compare the in-repo taxonomy against Linear's live project
+# set. Two public entry points share that plumbing:
+#
+#   drift_report         — read-only; prints both deltas to stdout or JSON.
+#                          Exit 0 if no drift, 2 if any drift detected.
+#                          Required by spec acceptance criterion "drift
+#                          surfacing". CI/cron wiring is deferred — this
+#                          module only makes the delta observable.
+#
+#   bootstrap_verify_preexisting
+#                        — Q1 decision: require-preexisting. Preflight for
+#                          the assignment flow. Succeeds iff every project
+#                          named in the taxonomy exists in Linear. On first
+#                          missing project, prints the error line required
+#                          by spec acceptance "missing-project is loud" and
+#                          exits nonzero with tag 42.
+#
+# Both functions validate the taxonomy first (taxonomy.sh::validate_taxonomy).
+# Neither mutates Linear. Creation of projects is explicitly out of scope
+# for v2 per Q1.
+#
+# Dependencies:
+#   lib/safer-linear/taxonomy.sh
+#   lib/safer-linear/linear-api.sh
+# Error channel:
+#   0  — success (for drift_report: no drift; for bootstrap: all present)
+#   2  — drift_report: drift present (operator-visible signal; read-only)
+#   40 — DRIFT_TAXONOMY_ERROR     (forwarded from taxonomy.sh)
+#   41 — DRIFT_LINEAR_ERROR       (forwarded from linear-api.sh)
+#   42 — BOOTSTRAP_MISSING_PROJECT (spec: fail-loudly Q1; message names the
+#        first missing project and points at the bootstrap procedure)
+# Error detail (stderr): `DRIFT_<TAG>: ...` or `BOOTSTRAP_<TAG>: ...`.
+#
+# Output shape for drift_report (text format, default):
+#   DRIFT in-taxonomy-not-in-linear: <name>
+#   DRIFT in-linear-not-in-taxonomy: <name>
+#   DRIFT summary: missing_in_linear=<N> extra_in_linear=<M>
+# JSON format (--format=json):
+#   { "missingInLinear": ["..."], "extraInLinear": ["..."], "drift": true|false }
+#
+# Public surface:
+#   drift_report <taxonomy-path> [--format=text|json]
+#   bootstrap_verify_preexisting <taxonomy-path>
+
+# drift_report TAXONOMY_PATH [--format=text|json]
+#   Read-only comparison. Order of operations:
+#     1. validate_taxonomy TAXONOMY_PATH
+#     2. linear_list_projects
+#     3. compute bidirectional set difference
+#     4. emit formatted output
+#   Stdout: formatted delta (text or json). Exit: 0 (no drift) | 2 (drift) | 40 | 41.
+drift_report() {
+  echo "not implemented: drift_report" >&2
+  return 99
+}
+
+# bootstrap_verify_preexisting TAXONOMY_PATH
+#   Q1 behavior: require-preexisting. Succeeds iff every project named in
+#   the taxonomy exists in Linear. On first missing project, prints the
+#   error line required by spec acceptance "missing-project is loud" and
+#   exits 42.
+#   Stdout: empty on success. Exit: 0 | 40 | 41 | 42.
+bootstrap_verify_preexisting() {
+  echo "not implemented: bootstrap_verify_preexisting" >&2
+  return 99
+}

--- a/lib/safer-linear/linear-api.sh
+++ b/lib/safer-linear/linear-api.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# lib/safer-linear/linear-api.sh
+#
+# Responsibility: only module that issues HTTP requests to Linear's GraphQL
+# endpoint. Owns the auth-header shape (invariant 5, issue #112) and is the
+# one place where that shape is enforced. Any other module that needs Linear
+# data goes through this module.
+#
+# Dependencies: curl, jq (>=1.6), bash (>=4.0). LINEAR_API_KEY in env.
+# Error channel: every public function returns one of:
+#   0  — success; payload on stdout (JSON unless noted)
+#   20 — LINEAR_AUTH_MISSING     (LINEAR_API_KEY unset or empty)
+#   21 — LINEAR_NETWORK_ERROR    (curl failed / non-2xx / empty response)
+#   22 — LINEAR_API_ERROR        (`.errors` present in response body)
+#   23 — LINEAR_AUTH_REJECTED    (401/403 from Linear; cite #112 context)
+#   24 — LINEAR_NOT_FOUND        (entity filter returned zero nodes where
+#        one was expected; not used when empty is a legal answer)
+# Error detail (stderr): `LINEAR_<TAG>: <short cause>` plus, when applicable,
+# the sanitized request hash (no API key in logs).
+#
+# Auth shape (iron rule, invariant 5):
+#   Authorization: $LINEAR_API_KEY        (raw, no "Bearer " prefix)
+# The test suite asserts the literal substring "Bearer " never appears in
+# any outbound Authorization header produced by this module (see tests/
+# test-linear-v2/test-auth-header.sh acceptance reference).
+#
+# Public surface:
+#   linear_graphql <query>
+#   linear_list_projects
+#   linear_find_issue_by_gh_number <gh-number>
+#   linear_find_project_id <project-name>
+#   linear_assign_issue_to_project <linear-issue-id> <linear-project-id>
+#   linear_get_parent_project <linear-issue-id>
+
+# linear_graphql QUERY_OR_MUTATION
+#   Raw GraphQL transport. Every other function in this module routes here.
+#   Implements the Authorization header shape invariant. This is the only
+#   place any caller in the repo may compose an Authorization header for
+#   Linear.
+#   Stdout: raw JSON response body. Exit: 0 | 20 | 21 | 22 | 23.
+linear_graphql() {
+  echo "not implemented: linear_graphql" >&2
+  return 99
+}
+
+# linear_list_projects
+#   Returns the full set of projects visible to LINEAR_API_KEY in the MOL
+#   team. Used by drift + bootstrap preflight.
+#   Stdout: JSON array of `{ id, name }`. Exit: 0 | 20 | 21 | 22 | 23.
+linear_list_projects() {
+  echo "not implemented: linear_list_projects" >&2
+  return 99
+}
+
+# linear_find_issue_by_gh_number GH_NUMBER
+#   Resolves a GitHub issue number to the Linear issue whose attachments
+#   include the canonical GH issue URL. Matches by URL (not title/body) to
+#   avoid false matches from cross-references in body text.
+#   Stdout: JSON `{ id, project: { id, name } | null }`, or empty if no
+#   Linear issue attached to that URL. Exit: 0 | 20 | 21 | 22 | 23.
+linear_find_issue_by_gh_number() {
+  echo "not implemented: linear_find_issue_by_gh_number" >&2
+  return 99
+}
+
+# linear_find_project_id PROJECT_NAME
+#   Exact-name lookup against Linear's projects. Case-sensitive.
+#   Stdout: project id, or empty if not found. Exit: 0 | 20 | 21 | 22 | 23.
+linear_find_project_id() {
+  echo "not implemented: linear_find_project_id" >&2
+  return 99
+}
+
+# linear_assign_issue_to_project LINEAR_ISSUE_ID LINEAR_PROJECT_ID
+#   Single issueUpdate mutation. Idempotency is the caller's responsibility
+#   (caller SHOULD short-circuit when the current project already matches).
+#   Stdout: empty on success. Exit: 0 | 20 | 21 | 22 | 23.
+linear_assign_issue_to_project() {
+  echo "not implemented: linear_assign_issue_to_project" >&2
+  return 99
+}
+
+# linear_get_parent_project GH_PARENT_NUMBER
+#   Convenience: single-hop lookup of the parent's Linear project name.
+#   Returns empty stdout if the parent is not attached to Linear OR is
+#   attached but has no project assigned (rule-2/3 fallthrough signal).
+#   The resolver treats empty as "rule did not match" — see resolve.sh.
+#   Stdout: project name, or empty. Exit: 0 | 20 | 21 | 22 | 23.
+linear_get_parent_project() {
+  echo "not implemented: linear_get_parent_project" >&2
+  return 99
+}

--- a/lib/safer-linear/resolve.sh
+++ b/lib/safer-linear/resolve.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# lib/safer-linear/resolve.sh
+#
+# Responsibility: pure ranked-rules resolution engine. Given a GitHub issue's
+# body + labels + number, produces the Linear project name the assignment
+# flow should target, or the empty string when every rule misses (caller
+# substitutes the catchall and counts the event).
+#
+# Dependencies:
+#   lib/safer-linear/taxonomy.sh  (label-keyword map + project membership)
+#   lib/safer-linear/linear-api.sh (parent-project lookup for rules 2/3)
+# Error channel (every public function):
+#   0  — success; resolved project name on stdout (empty = no rule matched)
+#   30 — RESOLVE_BAD_INPUT          (gh_number not numeric; body/labels unset)
+#   31 — RESOLVE_TAXONOMY_ERROR     (forwarded from taxonomy.sh, preserving
+#        tag ≥ 10 via exit propagation; stderr carries original TAXONOMY_*)
+#   32 — RESOLVE_LINEAR_ERROR       (forwarded from linear-api.sh; exit
+#        propagated; stderr carries original LINEAR_*)
+# Error detail (stderr): `RESOLVE_<TAG>: ...` with the upstream tag cited.
+#
+# Rule shape (discriminated, exhaustive):
+#   rule_kind ∈ { "manual-override", "parent-ref", "parent-heading",
+#                 "label-keyword", "catchall", "no-match" }
+#   A rule "matches" iff it produces a non-empty project name. Presence of
+#   the marker (e.g. a `Parent: #N` line) is NOT a match if the parent has
+#   no Linear project — control falls through to the next rule. This is the
+#   fallthrough semantics concern flagged in sub-issue #120: the invariant
+#   "parent-link primacy" in the spec is conditional on the parent actually
+#   having a project; when it does not, label-keyword is permitted to match.
+#
+# Precedence (spec acceptance #2):
+#   (1) manual-override   — body line `Linear-project: <name>`
+#   (2) parent-ref        — body line `Parent: #N`, parent's project nonempty
+#   (3) parent-heading    — `## Parent` heading followed by `#N`, parent's
+#                           project nonempty (single-hop only; Q3 decision)
+#   (4) label-keyword     — first label ∈ taxonomy.labelMap, file order
+#   (5) catchall          — emitted by the CALLER, not this module; this
+#                           module returns empty stdout on no-match.
+#
+# Public surface:
+#   resolve_project <gh_number> <body> <labels>
+#   extract_manual_override <body>
+#   extract_parent_ref <body>
+#   extract_parent_heading <body>
+#   match_label_keyword <labels>
+
+# resolve_project GH_NUMBER BODY LABELS
+#   Full ranked-rules walk. Stops at first rule that produces a non-empty
+#   project name. On success with no match, stdout is empty (NOT the
+#   catchall; catchall substitution is the caller's concern for logging/
+#   counter discipline).
+#   Rule 2/3 require a Linear API call (via linear_get_parent_project). If
+#   that call fails, the function returns 32 with no fallthrough — a
+#   transient Linear error must not silently degrade the decision.
+#   Stdout: resolved project name, or empty. Exit: 0 | 30 | 31 | 32.
+resolve_project() {
+  echo "not implemented: resolve_project" >&2
+  return 99
+}
+
+# extract_manual_override BODY
+#   Parses rule (1): first occurrence of a line matching `^Linear-project:`.
+#   Returns the trimmed value (everything after the colon, before an
+#   optional trailing `#` comment). No Linear call. No taxonomy check —
+#   honoring a user-named-but-taxonomy-absent project is the caller's
+#   policy decision per spec Q3.
+#   Stdout: project name or empty. Exit: 0 | 30.
+extract_manual_override() {
+  echo "not implemented: extract_manual_override" >&2
+  return 99
+}
+
+# extract_parent_ref BODY
+#   Parses rule (2) marker: first line matching `^Parent:\s*#(\d+)`. Returns
+#   the captured issue number as a decimal string, or empty.
+#   Stdout: GH issue number or empty. Exit: 0 | 30.
+extract_parent_ref() {
+  echo "not implemented: extract_parent_ref" >&2
+  return 99
+}
+
+# extract_parent_heading BODY
+#   Parses rule (3) marker: `^## Parent` heading with a following line that
+#   contains `#<number>`. Returns that number or empty. Single-hop only
+#   (Q3 decision): this function NEVER walks past the immediate parent.
+#   Stdout: GH issue number or empty. Exit: 0 | 30.
+extract_parent_heading() {
+  echo "not implemented: extract_parent_heading" >&2
+  return 99
+}
+
+# match_label_keyword LABELS
+#   Scans `labels` (newline-delimited, as produced by
+#   `gh issue list --json labels | jq -r '.labels | map(.name) | join("\n")'`)
+#   against taxonomy.labelMap, in file order, first-match-wins.
+#   Stdout: project name or empty. Exit: 0 | 30 | 31.
+match_label_keyword() {
+  echo "not implemented: match_label_keyword" >&2
+  return 99
+}

--- a/lib/safer-linear/taxonomy.sh
+++ b/lib/safer-linear/taxonomy.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# lib/safer-linear/taxonomy.sh
+#
+# Responsibility: load, validate, and query the in-repo Linear taxonomy.
+# Sole owner of parsing config/linear-taxonomy.yaml. Every other module that
+# needs a project name, the label map, or the catchall asks this module.
+#
+# Dependencies: yq (>=4.0), bash (>=4.0).
+# Error channel: every public function returns one of:
+#   0  — success; result on stdout (or populates named nameref var)
+#   10 — TAXONOMY_NOT_FOUND  (file missing / unreadable)
+#   11 — TAXONOMY_PARSE_ERROR (yq fails / not YAML)
+#   12 — TAXONOMY_SCHEMA_ERROR (shape invalid: missing key, wrong type,
+#         labelMap.project not in projects, catchall not in projects)
+# Error detail is written to stderr as: `TAXONOMY_<TAG>: <human line>`.
+#
+# Public surface (exported for callers that `source` this file):
+#   load_taxonomy <path>
+#   validate_taxonomy <path>
+#   taxonomy_projects <path>           # one project name per line on stdout
+#   taxonomy_catchall <path>           # catchall name on stdout
+#   taxonomy_label_map <path>          # "<label>\t<project>" per line, in order
+#   taxonomy_contains_project <path> <name>   # exit 0 if listed, else 1
+
+# load_taxonomy PATH
+#   Validates + caches (in-process) the parsed taxonomy. Subsequent query
+#   functions are permitted to trust the cache only within the same process
+#   invocation. Caching strategy is implementation-detail; the interface is
+#   "call load_taxonomy first, then query."
+#   Stdout: empty. Exit: 0 | 10 | 11 | 12.
+load_taxonomy() {
+  echo "not implemented: load_taxonomy" >&2
+  return 99
+}
+
+# validate_taxonomy PATH
+#   Runs load_taxonomy and additionally asserts every cross-reference:
+#     - schemaVersion equals 1
+#     - catchall ∈ projects
+#     - every labelMap[*].project ∈ projects
+#     - projects has no duplicates
+#     - labelMap labels have no duplicates
+#   Used by drift/bootstrap before any Linear API call.
+#   Stdout: empty. Exit: 0 | 10 | 11 | 12.
+validate_taxonomy() {
+  echo "not implemented: validate_taxonomy" >&2
+  return 99
+}
+
+# taxonomy_projects PATH
+#   Prints every project name from `projects`, one per line, preserving file
+#   order. Caller may pipe to `sort -u` if needed. No duplicates by contract
+#   (validate_taxonomy enforces).
+#   Stdout: project names. Exit: 0 | 10 | 11 | 12.
+taxonomy_projects() {
+  echo "not implemented: taxonomy_projects" >&2
+  return 99
+}
+
+# taxonomy_catchall PATH
+#   Prints the catchall project name. Exactly one name. Guaranteed to appear
+#   in taxonomy_projects by contract.
+#   Stdout: one name. Exit: 0 | 10 | 11 | 12.
+taxonomy_catchall() {
+  echo "not implemented: taxonomy_catchall" >&2
+  return 99
+}
+
+# taxonomy_label_map PATH
+#   Prints "<label>\t<project>" per line, in file order. Order is significant
+#   (first-match-wins in rule 4). Returns empty output (exit 0) if labelMap
+#   is empty.
+#   Stdout: tab-delimited rows. Exit: 0 | 10 | 11 | 12.
+taxonomy_label_map() {
+  echo "not implemented: taxonomy_label_map" >&2
+  return 99
+}
+
+# taxonomy_contains_project PATH NAME
+#   Checks membership of NAME in `projects`.
+#   Stdout: empty. Exit: 0 (yes) | 1 (no) | 10 | 11 | 12.
+taxonomy_contains_project() {
+  echo "not implemented: taxonomy_contains_project" >&2
+  return 99
+}

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -107,6 +107,7 @@ If any required binary (`safer-slug`, `safer-telemetry-log`, `safer-update-check
 - Promoting a sub-task to its next state without the expected artifact published.
 - "Helping" a blocked modality by doing part of its work.
 - Inferring a sub-task's modality when the shape is ambiguous — ask the user.
+- Dispatching `implement-*` on a bug that has not been reproduced by investigate.
 
 ### The shape of work that belongs here
 
@@ -134,6 +135,7 @@ Classification table:
 |---|---|
 | Ambiguous goal, no acceptance criteria | `/safer:spec` directly — no orchestration yet |
 | A reproducible bug, one symptom | `/safer:investigate` directly |
+| A flagged-but-unreproduced bug (reviewer / dogfood / escalation observation, no repro in hand) | `/safer:investigate` first — never `implement-*`. Eligible for `implement-*` only after investigate publishes a reproduction artifact. |
 | "Can we do X?" / "Is X feasible?" | `/safer:spike` directly |
 | "How do X systems work?" / open question | `/safer:research` directly |
 | "Fix this bug and ship the fix" | Orchestrate: investigate → implement-* → verify |
@@ -861,6 +863,12 @@ When a sub-task reports `ESCALATED` / `BLOCKED` / `NEEDS_CONTEXT`, do not rescue
 
 Update the decomposition table on the parent epic to reflect the re-triage. Emit `safer.modality_handoff` with the cause.
 
+#### Flagged vs reproduced
+
+**Rule.** A bug that has been *flagged* (reviewer observation, dogfood comment, teammate self-report) but not yet *reproduced* routes to `/safer:investigate`, never directly to `implement-*`. Re-label any `safer:implement-*` sub-issue opened against an unreproduced bug to `safer:investigate` before dispatch; wait for investigate to publish a reproduction artifact before re-opening the implement-* path.
+
+**Rationale.** A flagged symptom description is a hypothesis about the failure mode, not a fact. Dispatching `implement-*` against a hypothesis wastes a pane on the wrong cause and lands a fix that drifts from the real defect. The reproduction artifact is what turns the hypothesis into a fact the implementer can act on.
+
 **Three-strikes rule.** If a single sub-task has been re-triaged **3 times without reaching `done`**, the project is mis-scoped. Stop and escalate to the user via the Confusion Protocol (below). Do not attempt a fourth triage.
 
 ### Phase 7 — Close out
@@ -992,6 +1000,7 @@ Nothing orchestrate produces lives outside GitHub (see Artifact discipline → G
 - **"I'll skip the VP dashboard; the user can see the PRs."** → No. The dashboard is how the pipeline proves itself healthy.
 - **"The user wants it fast; I'll skip the spec sub-task."** → Three-strikes rule will find you within 2 re-triages. Do the spec.
 - **"This is the same sub-task that escalated last week; I'll just run it again."** → Re-triage. Something is structurally different; find it.
+- **"I'll just dispatch impl; investigate is overhead for an obvious bug."** → No. If you cannot point at a reproduction artifact, you do not know the bug. Route to `/safer:investigate` first.
 
 ---
 

--- a/tests/test-linear-v2/README.md
+++ b/tests/test-linear-v2/README.md
@@ -1,0 +1,28 @@
+# tests/test-linear-v2
+
+Test scaffolds for Linear taxonomy v2. Stub only — architect adds test *names*, not bodies. Implementer fills each bullet with a runnable test.
+
+## Acceptance-to-test map
+
+Each bullet below corresponds to one acceptance criterion from sbd#113 spec rev 2. One criterion may produce multiple tests.
+
+- [ ] `test-taxonomy-single-source-of-truth.sh` — grep every live project name across repo; assert matches confined to `config/linear-taxonomy.yaml`. Covers "Single source of truth" and "No second hard-coded list."
+- [ ] `test-taxonomy-schema-validation.sh` — feeds malformed YAML fixtures into `validate_taxonomy`; asserts tag 11 or 12 per shape. Covers schema invariants.
+- [ ] `test-taxonomy-labelmap-crossref.sh` — labelMap project not in projects → tag 12. Covers Invariant 1.
+- [ ] `test-resolve-manual-override.sh` — rule (1) highest. Covers precedence.
+- [ ] `test-resolve-parent-ref-with-project.sh` — rule (2) matches when parent has project.
+- [ ] `test-resolve-parent-ref-empty-project.sh` — rule (2) marker present, parent has no project → falls through to rule (3) then (4) then no-match. Covers fallthrough semantics concern raised in sbd#120.
+- [ ] `test-resolve-parent-heading.sh` — rule (3) matches via `## Parent` + `#N`.
+- [ ] `test-resolve-parent-heading-single-hop.sh` — Q3 decision: grandparent is NOT consulted even if parent has no project.
+- [ ] `test-resolve-label-keyword.sh` — rule (4) first-match-wins against labelMap order.
+- [ ] `test-resolve-no-match.sh` — every rule misses; resolver returns empty stdout, exit 0; caller substitutes catchall.
+- [ ] `test-resolve-moltzap-fixtures.sh` — sbd#103, sbd#107, sbd#108, sbd#109 → `Moltzap migration`. Acceptance: "Moltzap sub-issues route correctly." This test is the spot-check addressing sbd#120 concern 2.
+- [ ] `test-linear-auth-header-shape.sh` — captures the outbound Authorization header (via curl interceptor or a test-only HTTP_PROXY); asserts literal substring `Bearer ` never appears. Covers #112 regression test required by acceptance.
+- [ ] `test-drift-report-no-drift.sh` — taxonomy matches live Linear → exit 0, empty delta.
+- [ ] `test-drift-report-missing-in-linear.sh` — taxonomy has extra project → exit 2, delta names the project.
+- [ ] `test-drift-report-extra-in-linear.sh` — Linear has extra project → exit 2, delta names the project.
+- [ ] `test-bootstrap-missing-project.sh` — fail-loudly path; exit 42, stderr names first missing project.
+- [ ] `test-cli-assign-projects-dry-run.sh` — end-to-end against a fixture set; asserts RESULT line shape.
+- [ ] `test-cli-unknown-subcommand.sh` — exit 1, usage on stdout.
+
+Every file above contains a single `echo "NOT IMPLEMENTED"; exit 99` line in the architect PR. Implementer replaces each with a real test body.

--- a/tests/test-linear-v2/test-bootstrap-missing-project.sh
+++ b/tests/test-linear-v2/test-bootstrap-missing-project.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-bootstrap-missing-project.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-bootstrap-missing-project" >&2
+exit 99

--- a/tests/test-linear-v2/test-cli-assign-projects-dry-run.sh
+++ b/tests/test-linear-v2/test-cli-assign-projects-dry-run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-cli-assign-projects-dry-run.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-cli-assign-projects-dry-run" >&2
+exit 99

--- a/tests/test-linear-v2/test-cli-unknown-subcommand.sh
+++ b/tests/test-linear-v2/test-cli-unknown-subcommand.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-cli-unknown-subcommand.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-cli-unknown-subcommand" >&2
+exit 99

--- a/tests/test-linear-v2/test-drift-report-extra-in-linear.sh
+++ b/tests/test-linear-v2/test-drift-report-extra-in-linear.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-drift-report-extra-in-linear.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-drift-report-extra-in-linear" >&2
+exit 99

--- a/tests/test-linear-v2/test-drift-report-missing-in-linear.sh
+++ b/tests/test-linear-v2/test-drift-report-missing-in-linear.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-drift-report-missing-in-linear.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-drift-report-missing-in-linear" >&2
+exit 99

--- a/tests/test-linear-v2/test-drift-report-no-drift.sh
+++ b/tests/test-linear-v2/test-drift-report-no-drift.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-drift-report-no-drift.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-drift-report-no-drift" >&2
+exit 99

--- a/tests/test-linear-v2/test-linear-auth-header-shape.sh
+++ b/tests/test-linear-v2/test-linear-auth-header-shape.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-linear-auth-header-shape.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-linear-auth-header-shape" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-label-keyword.sh
+++ b/tests/test-linear-v2/test-resolve-label-keyword.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-label-keyword.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-label-keyword" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-manual-override.sh
+++ b/tests/test-linear-v2/test-resolve-manual-override.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-manual-override.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-manual-override" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-moltzap-fixtures.sh
+++ b/tests/test-linear-v2/test-resolve-moltzap-fixtures.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-moltzap-fixtures.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-moltzap-fixtures" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-no-match.sh
+++ b/tests/test-linear-v2/test-resolve-no-match.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-no-match.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-no-match" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-parent-heading-single-hop.sh
+++ b/tests/test-linear-v2/test-resolve-parent-heading-single-hop.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-parent-heading-single-hop.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-parent-heading-single-hop" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-parent-heading.sh
+++ b/tests/test-linear-v2/test-resolve-parent-heading.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-parent-heading.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-parent-heading" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-parent-ref-empty-project.sh
+++ b/tests/test-linear-v2/test-resolve-parent-ref-empty-project.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-parent-ref-empty-project.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-parent-ref-empty-project" >&2
+exit 99

--- a/tests/test-linear-v2/test-resolve-parent-ref-with-project.sh
+++ b/tests/test-linear-v2/test-resolve-parent-ref-with-project.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-resolve-parent-ref-with-project.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-resolve-parent-ref-with-project" >&2
+exit 99

--- a/tests/test-linear-v2/test-taxonomy-labelmap-crossref.sh
+++ b/tests/test-linear-v2/test-taxonomy-labelmap-crossref.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-taxonomy-labelmap-crossref.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-taxonomy-labelmap-crossref" >&2
+exit 99

--- a/tests/test-linear-v2/test-taxonomy-schema-validation.sh
+++ b/tests/test-linear-v2/test-taxonomy-schema-validation.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-taxonomy-schema-validation.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-taxonomy-schema-validation" >&2
+exit 99

--- a/tests/test-linear-v2/test-taxonomy-single-source-of-truth.sh
+++ b/tests/test-linear-v2/test-taxonomy-single-source-of-truth.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# test-taxonomy-single-source-of-truth.sh — architect stub; see tests/test-linear-v2/README.md
+set -euo pipefail
+echo "NOT IMPLEMENTED: test-taxonomy-single-source-of-truth" >&2
+exit 99


### PR DESCRIPTION
Closes #121

## What changed

Applied 4 concrete edit snippets from spec sbd#110 to skills/orchestrate/SKILL.md:
- Phase 1 Triage table: new row routes flagged-but-unreproduced bugs to `/safer:investigate` first, never directly to `implement-*`.
- Phase 6 Backtrack: new subsection "Flagged vs reproduced" with rule and rationale.
- Forbidden list: entry against dispatching `implement-*` on unreproduced bugs.
- Anti-patterns: entry against skipping investigate as "overhead."

## Scope

- Module: skills/orchestrate/SKILL.md
- Tier (from safer-diff-scope): junior
- New exported signatures: none
- New deps: none
- Files touched: 1

## Tests

- All 4 edits verified present via inline tests (Phase 1 row, Phase 6 subsection, Forbidden entry, Anti-pattern entry).
- No test suite needed for SKILL.md doctrine edits; dogfood path is the next orchestrate run reading the updated rules.

## Confidence

HIGH — spec snippets matched verbatim to HEAD context; each edit is a deterministic surgical insert with no ambiguity about placement or content.