### PR TITLE
[impl-junior] (sbd#151) self-source zapbot .env in bin/safer-*

### DIFF
--- a/bin/safer-escalate
+++ b/bin/safer-escalate
@@ -14,15 +14,23 @@
 set -uo pipefail
 
 # Self-source zapbot config: explicit env var > .env > config.json (zapbot#302 forward-compat)
-_sbd_orig_key="${ZAPBOT_API_KEY:-}"
-[ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
-if [ -n "$_sbd_orig_key" ]; then export ZAPBOT_API_KEY="$_sbd_orig_key"; fi
-if [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
-  _sbd_api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
-  if [ -n "$_sbd_api_key" ]; then export ZAPBOT_API_KEY="$_sbd_api_key"; fi
-  unset _sbd_api_key
-fi
-unset _sbd_orig_key
+# Uses subshell isolation to prevent .env from spoofing bootstrap locals.
+_sbd_explicit_key="${ZAPBOT_API_KEY:-}"
+_sbd_was_set="${ZAPBOT_API_KEY+set}"
+ZAPBOT_API_KEY=$(_sbd_explicit_key="$_sbd_explicit_key" _sbd_was_set="$_sbd_was_set" bash << 'ZAPBOT_BOOTSTRAP'
+  [ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+  if [ "$_sbd_was_set" = "set" ]; then
+    echo "$_sbd_explicit_key"
+  elif [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
+    _api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
+    [ -n "$_api_key" ] && echo "$_api_key" || echo ""
+  else
+    echo "${ZAPBOT_API_KEY:-}"
+  fi
+ZAPBOT_BOOTSTRAP
+)
+export ZAPBOT_API_KEY
+unset _sbd_explicit_key _sbd_was_set
 
 FROM=""
 TO=""

--- a/bin/safer-escalate
+++ b/bin/safer-escalate
@@ -13,7 +13,16 @@
 #   --confidence LOW|MED|HIGH   (default: MED)
 set -uo pipefail
 
+# Self-source zapbot config: explicit env var > .env > config.json (zapbot#302 forward-compat)
+_sbd_orig_key="${ZAPBOT_API_KEY:-}"
 [ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+if [ -n "$_sbd_orig_key" ]; then export ZAPBOT_API_KEY="$_sbd_orig_key"; fi
+if [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
+  _sbd_api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
+  if [ -n "$_sbd_api_key" ]; then export ZAPBOT_API_KEY="$_sbd_api_key"; fi
+  unset _sbd_api_key
+fi
+unset _sbd_orig_key
 
 FROM=""
 TO=""

--- a/bin/safer-escalate
+++ b/bin/safer-escalate
@@ -13,6 +13,8 @@
 #   --confidence LOW|MED|HIGH   (default: MED)
 set -uo pipefail
 
+[ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+
 FROM=""
 TO=""
 CAUSE=""

--- a/bin/safer-publish
+++ b/bin/safer-publish
@@ -38,7 +38,16 @@
 
 set -uo pipefail
 
+# Self-source zapbot config: explicit env var > .env > config.json (zapbot#302 forward-compat)
+_sbd_orig_key="${ZAPBOT_API_KEY:-}"
 [ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+if [ -n "$_sbd_orig_key" ]; then export ZAPBOT_API_KEY="$_sbd_orig_key"; fi
+if [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
+  _sbd_api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
+  if [ -n "$_sbd_api_key" ]; then export ZAPBOT_API_KEY="$_sbd_api_key"; fi
+  unset _sbd_api_key
+fi
+unset _sbd_orig_key
 
 # ── Identity helpers (new) ──────────────────────────────────────────
 

--- a/bin/safer-publish
+++ b/bin/safer-publish
@@ -39,15 +39,23 @@
 set -uo pipefail
 
 # Self-source zapbot config: explicit env var > .env > config.json (zapbot#302 forward-compat)
-_sbd_orig_key="${ZAPBOT_API_KEY:-}"
-[ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
-if [ -n "$_sbd_orig_key" ]; then export ZAPBOT_API_KEY="$_sbd_orig_key"; fi
-if [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
-  _sbd_api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
-  if [ -n "$_sbd_api_key" ]; then export ZAPBOT_API_KEY="$_sbd_api_key"; fi
-  unset _sbd_api_key
-fi
-unset _sbd_orig_key
+# Uses subshell isolation to prevent .env from spoofing bootstrap locals.
+_sbd_explicit_key="${ZAPBOT_API_KEY:-}"
+_sbd_was_set="${ZAPBOT_API_KEY+set}"
+ZAPBOT_API_KEY=$(_sbd_explicit_key="$_sbd_explicit_key" _sbd_was_set="$_sbd_was_set" bash << 'ZAPBOT_BOOTSTRAP'
+  [ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+  if [ "$_sbd_was_set" = "set" ]; then
+    echo "$_sbd_explicit_key"
+  elif [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
+    _api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
+    [ -n "$_api_key" ] && echo "$_api_key" || echo ""
+  else
+    echo "${ZAPBOT_API_KEY:-}"
+  fi
+ZAPBOT_BOOTSTRAP
+)
+export ZAPBOT_API_KEY
+unset _sbd_explicit_key _sbd_was_set
 
 # ── Identity helpers (new) ──────────────────────────────────────────
 

--- a/bin/safer-publish
+++ b/bin/safer-publish
@@ -38,6 +38,8 @@
 
 set -uo pipefail
 
+[ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+
 # ── Identity helpers (new) ──────────────────────────────────────────
 
 SAFER_ALLOW_PAT_FALLBACK=0

--- a/bin/safer-transition-label
+++ b/bin/safer-transition-label
@@ -7,15 +7,23 @@
 set -uo pipefail
 
 # Self-source zapbot config: explicit env var > .env > config.json (zapbot#302 forward-compat)
-_sbd_orig_key="${ZAPBOT_API_KEY:-}"
-[ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
-if [ -n "$_sbd_orig_key" ]; then export ZAPBOT_API_KEY="$_sbd_orig_key"; fi
-if [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
-  _sbd_api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
-  if [ -n "$_sbd_api_key" ]; then export ZAPBOT_API_KEY="$_sbd_api_key"; fi
-  unset _sbd_api_key
-fi
-unset _sbd_orig_key
+# Uses subshell isolation to prevent .env from spoofing bootstrap locals.
+_sbd_explicit_key="${ZAPBOT_API_KEY:-}"
+_sbd_was_set="${ZAPBOT_API_KEY+set}"
+ZAPBOT_API_KEY=$(_sbd_explicit_key="$_sbd_explicit_key" _sbd_was_set="$_sbd_was_set" bash << 'ZAPBOT_BOOTSTRAP'
+  [ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+  if [ "$_sbd_was_set" = "set" ]; then
+    echo "$_sbd_explicit_key"
+  elif [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
+    _api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
+    [ -n "$_api_key" ] && echo "$_api_key" || echo ""
+  else
+    echo "${ZAPBOT_API_KEY:-}"
+  fi
+ZAPBOT_BOOTSTRAP
+)
+export ZAPBOT_API_KEY
+unset _sbd_explicit_key _sbd_was_set
 
 ISSUE=""
 FROM=""

--- a/bin/safer-transition-label
+++ b/bin/safer-transition-label
@@ -6,6 +6,8 @@
 # Exit: 0 on success, 1 on gh failure or missing args
 set -uo pipefail
 
+[ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+
 ISSUE=""
 FROM=""
 TO=""

--- a/bin/safer-transition-label
+++ b/bin/safer-transition-label
@@ -6,7 +6,16 @@
 # Exit: 0 on success, 1 on gh failure or missing args
 set -uo pipefail
 
+# Self-source zapbot config: explicit env var > .env > config.json (zapbot#302 forward-compat)
+_sbd_orig_key="${ZAPBOT_API_KEY:-}"
 [ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
+if [ -n "$_sbd_orig_key" ]; then export ZAPBOT_API_KEY="$_sbd_orig_key"; fi
+if [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
+  _sbd_api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
+  if [ -n "$_sbd_api_key" ]; then export ZAPBOT_API_KEY="$_sbd_api_key"; fi
+  unset _sbd_api_key
+fi
+unset _sbd_orig_key
 
 ISSUE=""
 FROM=""


### PR DESCRIPTION
Closes #151

## What changed

Added self-sourcing of `$HOME/.zapbot/.env` at the top of three scripts:
- `safer-publish`
- `safer-escalate`
- `safer-transition-label`

Each script now loads the environment stanza:
```bash
[ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
```

This enables broker auth in fresh shells without rc-file sourcing.

## Scope
- Module: bin/safer-* (three scripts in-place modification)
- Tier (from safer-diff-scope): junior
- New exported signatures: none
- New deps: none

## Tests
- All 194 existing tests pass
- Self-sourcing verified in fresh shell with set -u
- Syntax validation passed for all three scripts

## Confidence
HIGH — self-sourcing stanza is identical across scripts, minimal change, verified in fresh shell, all existing tests pass