### PR TITLE
[impl-junior] README: apply docs-reader audit fixes (sbd#139)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,67 @@
 # safer-by-default
 
-Your coding agent is miscalibrated.
+A Claude skill plugin that recalibrates your coding agent for type-safe, scope-disciplined work. Eight principles in two categories.
 
-It was trained on human-written code — decades of it — written under one constraint that does not apply to it: typing was expensive for humans. That is why its training corpus is saturated with `throw new Error("bad")`, `as Record<string, unknown>`, `try { ... } catch {}`, `Promise<T>` return types, `if`-else without a `never` default, and untyped `process.env.FOO!` reads. Those were the compromises humans made when keyboard time was scarce. For an agent, keyboard time is not scarce. The agent can produce code that *eliminates classes of error by construction* — the way a compiler eliminates register-allocation bugs — if it is calibrated to do so.
+## The Problem
+
+Your coding agent is miscalibrated. It was trained on human-written code — decades of it — written under one constraint that does not apply to it: typing was expensive for humans. That is why its training corpus is saturated with `throw new Error("bad")`, `as Record<string, unknown>`, `try { ... } catch {}`, `Promise<T>` return types, `if`-else without a `never` default, and untyped `process.env.FOO!` reads. Those were the compromises humans made when keyboard time was scarce. For an agent, keyboard time is not scarce. The agent can produce code that *eliminates classes of error by construction* — the way a compiler eliminates register-allocation bugs — if it is calibrated to do so.
 
 It is not. This plugin recalibrates.
 
-## Two axes
+## Eight Principles: Two Axes
 
-**Part 1 — Use your powers (craft).** Four principles for eliminating classes of error at the type level: types beat tests, validate at every boundary, typed errors not raw throws, exhaustiveness over optionality.
+**Part 1 — Use your powers (craft).** Four principles for eliminating classes of error at the type level:
+- **Types beat tests:** Use branded types or discriminated unions to make invalid states unrepresentable. Every constraint that can live in the type system should.
+- **Validate at every boundary:** Inside a module, trust your types. At boundaries (disk, env, network, another package), decode with a schema.
+- **Typed errors not raw throws:** Every error is a tagged union or discriminated result. No `throw new Error("bad")`, no bare `catch {}`.
+- **Exhaustiveness over optionality:** Every switch ends in `default: return absurd(x)`. Every `Option`/`Either`/`Result.match` handles both branches explicitly.
 
-**Part 2 — Stay in your lane (scope).** Four principles for scope discipline: the junior-dev rule, the budget gate, literal stop rules, the ratchet (escalate up, never around).
+**Part 2 — Stay in your lane (scope).** Four principles for scope discipline:
+- **Junior-dev rule:** You fill one module. Cross-module reach is a boundary; reach is escalation.
+- **Budget gate:** Shape is the rule, not volume. A 500-line module is fine; one line across two modules is not.
+- **Literal stop rules:** When a 2nd module is touched, the rule has fired. Do not rationalize. Escalate.
+- **The ratchet:** Escalate up (to senior, architect, staff), never sideways. No quick fixes in sibling modules.
 
 Read [PRINCIPLES.md](./PRINCIPLES.md) for the full doctrine. Read any skill's `SKILL.md` to see one projection of the principles onto one kind of work.
 
 ## Install
 
-```
+**Pre-check:** If `~/.claude/skills/safer-by-default` already exists (from a prior install), remove it or choose a different path.
+
+**Step 1: Clone the plugin**
+
+```bash
 git clone --single-branch --depth 1 https://github.com/chughtapan/safer-by-default.git ~/.claude/skills/safer-by-default
 cd ~/.claude/skills/safer-by-default
+```
+
+⚠️ **Integrity note:** This clone is fetched over HTTPS with no checksum verification. If you require git signature verification, pin to a release tag instead: add `--branch v<version>` to the clone command. See [Releases](https://github.com/chughtapan/safer-by-default/releases).
+
+**Step 2: Install dependencies**
+
+```bash
 ./setup
+```
+
+`./setup` installs the `eslint-plugin-agent-code-guard` npm package into `.claude/plugins/`, configures `.claude/settings.json` with the lint rules, and probes for required CLIs (`gh`, `git`, `bash`, `bun`). It is idempotent and produces no output unless an error occurs.
+
+**Step 3: Configure GitHub labels** (one time per repo)
+
+```bash
 ./bin/safer-setup-labels
 ```
 
-Requirements: `gh` (authenticated), `git`, `bash`, `bun` (for the template generator). Optional: [`zapbot`](https://github.com/chughtapan/zapbot) for richer publish paths (falls back to `gh` cleanly if absent).
+`./bin/safer-setup-labels` creates the GitHub issue labels used by safer-by-default skills (`safer:spec`, `safer:planning`, `safer:implementing`, etc.). Requires `gh` authenticated with `repo` scope and write access to the repository. It is idempotent; running it twice on the same repo is safe.
+
+**Requirements:** `gh` (authenticated with `repo` scope), `git`, `bash`, `bun` (for the template generator).
+
+**Optional:** [`zapbot`](https://github.com/chughtapan/zapbot) for richer publish paths (falls back to `gh` cleanly if absent).
 
 ## Skill catalog
 
-Thirteen skills, grouped by modality.
+Thirteen skills, grouped by **modality** (the type of work: design, execution, gating, or bootstrap).
+
+Each skill is invoked as a **Claude slash-command** within a Claude Code session. Example: type `/safer:spec` in Claude Code, and the skill runs in your session. Each skill's detailed signature — required arguments, flags, input shapes, and full workflow — is documented in the skill's `SKILL.md` file in this repository.
 
 ### Design / exploration
 
@@ -76,6 +110,10 @@ user intent
     ├── /safer:review-senior → native PR review
     └── /safer:verify       → ship/hold verdict on PR
 ```
+
+**Parent epic + sub-issues:** The orchestrate skill breaks one user intent into a GitHub issue (parent epic) and creates child sub-issues for each work unit (spec, architecture, implementation, review). Each sub-issue tracks one modality of work.
+
+**Scope discipline:** The principles enforce that each skill works in isolation — one module, one design phase, one code review — without reaching sideways into sibling work. The `/safer:implement-junior` skill, for example, fills one module's internals and does not touch a second file. If a second file is needed, the work is escalated to a senior skill that has permission to cross module boundaries.
 
 Every skill publishes its artifact to GitHub before considering itself done. Status lives in issue labels, not local files. `safer-vp` renders the project dashboard from events + `gh` outcomes.
 


### PR DESCRIPTION
Closes #139

## What changed
Applied all 9 BLOCK items from docs-reader audit to README.md:
- Established plugin purpose upfront (was deferred to line 7)
- Stated all 8 principles inline with definitions (was pointing to PRINCIPLES.md)
- Documented ./setup script: purpose, output, success criterion
- Documented ./bin/safer-setup-labels: purpose, GitHub scopes, idempotency
- Added pre-check warning for git clone target-path
- Added integrity verification note with guidance on pinning to release tags
- Clarified that skills are invoked as Claude slash-commands (not shell, not Slack, not Actions)
- Noted that skill signatures are documented in each skill's SKILL.md
- Defined undefined terms: 'modality', 'scope discipline', 'parent epic + sub-issues'

## Scope
- Module: README.md only
- Tier (from safer-diff-scope): junior
- New exported signatures: none
- New deps: none

## Tests
- N/A (documentation only)

## Confidence
HIGH — all 9 BLOCK items directly addressed; no new content beyond the audit's scope.