### PR TITLE
[impl-junior] (sbd#154) simplify zapbot env resolution: kill .env path

### DIFF
--- a/bin/_safer-zapbot-env.sh
+++ b/bin/_safer-zapbot-env.sh
@@ -1,24 +1,23 @@
 #!/usr/bin/env bash
 # _safer-zapbot-env.sh — source this to resolve zapbot config.
 #
-# Self-source zapbot config: explicit env var > .env > config.json (zapbot#302 forward-compat)
-# Uses subshell isolation to prevent .env from spoofing bootstrap locals.
-# Sets ZAPBOT_API_KEY in the calling environment.
-# Exit: always 0.
+# Read ZAPBOT_API_KEY from ~/.zapbot/config.json "apiKey" field.
+# Single source of truth: config.json. No explicit env override.
 
-_sbd_explicit_key="${ZAPBOT_API_KEY:-}"
-_sbd_was_set="${ZAPBOT_API_KEY+set}"
-ZAPBOT_API_KEY=$(_sbd_explicit_key="$_sbd_explicit_key" _sbd_was_set="$_sbd_was_set" bash << 'ZAPBOT_BOOTSTRAP'
-  [ -f "$HOME/.zapbot/.env" ] && { set -a; . "$HOME/.zapbot/.env"; set +a; }
-  if [ "$_sbd_was_set" = "set" ]; then
-    echo "$_sbd_explicit_key"
-  elif [ -z "${ZAPBOT_API_KEY:-}" ] && [ -f "$HOME/.zapbot/config.json" ]; then
-    _api_key=$(jq -r '.apiKey // empty' "$HOME/.zapbot/config.json" 2>/dev/null)
-    [ -n "$_api_key" ] && echo "$_api_key" || echo ""
-  else
-    echo "${ZAPBOT_API_KEY:-}"
-  fi
-ZAPBOT_BOOTSTRAP
-)
-export ZAPBOT_API_KEY
-unset _sbd_explicit_key _sbd_was_set
+if [ ! -f "$HOME/.zapbot/config.json" ]; then
+  echo "safer-zapbot-env: $HOME/.zapbot/config.json not found" >&2
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "safer-zapbot-env: jq required to read $HOME/.zapbot/config.json" >&2
+  exit 1
+fi
+_key=$(jq -er '
+  if (.apiKey | type) == "string" and (.apiKey | length) > 0
+  then .apiKey else empty end
+' "$HOME/.zapbot/config.json") || {
+  echo "safer-zapbot-env: apiKey missing or not a non-empty string in $HOME/.zapbot/config.json" >&2
+  exit 1
+}
+export ZAPBOT_API_KEY="$_key"
+unset _key

--- a/tests/test-bin/test-zapbot-env-helper.sh
+++ b/tests/test-bin/test-zapbot-env-helper.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Tests for _safer-zapbot-env.sh helper sourcing in the three broker scripts.
-# Verifies that safer-publish, safer-escalate, and safer-transition-label
-# correctly source the helper and resolve ZAPBOT_API_KEY.
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck disable=SC1091
@@ -9,9 +6,6 @@ source "$HERE/../test-helpers.sh"
 
 PLUGIN_DIR="$(cd "$HERE/../.." && pwd)"
 HELPER="$PLUGIN_DIR/bin/_safer-zapbot-env.sh"
-BIN_PUBLISH="$PLUGIN_DIR/bin/safer-publish"
-BIN_ESCALATE="$PLUGIN_DIR/bin/safer-escalate"
-BIN_TRANSITION="$PLUGIN_DIR/bin/safer-transition-label"
 
 # ── Sandbox setup ───────────────────────────────────────────────────
 
@@ -19,116 +13,123 @@ SANDBOX=$(mktemp -d)
 trap 'rm -rf "$SANDBOX"' EXIT
 
 export HOME="$SANDBOX/home"
-mkdir -p "$HOME"
+mkdir -p "$HOME/.zapbot"
 
 _reset_sandbox() {
-  rm -rf "$HOME/.zapbot" "$SANDBOX/config.json"
-  mkdir -p "$HOME"
-  unset ZAPBOT_API_KEY
+  rm -rf "$HOME/.zapbot"
+  mkdir -p "$HOME/.zapbot"
+  unset ZAPBOT_API_KEY 2>/dev/null || true
 }
 
-# ── Helper sourcing tests ───────────────────────────────────────────
+# ── Tests ───────────────────────────────────────────────────────────
 
 test_helper_file_exists() {
   assert_file_exists "$HELPER" "helper file exists"
 }
 
-test_safer_publish_sources_helper() {
+# C1: config.json apiKey string → exported
+test_config_json_string_exported() {
   _reset_sandbox
-  # Set up zapbot config with explicit env var
-  export ZAPBOT_API_KEY="test-key-publish"
-
-  # Source the helper directly (simulating what safer-publish does)
-  local result
-  result=$(bash -c "export ZAPBOT_API_KEY='test-key-publish'; . '$HELPER'; echo \"\$ZAPBOT_API_KEY\"")
-  echo "$result" | grep -q "test-key-publish"
-  assert_zero $? "safer-publish helper should resolve ZAPBOT_API_KEY from env var"
-}
-
-test_safer_escalate_sources_helper() {
-  _reset_sandbox
-  # Set up zapbot config with explicit env var
-  export ZAPBOT_API_KEY="test-key-escalate"
-
-  # Source the helper directly (simulating what safer-escalate does)
-  local result
-  result=$(bash -c "export ZAPBOT_API_KEY='test-key-escalate'; . '$HELPER'; echo \"\$ZAPBOT_API_KEY\"")
-  echo "$result" | grep -q "test-key-escalate"
-  assert_zero $? "safer-escalate helper should resolve ZAPBOT_API_KEY from env var"
-}
-
-test_safer_transition_label_sources_helper() {
-  _reset_sandbox
-  # Set up zapbot config with explicit env var
-  export ZAPBOT_API_KEY="test-key-transition"
-
-  # Source the helper directly (simulating what safer-transition-label does)
-  local result
-  result=$(bash -c "export ZAPBOT_API_KEY='test-key-transition'; . '$HELPER'; echo \"\$ZAPBOT_API_KEY\"")
-  echo "$result" | grep -q "test-key-transition"
-  assert_zero $? "safer-transition-label helper should resolve ZAPBOT_API_KEY from env var"
-}
-
-test_helper_preserves_empty_but_set() {
-  _reset_sandbox
-  # Test the ${var+set} precedence preservation
-  result=$(bash -c "export ZAPBOT_API_KEY=''; . '$HELPER'; [ -z \"\$ZAPBOT_API_KEY\" ] && echo 'empty' || echo 'not-empty'")
-  echo "$result" | grep -q "empty"
-  assert_zero $? "helper should preserve empty-but-set ZAPBOT_API_KEY"
-}
-
-test_symlink_invocation_resolves_helper() {
-  _reset_sandbox
-  # Create symlink to safer-publish in temp PATH
-  local testpath="$SANDBOX/testbin"
-  mkdir -p "$testpath"
-  ln -s "$BIN_PUBLISH" "$testpath/safer-publish"
-
-  # Create a minimal .env file with ZAPBOT_API_KEY
-  mkdir -p "$HOME/.zapbot"
-  echo "ZAPBOT_API_KEY=symlink-test-key" > "$HOME/.zapbot/.env"
-
-  # Invoke via symlink. Without --kind it should fail with argument validation, not file-not-found
-  result=$(HOME="$HOME" PATH="$testpath:$PATH" "$testpath/safer-publish" 2>&1 || true)
-  # If helper fails to source, we'd get "No such file", but if it sources OK we get an arg validation error
-  if echo "$result" | grep -q "No such file\|cannot open"; then
-    return 1
-  fi
-  return 0
-}
-
-test_helper_resolves_env_only() {
-  _reset_sandbox
-  # Set ZAPBOT_API_KEY via .env file only (no config.json)
-  mkdir -p "$HOME/.zapbot"
-  echo "ZAPBOT_API_KEY=env-only-key" > "$HOME/.zapbot/.env"
-
+  echo '{"apiKey":"test-api-key"}' > "$HOME/.zapbot/config.json"
   local result
   result=$(bash -c "HOME='$HOME' . '$HELPER'; echo \"\$ZAPBOT_API_KEY\"")
-  echo "$result" | grep -q "env-only-key"
-  assert_zero $? "helper should resolve ZAPBOT_API_KEY from .env file when config.json absent"
+  echo "$result" | grep -q "test-api-key"
+  assert_zero $? "helper should export apiKey string from config.json"
 }
 
-test_helper_resolves_config_json_only() {
+# C2: config.json apiKey missing → loud exit with error
+test_config_json_missing_apikey_loud_fail() {
   _reset_sandbox
-  # Set ZAPBOT_API_KEY via config.json only (no .env file)
-  mkdir -p "$HOME/.zapbot"
-  echo '{"apiKey":"config-json-only-key"}' > "$HOME/.zapbot/config.json"
+  echo '{"other":"value"}' > "$HOME/.zapbot/config.json"
+  bash -c "HOME='$HOME' . '$HELPER'" 2>/dev/null
+  local rc=$?
+  assert_nonzero $rc "helper should exit nonzero when apiKey missing from config.json"
+}
 
+# C3: config.json apiKey non-string type → loud exit with error
+test_config_json_apikey_non_string_loud_fail() {
+  _reset_sandbox
+  echo '{"apiKey":42}' > "$HOME/.zapbot/config.json"
+  bash -c "HOME='$HOME' . '$HELPER'" 2>/dev/null
+  local rc=$?
+  assert_nonzero $rc "helper should exit nonzero when apiKey is not a string"
+}
+
+# C4: config.json apiKey empty string → loud exit with error
+test_config_json_apikey_empty_string_loud_fail() {
+  _reset_sandbox
+  echo '{"apiKey":""}' > "$HOME/.zapbot/config.json"
+  bash -c "HOME='$HOME' . '$HELPER'" 2>/dev/null
+  local rc=$?
+  assert_nonzero $rc "helper should exit nonzero when apiKey is an empty string"
+}
+
+# C5: jq missing + config.json present → loud exit with "jq required" error
+test_jq_missing_loud_fail() {
+  _reset_sandbox
+  echo '{"apiKey":"test-key"}' > "$HOME/.zapbot/config.json"
+  local tmpbin
+  tmpbin=$(mktemp -d)
+  HOME="$HOME" PATH="$tmpbin" /bin/bash << TESTEOF >/dev/null 2>&1
+. '$HELPER'
+TESTEOF
+  local rc=$?
+  rm -rf "$tmpbin"
+  assert_nonzero $rc "helper should exit nonzero when jq is missing"
+}
+
+# C6: config.json missing → loud exit with "not found" error
+test_config_json_missing_loud_fail() {
+  _reset_sandbox
+  rm -rf "$HOME/.zapbot/config.json"
+  bash -c "HOME='$HOME' . '$HELPER'" 2>/dev/null
+  local rc=$?
+  assert_nonzero $rc "helper should exit nonzero when config.json not found"
+}
+
+# C7: config.json malformed JSON → loud exit (jq exits nonzero)
+test_config_json_malformed_loud_fail() {
+  _reset_sandbox
+  echo '{invalid json}' > "$HOME/.zapbot/config.json"
+  bash -c "HOME='$HOME' . '$HELPER'" 2>/dev/null
+  local rc=$?
+  assert_nonzero $rc "helper should exit nonzero when config.json is malformed"
+}
+
+# NEW: pre-existing ZAPBOT_API_KEY gets OVERWRITTEN by config.json value
+test_explicit_env_overwritten_by_config_json() {
+  _reset_sandbox
+  echo '{"apiKey":"config-json-value"}' > "$HOME/.zapbot/config.json"
   local result
-  result=$(bash -c "HOME='$HOME' . '$HELPER'; echo \"\$ZAPBOT_API_KEY\"")
-  echo "$result" | grep -q "config-json-only-key"
-  assert_zero $? "helper should resolve ZAPBOT_API_KEY from config.json when .env absent"
+  result=$(HOME="$HOME" ZAPBOT_API_KEY='old-value' /bin/bash << TESTEOF
+. '$HELPER'
+echo "\$ZAPBOT_API_KEY"
+TESTEOF
+)
+  echo "$result" | grep -q "config-json-value"
+  assert_zero $? "helper should overwrite pre-existing ZAPBOT_API_KEY with config.json value"
+}
+
+# Verify error messages are loud (go to stderr)
+test_error_messages_to_stderr() {
+  _reset_sandbox
+  echo '{"other":"value"}' > "$HOME/.zapbot/config.json"
+  local result
+  result=$(bash -c "HOME='$HOME' . '$HELPER' 2>&1")
+  echo "$result" | grep -q "apiKey missing or not a non-empty string"
+  assert_zero $? "helper should output descriptive error message to stderr"
 }
 
 # ── Run tests ───────────────────────────────────────────────────────
 
 run_test "helper file exists" test_helper_file_exists
-run_test "safer-publish sources helper" test_safer_publish_sources_helper
-run_test "safer-escalate sources helper" test_safer_escalate_sources_helper
-run_test "safer-transition-label sources helper" test_safer_transition_label_sources_helper
-run_test "helper preserves empty-but-set variable" test_helper_preserves_empty_but_set
-run_test "symlink invocation resolves helper" test_symlink_invocation_resolves_helper
-run_test "helper resolves ZAPBOT_API_KEY from .env only" test_helper_resolves_env_only
-run_test "helper resolves ZAPBOT_API_KEY from config.json only" test_helper_resolves_config_json_only
+run_test "C1: config.json apiKey string exported" test_config_json_string_exported
+run_test "C2: config.json apiKey missing loud fail" test_config_json_missing_apikey_loud_fail
+run_test "C3: config.json apiKey non-string loud fail" test_config_json_apikey_non_string_loud_fail
+run_test "C4: config.json apiKey empty string loud fail" test_config_json_apikey_empty_string_loud_fail
+run_test "C5: jq missing loud fail" test_jq_missing_loud_fail
+run_test "C6: config.json missing loud fail" test_config_json_missing_loud_fail
+run_test "C7: config.json malformed loud fail" test_config_json_malformed_loud_fail
+run_test "explicit env overwritten by config.json" test_explicit_env_overwritten_by_config_json
+run_test "error messages to stderr" test_error_messages_to_stderr
 report


### PR DESCRIPTION
Closes #154

## What changed

Rewrote `bin/_safer-zapbot-env.sh` to eliminate all `.env` sourcing. Helper now reads from config.json only (single source of truth), removing entire classes of bugs that accumulated around multi-path resolution: forgery vector (#159), malformed-input handling (#156), set-a scope leakage (#155).

Behavior change: pre-existing `ZAPBOT_API_KEY` env var now gets overwritten by config.json value on source (was: explicit env would win). This is the intended forward behavior per operator direction.

## Scope
- Module: `bin/_safer-zapbot-env.sh` + tests
- Tier (from commit message): junior
- New exported signatures: none
- New deps: none

## Tests
- C1: config.json apiKey string → exported
- C2: config.json apiKey missing → loud exit
- C3: config.json apiKey non-string type → loud exit
- C4: config.json apiKey empty string → loud exit
- C5: jq missing + config.json present → loud exit with "jq required"
- C6: config.json missing → loud exit with "not found"
- C7: config.json malformed JSON → loud exit
- NEW: pre-existing env var gets overwritten by config.json value
- All tests use temp-HOME pattern; no .env references

## Acceptance
✓ No `.env` references (grep-verifiable)
✓ Tests cover C1-C7 per issue
✓ All error cases fail loudly with descriptive messages
✓ Caller scripts (safer-publish, safer-escalate, safer-transition-label) unchanged

## Confidence
HIGH — Implementation matches operator specification exactly. All acceptance criteria met. Tests passing locally. Zero scope concerns.