### PR TITLE
[impl-junior] (sbd#224) orchestrate Step 5d Path (b): respect waiting-on-user state

### DIFF
--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -589,6 +589,7 @@ Record the returned job id on the parent epic (comment) so the next operator can
    Guardrails (the loop enforces these before touching anything):
    - Never delete `team-lead` from the roster. Never kill the team-lead pane.
    - Path (b) requires BOTH pane-alive AND sub-issue-terminal. Neither alone is enough.
+   - **Path (b) does NOT apply to teammates waiting on user input.** A teammate whose latest SendMessage to team-lead reported `NEEDS_CONTEXT` or `BLOCKED` AND who has not received a team-lead reply since that marker MUST NOT be killed, even if their sub-issue label is `safer:<modality>,review` and would otherwise look terminal. The "terminal" predicate excludes this case. Reasoning: interactive skills run hold-scope autonomous and escalate taste decisions or pending input up to the orchestrator; the orchestrator surfaces those to the user via `AskUserQuestion`. The teammate is alive and load-bearing while it waits for the reply; killing it loses the in-progress reasoning context. (Driven by the runtime contract in WS3 spec v2's Goal 7 / Invariant 4.)
    - Path (a) requires only pane-missing from `$ALIVE`. A teammate whose work is incomplete but whose process died is still removed — their pane is gone either way, and the work needs to be re-dispatched.
    - When uncertain whether a teammate is truly done, leave them. A held pane is cheaper than lost work.
 
@@ -749,6 +750,7 @@ Stop iterating the moment any of these fire: `budget` reaches 0, the Agent tool 
 
 - Kill the team-lead pane, or delete `team-lead` from the roster.
 - Kill or delete a teammate whose `isActive == true`, or whose sub-issue is not terminal. Both conditions must hold, or the loop leaves them.
+- Kill or delete a teammate whose latest team-lead message was `NEEDS_CONTEXT` or `BLOCKED` and is still awaiting a team-lead reply. Waiting-on-orchestrator state is alive state, not terminal state. The pane holds load-bearing in-progress reasoning context that gets lost on kill.
 - Merge a PR with failing tests, failing CI, or unresolved review comments.
 - Gate a sub-issue whose acceptance criteria require judgment the loop cannot encode (design review, spec approval, any criterion the modality's `review` step delegates to `/safer:review-senior`).
 - Write code, edit files, or run `/safer:<modality>` skills in-session. Dispatch via teammate only.


### PR DESCRIPTION
Closes #224.

## What changes

`skills/orchestrate/SKILL.md` Step 5d Path (b) auto-monitor cleanup is amended so it does NOT kill teammates whose latest team-lead message was `NEEDS_CONTEXT` or `BLOCKED` and who are still awaiting a team-lead reply — even if their sub-issue label is `safer:<modality>,review` and would otherwise look terminal.

Two surgical additions, both in `skills/orchestrate/SKILL.md`:

1. **Step 5d, Path (b) guardrails:** new bullet excluding waiting-on-user from the terminal-state predicate. Reasoning + cross-reference to WS3 v2's Goal 7 / Invariant 4.
2. **"What the loop MUST NEVER do":** new anti-pattern entry naming the same case from the negative direction.

## Plan-anchor

Sub-issue #224 acceptance verbatim:

> `skills/orchestrate/SKILL.md` Step 5d Path (b) auto-monitor cleanup is amended to respect a "waiting on user" teammate state. Specifically: a teammate whose pane is alive and whose assigned sub-issue label is `safer:<modality>,review` AND whose latest SendMessage to team-lead reported `NEEDS_CONTEXT` or `BLOCKED` MUST NOT be killed. The terminality predicate must add: NOT (last status marker ∈ {NEEDS_CONTEXT, BLOCKED} AND no team-lead reply since that marker). Plus: a corresponding anti-pattern entry under "What the loop MUST NEVER do" naming this case.

Mapping to the diff:
- Path (b) guardrails bullet (new) — encodes the "NOT (last status marker ∈ {NEEDS_CONTEXT, BLOCKED} AND no team-lead reply since that marker)" predicate in plain English.
- "What the loop MUST NEVER do" bullet (new) — same case from the anti-pattern angle.
- Diff scope: one file, two new bullets, +2 lines, no other changes.

## Why

Driven by the WS3 v2 runtime contract: interactive skills run hold-scope autonomous and escalate taste decisions / pending input up to the orchestrator. The orchestrator surfaces those to the user via `AskUserQuestion`. The teammate is alive (and load-bearing) while it waits for the reply. The auto-monitor should not reap it.

## Authorship note

Per user directive in the dispatching session, the team-lead orchestrator wrote this PR directly (not via a dispatched impl-junior teammate) because the diff is single-file <30 LOC — the dispatch overhead exceeds the work. `/safer:review-senior` still runs before merge.

## Test plan

- [ ] `/safer:review-senior` reads the diff and confirms the two new bullets correctly encode the acceptance predicate.
- [ ] No other files modified; `safer-diff-scope` reports `junior` tier.