### PR TITLE
[impl-senior] apply doctrine triangle (sbd#129/130/131)

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -108,6 +108,8 @@ If any required binary (`safer-slug`, `safer-telemetry-log`, `safer-update-check
 - "Helping" a blocked modality by doing part of its work.
 - Inferring a sub-task's modality when the shape is ambiguous — ask the user.
 - Dispatching `implement-*` on a bug that has not been reproduced by investigate.
+- Merging a PR or closing a sub-issue based solely on a teammate `SendMessage` summary, without reading the reviewer body on GitHub via the Step 5c.0 procedure.
+- Letting a teammate `permission_request` sit unanswered past one sweep tick. Decide and respond that tick — approve via SendMessage, deny via Escape + SendMessage, or take the action from team-lead context. Idle permission_requests are a stop-rule violation.
 
 ### The shape of work that belongs here
 
@@ -322,6 +324,50 @@ Then cascade forward per modality lifecycle:
 - `implement-*` → `plan-approved` → `implementing` (the PR is merged) → `verifying` (verify sub-task runs) → `done`.
 - `investigate` / `spike` / `research` → `plan-approved` → `done` (these produce writeups, not code).
 
+**Step 5c.0 — Read reviewer body before merging.**
+
+Before transitioning a sub-issue out of `review` (`review → plan-approved` on the
+manual path in Step 5c, or `review → plan-approved` on the auto-gate path in
+Phase 5d loop body item 5), team-lead MUST read the full reviewer body on
+GitHub. The teammate's `SendMessage` summary is a one-line compression; gating
+conditions live in the body, not in the summary. Acting on the summary alone is
+how the verify gate gets skipped (incident: 2026-04-19, acg#27).
+
+Fetch the most recent review body:
+
+```bash
+gh pr view <N> --repo <R> --json reviews --jq '.reviews[-1].body'
+```
+
+Scan the body for these three condition patterns. Any match blocks the merge:
+
+1. **Conditional approval** — phrases like *"approve but do not merge without X"*,
+   *"LGTM pending Y"*, *"approve subject to Z"*. The verdict is approval against
+   the stated acceptance, not unconditional ship.
+2. **Follow-up gates** — explicit references to a downstream modality that must
+   run before merge: *"goes to verify before merge"*, *"needs another review
+   pass"*, *"hold for stamina"*, *"out-of-band check required"*.
+3. **Deferred-acceptance items** — acceptance criteria the reviewer marked as
+   not-yet-met but acceptable to defer past this review, with a stated condition
+   for closing the deferral: *"accept as DRAFT pending CI green"*, *"merge after
+   the linked Linear ticket lands"*.
+
+If any pattern matches:
+- **Manual path (Step 5c):** treat as `ESCALATED`. Do not transition the label.
+  Post the matched pattern as a comment on the sub-issue and route per Phase 6.
+- **Auto-gate path (Step 5d item 5):** skip this sub-issue on this tick. Post a
+  one-line comment naming the matched pattern (per the same human-visible
+  rule that governs Step 5c.1), and defer to the next human-driven tick. The
+  auto-gate never resolves a condition; it only detects and defers.
+
+If none of the patterns match and the body is an unconditional approval against
+the stated acceptance criteria, proceed to Step 5c.1.
+
+Failure mode the gate prevents: team-lead reads the teammate summary `APPROVE`,
+proceeds to Step 5c.1, closes the sub-issue, and merges the PR — while the
+reviewer body said *"goes to verify before merge."* The verify gate is skipped;
+the merge ships unmeasured.
+
 Once accepted, run the four steps below in order. These are the canonical gate-and-dispatch procedure; the Phase 5d auto-monitor calls into them (step 5 → Step 5c.1–5c.2; step 6 → Step 5c.3–5c.4).
 
 **Step 5c.1 — Post the gating comment and close the sub-issue.**
@@ -444,6 +490,34 @@ Record the returned job id on the parent epic (comment) so the next operator can
 **Loop body.** Each tick does exactly the checks below, in order. The loop writes no code and makes no decisions that are not already encoded in an artifact.
 
 1. **Team roster.** Read `~/.claude/teams/<team-name>/config.json` with `jq` to list teammates and their `isActive` flag. Example: `jq -r '.members[] | "\(.name)\t\(.isActive)\t\(.paneId // "-")"' ~/.claude/teams/<team-name>/config.json`.
+
+1a. **Teammate pane stall check.** For every teammate (excluding `team-lead`) whose `tmuxPaneId` is in `$ALIVE`, capture the pane and regex-match for the claude-swarm permission dialog string. The Agent backend uses a separate tmux socket — discover it once per tick, do NOT assume `default`:
+
+    ```bash
+    SWARM_SOCKET=$(ls /tmp/tmux-$(id -u)/claude-swarm-* 2>/dev/null | head -1)
+    [ -z "$SWARM_SOCKET" ] && echo "swarm_socket_missing: skipping pane stall check" && return 0
+
+    for paneId in $(jq -r '.members[] | select(.name != "team-lead") | .tmuxPaneId // empty' \
+                    ~/.claude/teams/<team-name>/config.json); do
+      capture=$(tmux -S "$SWARM_SOCKET" capture-pane -t "$paneId" -p 2>/dev/null) || continue
+      if echo "$capture" | grep -q 'Waiting for team lead approval'; then
+        # Extract the requested tool + command from the last ~40 lines of the capture.
+        # Surface as a sweep-summary anomaly. The team-lead MUST respond this tick
+        # via the Phase 5e protocol — not the next.
+        teammate=$(jq -r --arg pid "$paneId" \
+          '.members[] | select(.tmuxPaneId == $pid) | .name' \
+          ~/.claude/teams/<team-name>/config.json)
+        echo "permission_stall: teammate=$teammate pane=$paneId"
+        echo "$capture" | tail -40
+      fi
+    done
+    ```
+
+    Guardrails:
+    - Never kill a pane that matched `Waiting for team lead approval`. Path (a) and Path (b) cleanup in step 4 do not apply to stalled panes; the work is alive, blocked on a decision.
+    - Never auto-respond. The Phase 5e protocol below defines the team-lead's response mechanisms; this step only surfaces the anomaly.
+    - If `$SWARM_SOCKET` is empty (claude-swarm not running, or socket name changed upstream), log `swarm_socket_missing` and skip the step. Do not fall back to the `default` socket — that would scan the wrong panes.
+
 2. **Review-ready sub-issues.** `gh issue list --label review --json number,title,url,labels` for this repo. Any hit is a candidate for Step 5c.
 3. **Open PRs.** `gh pr list --json number,url,isDraft,mergeable,statusCheckRollup` to see which draft PRs are green.
    - **Linear project sync (if configured).** Run `safer-linear-setup assign-projects --since 5m --quiet` to backfill any issues filed in the last 5 minutes to their correct Linear project. Requires `LINEAR_API_KEY` env var; silently skips if not set.
@@ -482,7 +556,7 @@ Record the returned job id on the parent epic (comment) so the next operator can
    - Path (a) requires only pane-missing from `$ALIVE`. A teammate whose work is incomplete but whose process died is still removed — their pane is gone either way, and the work needs to be re-dispatched.
    - When uncertain whether a teammate is truly done, leave them. A held pane is cheaper than lost work.
 
-5. **Auto-gate + update epic progress.** For each sub-issue whose acceptance is mechanically verifiable (clean draft PR green on CI, review-ready comment matching the acceptance criterion, etc.), run **Step 5c.1 and Step 5c.2**: transition `review → plan-approved`, post the gating comment, close the sub-issue, then rewrite the parent epic's `## Progress` section. Skip the sub-issue when tests are red, CI is pending, or the acceptance artifact requires human judgment (any criterion the modality delegates to `/safer:review-senior`).
+5. **Auto-gate + update epic progress.** For each sub-issue whose acceptance is mechanically verifiable (clean draft PR green on CI, review-ready comment matching the acceptance criterion, etc.), run **Step 5c.1 and Step 5c.2**: transition `review → plan-approved`, post the gating comment, close the sub-issue, then rewrite the parent epic's `## Progress` section. Skip the sub-issue when tests are red, CI is pending, or the acceptance artifact requires human judgment (any criterion the modality delegates to `/safer:review-senior`). Before any auto-gate transition fires, run **Step 5c.0** against the linked PR's reviewer body; skip the sub-issue if any of the three condition patterns matches.
 6. **Auto-dispatch pending work (work-queue scan).** The prior steps react to state the loop already knows about. Step 6 is the proactive scan: enumerate pending sub-issues across every repo this team serves, filter out the ones that are already in flight, prioritize what is left, and dispatch up to the per-tick cap. Without this step the orchestrator idles between user prompts even when work is queued. Step 6 is mandatory once a team is installed.
 
 **Step 6a — enumerate pending work.** Scan every repo this team watches (`~/.claude/teams/<team-name>/config.json` carries `repos: []`; fall back to the current repo if the field is absent). For each, list open sub-issues whose labels name a dispatchable modality:
@@ -894,6 +968,31 @@ team lead with the spec URL.
 
 Templates are intentionally terse. They do not replicate the full modality charter; they point the teammate at `SKILL.md` and carry the scope contract that differs per modality. If a template grows beyond ~25 lines, the modality has shifted; revisit the template rather than expanding it in-place.
 
+### Phase 5e — permission_request response protocol
+
+When Step 1a surfaces a `permission_stall:` anomaly in the sweep summary, the team-lead MUST respond within the same tick. Sitting on a permission_request past one sweep tick is a Forbidden-list violation.
+
+**Decision sequence (always in this order):**
+
+1. **Read the pane capture** (the last ~40 lines printed under the `permission_stall:` line). Extract the actual tool name and the actual command. The truncated inbox JSON is unreliable; the pane capture is authoritative.
+2. **Classify the request.** Three checks, in order:
+   - **Scope.** Is the request inside the teammate's named sub-issue scope? Cross-scope requests get denied — the teammate is escalating sideways instead of upstream (Principle 8 violation).
+   - **Destructive-action rules.** Per existing rules in PRINCIPLES.md, the team-lead does NOT approve `rm -rf` outside the working directory, `git push --force` to protected branches, `DROP TABLE`, or any irreversible operation without explicit user authorization.
+   - **Session-level authorization.** If the user has pre-authorized the operation class for this session (e.g., "approve all rebases on this branch"), apply it; otherwise default-deny destructive operations.
+3. **Respond via one of three mechanisms:**
+   - **Approve via SendMessage.** Send the teammate a message naming the approval and any conditions: `{"to": "<teammate>", "summary": "permission approved", "message": "Approved: <tool> <command>. Proceed."}`. The teammate reads its inbox and the dialog clears on acceptance.
+   - **Deny via Escape + SendMessage.** Dismiss the modal first, then explain the denial:
+     ```bash
+     SWARM_SOCKET=$(ls /tmp/tmux-$(id -u)/claude-swarm-* | head -1)
+     tmux -S "$SWARM_SOCKET" send-keys -t <paneId> Escape
+     ```
+     Follow with `SendMessage({to: "<teammate>", message: "Denied: <reason>. Escalate to <upstream-modality> if blocked."})`.
+   - **Take the action from team-lead context, then notify.** When the action is safer from team-lead context (lockfile cleanup, branch hygiene, anything that requires repo-level authority the teammate does not need), perform the action in the team-lead pane, dismiss the teammate's dialog with `tmux send-keys Escape`, then SendMessage the teammate that the action is done and to proceed.
+
+**Discovery.** The claude-swarm tmux socket is at `/tmp/tmux-<uid>/claude-swarm-<pid>`, NOT `default`. Confirm with `ls /tmp/tmux-$(id -u)/claude-swarm-*`. Hardcoding `default` silently scans the wrong panes — capture-pane returns blank, the regex never matches, and stuck dialogs go unnoticed.
+
+**Audit.** Every Phase 5e response logs a one-line entry to the parent epic comment: `permission_decision: teammate=<name> tool=<tool> verdict=<approve|deny|sideaction> reason="<short>"`. The audit line is not optional — the next operator reading the epic must be able to reconstruct why each request was answered the way it was.
+
 ### Phase 6 — Backtrack
 
 When a sub-task reports `ESCALATED` / `BLOCKED` / `NEEDS_CONTEXT`, do not rescue. Read the escalation artifact, classify the cause, and route:
@@ -1048,6 +1147,8 @@ Nothing orchestrate produces lives outside GitHub (see Artifact discipline → G
 - **"The user wants it fast; I'll skip the spec sub-task."** → Three-strikes rule will find you within 2 re-triages. Do the spec.
 - **"This is the same sub-task that escalated last week; I'll just run it again."** → Re-triage. Something is structurally different; find it.
 - **"I'll just dispatch impl; investigate is overhead for an obvious bug."** → No. If you cannot point at a reproduction artifact, you do not know the bug. Route to `/safer:investigate` first.
+- **"The teammate said APPROVE, so I merged."** → No. Read the reviewer body via the Step 5c.0 procedure. Approve against the stated acceptance is conditional on all named gates (verify, re-review, out-of-band checks) having run. The teammate summary compresses; conditions live in the body.
+- **"Teammate pane is quiet; task must be progressing."** → No. Quiet pane + roster `isActive=false` has three causes: (a) task done, (b) process crashed, (c) stuck on a permission dialog the team-lead never saw. Capture the pane (Step 1a) before assuming (a). The existing Path (a) cleanup is correct only when the pane is missing from `$ALIVE`, not when it is alive but quiet.
 
 ---
 

--- a/skills/review-senior/SKILL.md
+++ b/skills/review-senior/SKILL.md
@@ -43,6 +43,20 @@ Read `PRINCIPLES.md` at the plugin root. Your projection of the principles onto 
 
 If the instinct to "just fix this one line" appears, it is the stop rule firing. Write the comment; let the author push the fix. Every edit you make is a lie in the review history about who wrote what.
 
+## Forbidden verdicts
+
+**APPROVE requires every acceptance criterion to be either (a) directly verified by the reviewer in the PR diff, or (b) closed by a verify-modality comment already posted on the sub-issue or PR at review time.**
+
+If an acceptance criterion names a numeric threshold (mutation score ≥X%, coverage ≥Y%, latency ≤Z, throughput ≥R) and the PR only claims the number without a measurement artifact, the verdict MUST be `HOLD`, not `APPROVE`.
+
+`HOLD` is correct-but-unmeasured. `REQUEST-CHANGES` is broken-or-wrong. Consumers route them to different modalities; mixing them misleads the consumer.
+
+**Forbidden verdict patterns:**
+
+- Returning APPROVE with a deferred measurement condition the reviewer cannot confirm.
+- Returning APPROVE with "verify next" phrasing — if verify has not run, the verdict is HOLD.
+- Returning APPROVE citing the author's claim of a metric (e.g., "author reports 85% mutation") — the claim is not the measurement.
+
 ## Role
 
 You are a senior reviewer. Given a PR and a sub-issue (or an acceptance criteria list), you:
@@ -188,9 +202,35 @@ Missing tests for non-trivial logic is a finding, not an automatic block. Weigh 
 
 Decide the verdict:
 
-- **`--approve`** the diff matches the claimed modality, craft principles are followed, acceptance criteria are met, tests are present and meaningful. No findings, or only nit-level findings.
-- **`--request-changes`** any of: scope mismatch, craft principle violation with clear fix, acceptance criteria unmet, tests missing for non-trivial logic, existing tests gutted.
-- **`--comment`** findings exist but the reviewer is not the decision authority (e.g., the PR is for information). Rare at senior tier; default to one of the first two.
+- **`--approve`** the diff matches the claimed modality, craft principles are followed, and every acceptance criterion is either directly verified in the diff or closed by an already-posted verify-modality comment. No findings, or only nit-level findings.
+- **`HOLD`** (published via `gh pr review --comment` with body prefixed `## Verdict\nHOLD`) the diff matches the claimed modality and craft is green, but one or more acceptance criteria name a measured threshold the PR does not prove with a posted measurement artifact. HOLD is the trigger for team-lead to dispatch `/safer:verify`. HOLD is not `--request-changes`: the code is not broken, it is unmeasured.
+- **`--request-changes`** any of: scope mismatch, craft principle violation with clear fix, non-measurement acceptance criterion unmet, tests missing for non-trivial logic, existing tests gutted.
+- **`--comment`** findings exist but the reviewer is not the decision authority. Rare at senior tier; default to one of the first three.
+
+**Verdict decision table:**
+
+| Condition | Verdict |
+|---|---|
+| Diff shape matches claimed modality; craft green; every acceptance criterion directly verifiable from diff AND met | `--approve` |
+| Same as above, plus a prior `/safer:verify` comment on the sub-issue/PR closes any measured criterion | `--approve` |
+| Diff shape matches; craft green; one or more acceptance criteria names a measured threshold with no posted measurement artifact | `HOLD` |
+| Scope mismatch, craft violation with clear fix, non-measurement criterion unmet, or tests gutted | `--request-changes` |
+| Reviewer is not decision authority (rare at senior tier) | `--comment` |
+
+### HOLD vs REQUEST-CHANGES
+
+Two failure modes, two verdicts, two consumer actions.
+
+- **HOLD** the diff is *correct but unmeasured*. An acceptance criterion names a measured threshold the reviewer cannot confirm from the diff alone.
+  - Consumer (team-lead) action: dispatch `/safer:verify`.
+  - Label transition: `review` → `verifying`.
+  - Publish: `gh pr review --comment` with body `## Verdict\nHOLD`.
+- **REQUEST-CHANGES** the diff is *broken or wrong*. Craft violation, scope mismatch, missing implementation, gutted tests, or a non-measurement criterion unmet.
+  - Consumer action: dispatch `/safer:implement-*`.
+  - Label transition: `review` → `implementing`.
+  - Publish: `gh pr review --request-changes`.
+
+HOLD is not a soft REQUEST-CHANGES. REQUEST-CHANGES is not a harsh HOLD. Pick the verdict that matches the failure mode. Mixing them misleads the consumer and routes work to the wrong modality.
 
 Write the review body to a temp file:
 
@@ -246,7 +286,8 @@ safer-publish --kind comment --issue "$SUBISSUE" --body-file /tmp/safer-verdict-
 
 Transition labels:
 
-- On `--approve`: `safer-transition-label --issue "$SUBISSUE" --from review --to verifying` (the `verify` modality runs next).
+- On `--approve`: `safer-transition-label --issue "$SUBISSUE" --from review --to verifying` (verify runs next).
+- On `HOLD`: `safer-transition-label --issue "$SUBISSUE" --from review --to verifying`. Attach to the verdict body: "route to /safer:verify; measurement pending for criterion: <name>."
 - On `--request-changes`: `safer-transition-label --issue "$SUBISSUE" --from review --to implementing` (author revises).
 - On `--comment`: no state change; the orchestrator decides.
 
@@ -273,6 +314,7 @@ Each stop rule fires on a specific condition. When fired, produce an escalation 
 Every invocation ends with exactly one status marker on the last line of your response:
 
 - `DONE` review posted; verdict is `--approve`; label transitioned to `verifying`.
+- `HOLD` review posted with `## Verdict\nHOLD` body; diff is correct but one or more measured-threshold criteria are unproven; label transitioned to `verifying`; route named is `/safer:verify`. HOLD is a valid terminal output for review-senior.
 - `DONE_WITH_CONCERNS` review posted; verdict is `--approve` but with concerns listed; state each.
 - `ESCALATED` stop rule fired; routed to `architect`, `spec`, or orchestrator re-triage.
 - `BLOCKED` cannot review without missing context (sub-issue, acceptance criteria).
@@ -328,6 +370,9 @@ Nothing review-senior produces lives outside GitHub.
 - **"I'll suggest a library swap in the review."** Out of scope. The review reads the diff; architectural suggestions route to `architect`.
 - **"I'll paste a rewritten version of the function in the comment."** Prose + `file:line` is enough. Pasting diffs blurs authorship.
 - **"No linked sub-issue; I'll review anyway."** Without acceptance criteria, there is nothing to review against. `NEEDS_CONTEXT`.
+- **"The diff looks clean and the author claims ≥80% mutation score, so APPROVE with 'verify next'."** No. APPROVE is misleading when a measurement is deferred; consumers merge on APPROVE. Use HOLD with an explicit verify-dispatch recommendation. Team-lead reads HOLD as "dispatch verify," not "do nothing."
+- **"Author reports the number in the PR body; that closes the criterion."** No. The author's claim is not the measurement. A verify comment with the measured number is the measurement. HOLD until that comment exists.
+- **"HOLD and REQUEST-CHANGES mean the same thing to me; I'll pick whichever."** No. They route to different modalities. HOLD → verify; REQUEST-CHANGES → implement-*. Pick the verdict that matches the failure mode.
 
 ## Checklist before declaring `DONE`
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -40,6 +40,20 @@ Read `PRINCIPLES.md` at the plugin root. Your projection of the principles onto 
 
 The instinct "this test is almost passing; let me tweak it" is the exact failure mode this iron rule prevents. Your tweak becomes shipped code under the label `verify`, which no one reviews at that label. Hold.
 
+## Verify is the merge gate
+
+When `review-senior` issues `HOLD` because an acceptance criterion names a measured threshold the reviewer could not confirm from the diff, **verify's published comment is the artifact that turns HOLD → merge-ready**.
+
+The comment contains:
+
+1. The measured number (mutation %, coverage %, latency ms, throughput rps, ...).
+2. A verdict: `SHIP`, `HOLD`, or `SHIP_WITH_CONCERNS`.
+3. The acceptance criterion the measurement closes.
+
+Until that comment exists on the PR or the sub-issue at the PR's head SHA, merge is blocked at team-lead's read-before-merge gate (see `orchestrate` skill). The team-lead reads verify's comment body before merging; the measured number in the comment is authoritative, not the author's claim in the PR body and not review-senior's HOLD summary.
+
+`SHIP` → HOLD closed; merge-ready. `HOLD` → measurement fell short; route to `implement-*`. `SHIP_WITH_CONCERNS` → merge-ready with named concerns; team-lead decides.
+
 ## Role
 
 You are a verifier. Given a PR and a set of acceptance criteria, you:
@@ -316,6 +330,8 @@ Nothing verify produces lives outside GitHub.
 - **"Lint warnings are not failures."** If the repo's lint command exits non-zero on warnings, they are failures. The exit code is the contract.
 - **"I can run just the tests that match the diff."** Run the full detected suite. Cross-file regressions are the most common failure mode; a scoped run misses them.
 - **"The verdict is in my conversation."** Publish. GitHub is the record.
+- **"The author's PR body claims 85% mutation; that's enough."** No. Verify's measured number is the contract. A claim without a verify artifact does not close the gate. Run the command; publish the number.
+- **"review-senior APPROVED, so I can skip verify."** No. APPROVE means the reviewer confirmed every criterion from the diff. HOLD means verify is required. Read the reviewer's verdict header, not the PR's merge button.
 
 ## Checklist before declaring `DONE`
 

--- a/tests/test-bin/test-doctrine-triangle-rules.sh
+++ b/tests/test-bin/test-doctrine-triangle-rules.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# test-doctrine-triangle-rules.sh — string-match tests for the three doctrine
+# rules introduced by sbd#129 (read-reviewer-body), sbd#130 (pane-monitor),
+# and sbd#131 (reviewer HOLD-vs-APPROVE).
+#
+# These tests pin the new doctrine in skills/review-senior/SKILL.md and
+# skills/verify/SKILL.md. If the key phrases drift out of the SKILL.md files,
+# the rules are silently unenforceable.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/../test-helpers.sh"
+
+REVIEW_SENIOR_MD="$(cd "$HERE/../.." && pwd)/skills/review-senior/SKILL.md"
+VERIFY_MD="$(cd "$HERE/../.." && pwd)/skills/verify/SKILL.md"
+
+# ---------------------------------------------------------------------------
+# sbd#131: review-senior Forbidden verdicts section
+
+test_review_senior_has_forbidden_verdicts_section() {
+  grep -qF "## Forbidden verdicts" "$REVIEW_SENIOR_MD"
+}
+
+test_review_senior_forbidden_approve_with_deferred_measurement() {
+  grep -qF "Returning APPROVE with a deferred measurement condition the reviewer cannot confirm" "$REVIEW_SENIOR_MD"
+}
+
+test_review_senior_has_hold_verdict() {
+  grep -qF "HOLD" "$REVIEW_SENIOR_MD"
+}
+
+test_review_senior_has_hold_vs_request_changes_subsection() {
+  grep -qF "### HOLD vs REQUEST-CHANGES" "$REVIEW_SENIOR_MD"
+}
+
+test_review_senior_completion_status_includes_hold() {
+  grep -qF "\`HOLD\` review posted with" "$REVIEW_SENIOR_MD"
+}
+
+# sbd#131: verify "Verify is the merge gate" section
+
+test_verify_has_merge_gate_section() {
+  grep -qF "## Verify is the merge gate" "$VERIFY_MD"
+}
+
+test_verify_merge_gate_names_hold_artifact() {
+  grep -qF "verify's published comment is the artifact that turns HOLD" "$VERIFY_MD"
+}
+
+test_verify_antipattern_author_claim_not_measurement() {
+  grep -qF "The author's PR body claims 85% mutation; that's enough" "$VERIFY_MD"
+}
+
+# ---------------------------------------------------------------------------
+
+echo "── doctrine-triangle-rules tests ──"
+
+run_test "review-senior has Forbidden verdicts section"          test_review_senior_has_forbidden_verdicts_section
+run_test "review-senior forbids APPROVE with deferred measure"   test_review_senior_forbidden_approve_with_deferred_measurement
+run_test "review-senior SKILL.md contains HOLD verdict"         test_review_senior_has_hold_verdict
+run_test "review-senior has HOLD-vs-REQUEST-CHANGES subsection" test_review_senior_has_hold_vs_request_changes_subsection
+run_test "review-senior completion status includes HOLD row"     test_review_senior_completion_status_includes_hold
+run_test "verify has 'Verify is the merge gate' section"        test_verify_has_merge_gate_section
+run_test "verify merge gate names HOLD artifact"                test_verify_merge_gate_names_hold_artifact
+run_test "verify anti-pattern: author claim not measurement"    test_verify_antipattern_author_claim_not_measurement
+
+report

--- a/tests/test-bin/test-orchestrate-auto-dispatch.sh
+++ b/tests/test-bin/test-orchestrate-auto-dispatch.sh
@@ -254,6 +254,33 @@ test_epic_body_template_includes_linear_project_line() {
     }
 }
 
+# sbd#129: Step 5c.0 read-reviewer-body gate must be present.
+test_skill_md_has_step_5c0_read_reviewer_body() {
+  grep -qF "Step 5c.0 — Read reviewer body before merging" "$SKILL_MD"
+}
+
+test_skill_md_step5c0_has_gh_pr_view_command() {
+  grep -qF 'gh pr view <N> --repo <R> --json reviews --jq' "$SKILL_MD"
+}
+
+# sbd#130: Phase 5e pane stall check must be present.
+test_skill_md_has_pane_stall_check() {
+  grep -qF "Waiting for team lead approval" "$SKILL_MD"
+}
+
+test_skill_md_has_phase_5e_protocol() {
+  grep -qF "Phase 5e — permission_request response protocol" "$SKILL_MD"
+}
+
+# sbd#129+130: forbidden list entries must be present.
+test_skill_md_forbidden_read_reviewer_body() {
+  grep -qF "without reading the reviewer body on GitHub via the Step 5c.0 procedure" "$SKILL_MD"
+}
+
+test_skill_md_forbidden_permission_request_stall() {
+  grep -qF "Letting a teammate \`permission_request\` sit unanswered past one sweep tick" "$SKILL_MD"
+}
+
 # ---------------------------------------------------------------------------
 
 echo "── orchestrate-auto-dispatch unit tests ──"
@@ -276,5 +303,11 @@ run_test "SKILL.md pins per_tick_cap=3"                         test_skill_md_pi
 run_test "SKILL.md pins pane_ceiling=20"                        test_skill_md_pins_pane_ceiling_to_twenty
 run_test "SKILL.md has one template per dispatchable modality"  test_skill_md_has_all_seven_templates
 run_test "epic body template includes Linear project line"      test_epic_body_template_includes_linear_project_line
+run_test "SKILL.md has Step 5c.0 read-reviewer-body gate"      test_skill_md_has_step_5c0_read_reviewer_body
+run_test "SKILL.md Step 5c.0 has gh pr view command"           test_skill_md_step5c0_has_gh_pr_view_command
+run_test "SKILL.md has pane stall check string"                test_skill_md_has_pane_stall_check
+run_test "SKILL.md has Phase 5e protocol subsection"           test_skill_md_has_phase_5e_protocol
+run_test "SKILL.md forbidden: read reviewer body"              test_skill_md_forbidden_read_reviewer_body
+run_test "SKILL.md forbidden: permission_request stall"        test_skill_md_forbidden_permission_request_stall
 
 report


### PR DESCRIPTION
Closes #135
Spec comments: sbd#129, sbd#130, sbd#131

## What changed

Applied three coordinated doctrine edits verbatim from spec-comment drop-in snippets. `skills/orchestrate/SKILL.md` gains Step 5c.0 (read reviewer body before merging), Step 1a (pane stall check in the auto-monitor loop), and Phase 5e (permission_request response protocol). `skills/review-senior/SKILL.md` gains a HOLD verdict distinct from APPROVE and REQUEST-CHANGES, a Forbidden verdicts section, a verdict decision table, a HOLD-vs-REQUEST-CHANGES subsection, and updated Phase 7 label transitions and completion status. `skills/verify/SKILL.md` gains a "Verify is the merge gate" section documenting that verify's published comment is the merge-gate artifact that closes a HOLD. All three Forbidden list entries and Anti-pattern entries from the specs are applied. Tests: 14 new string-match assertions pinning the new rules.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Insert Step 5c.0 in orchestrate | sbd#129 spec comment Insertion 1 |
| Append Forbidden entry (read reviewer body) | sbd#129 spec comment Insertion 2 |
| Append Anti-pattern (teammate said APPROVE) | sbd#129 spec comment Insertion 3 |
| Add Step 5d item 5 cross-ref to Step 5c.0 | sbd#129 spec comment Insertion 4 |
| Insert Step 1a (pane stall check) in Step 5d | sbd#130 spec comment A.1 |
| Add Phase 5e (permission_request protocol) | sbd#130 spec comment A.2 |
| Append Forbidden entry (permission_request stall) | sbd#130 spec comment A.3 |
| Append Anti-pattern (quiet pane = progressing) | sbd#130 spec comment A.4 |
| Insert Forbidden verdicts subsection | sbd#131 spec comment Snippet 1 |
| Replace Phase 6 verdict list (4 options) | sbd#131 spec comment Snippet 2 |
| Insert verdict decision table in Phase 6 | sbd#131 spec comment Snippet 3 |
| Insert HOLD-vs-REQUEST-CHANGES subsection | sbd#131 spec comment Snippet 4 |
| Replace Phase 7 label transitions (HOLD branch) | sbd#131 spec comment Snippet 5 |
| Append Anti-patterns (APPROVE with verify next, etc.) | sbd#131 spec comment Snippet 6 |
| Insert HOLD row in Completion status | sbd#131 spec comment Snippet 7 |
| Insert "Verify is the merge gate" subsection | sbd#131 spec comment Snippet 8 |
| Append Anti-patterns to verify (author claim, APPROVED) | sbd#131 spec comment Snippet 9 |
| 6 new tests pinning orchestrate rules | sbd#129 + sbd#130 |
| 8 new tests pinning review-senior + verify rules | sbd#131 |

## Scope

- Modules touched: skills/orchestrate, skills/review-senior, skills/verify, tests/test-bin
- Tier (from safer-diff-scope): safer-diff-scope binary not available in this environment; assessed manually as senior — 3 named SKILL.md files + 2 test files, no new modules, no new public surface, no new deps
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0

## Tests

- 6 new `grep -qF` assertions in `tests/test-bin/test-orchestrate-auto-dispatch.sh` pinning sbd#129 + sbd#130 rules
- 8 new `grep -qF` assertions in new `tests/test-bin/test-doctrine-triangle-rules.sh` pinning sbd#131 rules
- Total: 192 tests pass (was 178)

## Simplify

- Agent 1 (reuse): flagged `assert_contains` over bare `grep -qF` for new tests. Skipped: all existing SKILL.md pin tests in the same file use `grep -qF` directly; `assert_contains` requires `$(cat file)` which prints the full 1100-line SKILL.md on failure.
- Agent 2 (quality): rate-limited, no findings.
- Agent 3 (efficiency): diffed wrong repo; no findings applicable.

## Confidence

HIGH — every change is a verbatim drop-in from a spec-comment snippet. No redesign. Three SKILL.md files + 2 test files, all named in sub-issue #135 acceptance criteria.

---

/safer:review-senior is mandatory before this PR merges.