### PR TITLE
[impl-senior] (sbd#210) WS4 v6: ACG rule mapping via build-time generation

### DIFF
--- a/bin/safer-acg-sync
+++ b/bin/safer-acg-sync
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# safer-acg-sync — regenerate the ACG rule table in skills/typescript/SKILL.md.
+#
+# Reads:
+#   skills/setup/SKILL.md — for the install line `eslint-plugin-agent-code-guard@<spec>`.
+#   The resolved ACG source — either local node_modules or GitHub at the matching tag.
+#   skills/typescript/acg-rationale.json — hand-curated rule rationale + principle anchors.
+#
+# Writes:
+#   skills/typescript/SKILL.md — between `<!-- BEGIN: acg-mapping -->` and
+#   `<!-- END: acg-mapping -->` markers, the rendered table.
+#
+# Fails (exit 1) if ACG ships a rule that the rationale-map doesn't cover.
+# Warns (stderr) if rationale-map entries exist with no matching ACG rule.
+#
+# Usage: ./bin/safer-acg-sync   (run from the safer-by-default repo root)
+#
+# Trigger: when skills/setup/SKILL.md's install line for eslint-plugin-agent-code-guard
+# changes. PRINCIPLES.md heading rename/renumber is a separate mechanical anchor-repair.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SETUP_SKILL="$REPO_ROOT/skills/setup/SKILL.md"
+TS_SKILL="$REPO_ROOT/skills/typescript/SKILL.md"
+RATIONALE="$REPO_ROOT/skills/typescript/acg-rationale.json"
+
+# ---- Step 1: find the install spec ----
+INSTALL_LINE=$(grep -E 'eslint-plugin-agent-code-guard@' "$SETUP_SKILL" | head -1 || true)
+if [ -z "$INSTALL_LINE" ]; then
+  echo "ERROR: no eslint-plugin-agent-code-guard@<spec> line found in $SETUP_SKILL" >&2
+  exit 2
+fi
+SPEC=$(echo "$INSTALL_LINE" | grep -oE 'eslint-plugin-agent-code-guard@[^ "'"'"']+' | sed 's/eslint-plugin-agent-code-guard@//' | head -1)
+# Resolve ^0.0.2 → 0.0.2 (lowest-bound resolution per WS4 v6 spec).
+TAG="v$(echo "$SPEC" | sed 's/^[\^~>=<]//;s/[<>=].*//')"
+
+echo "install-line spec: $SPEC"
+echo "resolved tag:      $TAG"
+
+# ---- Step 2: fetch the ACG source for that tag ----
+ACG_INDEX="$(mktemp)"
+trap 'rm -f "$ACG_INDEX"' EXIT
+
+if [ -f "$REPO_ROOT/node_modules/eslint-plugin-agent-code-guard/dist/index.js" ]; then
+  cp "$REPO_ROOT/node_modules/eslint-plugin-agent-code-guard/dist/index.js" "$ACG_INDEX"
+  echo "source:            local node_modules"
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: gh CLI required to fetch ACG source from GitHub" >&2
+    exit 2
+  fi
+  gh api "repos/chughtapan/agent-code-guard/contents/src/index.ts?ref=$TAG" \
+    --jq '.content' 2>/dev/null | base64 -d > "$ACG_INDEX" 2>/dev/null
+  if [ ! -s "$ACG_INDEX" ]; then
+    echo "ERROR: failed to fetch chughtapan/agent-code-guard@$TAG src/index.ts" >&2
+    exit 2
+  fi
+  echo "source:            chughtapan/agent-code-guard@$TAG (GitHub)"
+fi
+
+# ---- Step 3: enumerate rules + their preset assignments + severities ----
+# Rules in ACG's index appear as `"agent-code-guard/<rule>": "error"` or `"warn"` lines
+# inside a `configs.<preset>.rules: { ... }` block. State-machine awk extracts them
+# along with which preset block they're in.
+RULES_TMP="$(mktemp)"
+trap 'rm -f "$ACG_INDEX" "$RULES_TMP"' EXIT
+
+awk '
+  /recommended: *\{/ { preset = "recommended" }
+  /integrationTests: *\{/ { preset = "integrationTests" }
+  /rules: *\{/ { in_rules = 1; next }
+  in_rules && /^[[:space:]]*\},/ { in_rules = 0; next }
+  in_rules && match($0, /"agent-code-guard\/[a-z-]+":[[:space:]]*"(error|warn)"/) {
+    chunk = substr($0, RSTART, RLENGTH)
+    # extract rule name
+    n = index(chunk, "/")
+    rest = substr(chunk, n + 1)
+    e = index(rest, "\"")
+    rule = substr(rest, 1, e - 1)
+    # extract severity (last quoted token)
+    sev = (chunk ~ /"warn"/) ? "warn" : "error"
+    printf "%s\t%s\t%s\n", preset, rule, sev
+  }
+' "$ACG_INDEX" >> "$RULES_TMP"
+
+RULE_COUNT=$(wc -l < "$RULES_TMP" | tr -d ' ')
+echo "rule count:        $RULE_COUNT"
+
+if [ "$RULE_COUNT" -eq 0 ]; then
+  echo "ERROR: failed to parse any rules from ACG source" >&2
+  exit 2
+fi
+
+# ---- Step 4: load rationale-map + check coverage ----
+if [ ! -f "$RATIONALE" ]; then
+  echo "ERROR: $RATIONALE missing — create it with rule rationale entries" >&2
+  exit 2
+fi
+
+UNMAPPED=()
+while IFS=$'\t' read -r preset rule severity; do
+  if ! jq -e --arg r "$rule" '.[$r]' "$RATIONALE" >/dev/null 2>&1; then
+    UNMAPPED+=("$rule")
+  fi
+done < "$RULES_TMP"
+
+if [ "${#UNMAPPED[@]}" -gt 0 ]; then
+  echo "ERROR: rules in ACG@$TAG with no entry in $RATIONALE:" >&2
+  for r in "${UNMAPPED[@]}"; do echo "  - $r" >&2; done
+  echo "Add rationale entries for these rules and re-run." >&2
+  exit 1
+fi
+
+# Warn on orphan rationale entries (in map, not in ACG).
+ACG_RULES_SORTED=$(cut -f2 "$RULES_TMP" | sort -u)
+MAP_RULES_SORTED=$(jq -r 'keys[]' "$RATIONALE" | sort -u)
+ORPHANS=$(comm -23 <(echo "$MAP_RULES_SORTED") <(echo "$ACG_RULES_SORTED"))
+if [ -n "$ORPHANS" ]; then
+  echo "WARNING: rationale-map entries with no matching ACG@$TAG rule:" >&2
+  echo "$ORPHANS" | sed 's/^/  - /' >&2
+  echo "(kept in map for historical reference; consider removing if not needed)" >&2
+fi
+
+# ---- Step 5: render the table ----
+TABLE="$(mktemp)"
+trap 'rm -f "$ACG_INDEX" "$RULES_TMP" "$TABLE"' EXIT
+
+cat > "$TABLE" <<EOF
+**Resolved version:** \`eslint-plugin-agent-code-guard@$SPEC\` (from \`skills/setup/SKILL.md\`) → ACG \`$TAG\` ships **$RULE_COUNT rules**.
+
+| Rule | Preset | Severity | Principle anchor(s) | Rationale | Before/After |
+|---|---|---|---|---|---|
+EOF
+
+while IFS=$'\t' read -r preset rule severity; do
+  anchors=$(jq -r --arg r "$rule" '.[$r].principle_anchors | map("**P" + . + "**") | join(", ")' "$RATIONALE")
+  rationale=$(jq -r --arg r "$rule" '.[$r].rationale' "$RATIONALE")
+  local_path="\`node_modules/eslint-plugin-agent-code-guard/docs/rules/$rule.md\`"
+  github_url="https://github.com/chughtapan/agent-code-guard/blob/$TAG/docs/rules/$rule.md"
+  echo "| \`$rule\` | \`$preset\` | $severity | $anchors | $rationale | $local_path / [doc]($github_url) |" >> "$TABLE"
+done < <(sort "$RULES_TMP")
+
+cat >> "$TABLE" <<EOF
+
+*Maintenance:* hand-maintained rationale-map in \`skills/typescript/acg-rationale.json\`. Updated by \`bin/safer-acg-sync\` when \`skills/setup/SKILL.md\`'s ACG install line changes. The local \`node_modules/...\` path is canonical; the GitHub URL is convenience-only.
+EOF
+
+# ---- Step 6: splice into skills/typescript/SKILL.md between markers ----
+if ! grep -q '<!-- BEGIN: acg-mapping -->' "$TS_SKILL"; then
+  echo "ERROR: $TS_SKILL missing <!-- BEGIN: acg-mapping --> marker" >&2
+  exit 2
+fi
+
+awk -v table_file="$TABLE" '
+  /<!-- BEGIN: acg-mapping -->/ {
+    print
+    while ((getline line < table_file) > 0) print line
+    close(table_file)
+    skip = 1
+    next
+  }
+  /<!-- END: acg-mapping -->/ {
+    skip = 0
+    print
+    next
+  }
+  !skip { print }
+' "$TS_SKILL" > "$TS_SKILL.tmp" && mv "$TS_SKILL.tmp" "$TS_SKILL"
+
+echo "wrote table:       $TS_SKILL between markers"
+echo "done."

--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -151,15 +151,29 @@ Then defer to user sovereignty if they insist. Name exactly what is being skippe
 
 The plugin is the lint floor. If code trips any of its rules, the code is below the floor. Fix the code; do not suppress the rule without a written reason.
 
-Each rule maps back to a principle:
+The rule table below is generated from ACG's source by `bin/safer-acg-sync`, joined against a hand-curated rationale-map at `skills/typescript/acg-rationale.json`. Updated when `skills/setup/SKILL.md`'s install line changes; PRINCIPLES.md heading rename/renumber is a separate mechanical anchor-repair (no rule rows, rationales, presets, or severities change).
 
-- **`async-keyword`, `promise-type`, `then-chain`** follow from **principle 3** (typed errors). `Promise<T>` erases the error channel; `async`/`await` is the sugar that hides it.
-- **`bare-catch`** follows from **principle 3 and principle 4** (typed errors + exhaustiveness). A silent catch hides both the error and the branch.
-- **`record-cast`** follows from **principle 2** (validate at boundaries). The cast papers over a missing schema at the edge.
-- **`no-manual-enum-cast`** follows from **principle 1 and principle 2** (types beat tests + validation). Hand-written unions drift; generated or schema-derived ones do not.
-- **`no-raw-sql`** follows from **principle 1 and principle 2** (types beat tests + boundary validation). Raw SQL defeats the compiler; a typed builder makes the schema load-bearing.
-- **`no-vitest-mocks`** follows from integration-test integrity (not one of the four, but implied by principle 2: the mock is a fiction at the boundary).
-- **`no-hardcoded-secrets`** follows from **principle 2** (validate at the environment boundary). A hardcoded secret bypasses the schema entirely.
+<!-- BEGIN: acg-mapping -->
+**Resolved version:** `eslint-plugin-agent-code-guard@^0.0.2` (from `skills/setup/SKILL.md`) → ACG `v0.0.2` ships **13 rules**.
+
+| Rule | Preset | Severity | Principle anchor(s) | Rationale | Before/After |
+|---|---|---|---|---|---|
+| `no-vitest-mocks` | `integrationTests` | error | **P2** | An integration test that mocks the boundary asserts your code works against your mock, not the real thing. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-vitest-mocks.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-vitest-mocks.md) |
+| `async-keyword` | `recommended` | error | **P3** | `async`/`await` is the sugar that hides the erased error channel of `Promise<T>`. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/async-keyword.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/async-keyword.md) |
+| `bare-catch` | `recommended` | error | **P3**, **P4** | A silent catch hides both the error AND the branch; exhaustiveness cannot apply. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/bare-catch.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/bare-catch.md) |
+| `no-coverage-threshold-gate` | `recommended` | warn | **P1** | Coverage % is a diagnostic, never a CI gate (Inozemtseva & Holmes ICSE 2014). Acts on the wrong signal. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-coverage-threshold-gate.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-coverage-threshold-gate.md) |
+| `no-hardcoded-assertion-literals` | `recommended` | warn | **P1** | Assertions hardcoding a literal (e.g., `expect(...).toBe(42)` where 42 is the implementation's output) compress the same information as a property; the property has higher coverage. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-hardcoded-assertion-literals.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-hardcoded-assertion-literals.md) |
+| `no-hardcoded-secrets` | `recommended` | error | **P2** | A hardcoded secret bypasses the env-boundary schema; secrets must be decoded at boot, not embedded in source. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-hardcoded-secrets.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-hardcoded-secrets.md) |
+| `no-manual-enum-cast` | `recommended` | error | **P1**, **P2** | Hand-written unions drift from their source; generated or schema-derived enums do not. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-manual-enum-cast.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-manual-enum-cast.md) |
+| `no-raw-sql` | `recommended` | error | **P1**, **P2** | Raw SQL defeats the compiler; a typed builder makes the schema load-bearing at compile time. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-raw-sql.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-raw-sql.md) |
+| `no-raw-throw-new-error` | `recommended` | error | **P3** | `throw new Error("bad")` has no type, no handling contract, no receipt for the caller; tagged errors do. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-raw-throw-new-error.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-raw-throw-new-error.md) |
+| `no-test-skip-only` | `recommended` | error | **P1** | Test-hygiene corollary of principle 1: a `.skip` or `.only` shipped to main is a test that does not test. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/no-test-skip-only.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/no-test-skip-only.md) |
+| `promise-type` | `recommended` | error | **P3** | `Promise<T>` erases the error channel; tagged-error or `Effect<T, E, R>` keep it visible. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/promise-type.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/promise-type.md) |
+| `record-cast` | `recommended` | error | **P2** | `as Record<string, unknown>` papers over a missing schema at the boundary; decode instead. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/record-cast.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/record-cast.md) |
+| `then-chain` | `recommended` | error | **P3** | `.then()` chains hide the error channel and reorder control flow; same erasure as `Promise<T>`. | `node_modules/eslint-plugin-agent-code-guard/docs/rules/then-chain.md` / [doc](https://github.com/chughtapan/agent-code-guard/blob/v0.0.2/docs/rules/then-chain.md) |
+
+*Maintenance:* hand-maintained rationale-map in `skills/typescript/acg-rationale.json`. Updated by `bin/safer-acg-sync` when `skills/setup/SKILL.md`'s ACG install line changes. The local `node_modules/...` path is canonical; the GitHub URL is convenience-only.
+<!-- END: acg-mapping -->
 
 Each rule ships a `Before` / `After` example at `node_modules/eslint-plugin-agent-code-guard/docs/rules/<rule-name>.md`. Read the relevant doc before attempting a fix.
 

--- a/skills/typescript/acg-rationale.json
+++ b/skills/typescript/acg-rationale.json
@@ -1,0 +1,54 @@
+{
+  "async-keyword": {
+    "principle_anchors": ["3"],
+    "rationale": "`async`/`await` is the sugar that hides the erased error channel of `Promise<T>`."
+  },
+  "promise-type": {
+    "principle_anchors": ["3"],
+    "rationale": "`Promise<T>` erases the error channel; tagged-error or `Effect<T, E, R>` keep it visible."
+  },
+  "then-chain": {
+    "principle_anchors": ["3"],
+    "rationale": "`.then()` chains hide the error channel and reorder control flow; same erasure as `Promise<T>`."
+  },
+  "bare-catch": {
+    "principle_anchors": ["3", "4"],
+    "rationale": "A silent catch hides both the error AND the branch; exhaustiveness cannot apply."
+  },
+  "record-cast": {
+    "principle_anchors": ["2"],
+    "rationale": "`as Record<string, unknown>` papers over a missing schema at the boundary; decode instead."
+  },
+  "no-raw-sql": {
+    "principle_anchors": ["1", "2"],
+    "rationale": "Raw SQL defeats the compiler; a typed builder makes the schema load-bearing at compile time."
+  },
+  "no-manual-enum-cast": {
+    "principle_anchors": ["1", "2"],
+    "rationale": "Hand-written unions drift from their source; generated or schema-derived enums do not."
+  },
+  "no-vitest-mocks": {
+    "principle_anchors": ["2"],
+    "rationale": "An integration test that mocks the boundary asserts your code works against your mock, not the real thing."
+  },
+  "no-hardcoded-secrets": {
+    "principle_anchors": ["2"],
+    "rationale": "A hardcoded secret bypasses the env-boundary schema; secrets must be decoded at boot, not embedded in source."
+  },
+  "no-raw-throw-new-error": {
+    "principle_anchors": ["3"],
+    "rationale": "`throw new Error(\"bad\")` has no type, no handling contract, no receipt for the caller; tagged errors do."
+  },
+  "no-test-skip-only": {
+    "principle_anchors": ["1"],
+    "rationale": "Test-hygiene corollary of principle 1: a `.skip` or `.only` shipped to main is a test that does not test."
+  },
+  "no-coverage-threshold-gate": {
+    "principle_anchors": ["1"],
+    "rationale": "Coverage % is a diagnostic, never a CI gate (Inozemtseva & Holmes ICSE 2014). Acts on the wrong signal."
+  },
+  "no-hardcoded-assertion-literals": {
+    "principle_anchors": ["1"],
+    "rationale": "Assertions hardcoding a literal (e.g., `expect(...).toBe(42)` where 42 is the implementation's output) compress the same information as a property; the property has higher coverage."
+  }
+}


### PR DESCRIPTION
Closes #210.

## What changes

Implements WS4 spec v6 ([build-time generation](https://github.com/chughtapan/safer-by-default/issues/223#issuecomment-4348111739)). Supersedes v1-v5 hand-maintained-table approach per user direction.

Three artifacts:

1. **`bin/safer-acg-sync`** — bash script (172 lines). Reads ACG source at the install-line tag (local `node_modules` if present, else GitHub at the matching version tag). Joins against the hand-curated rationale-map. Writes the rendered table into `skills/typescript/SKILL.md` between `<!-- BEGIN: acg-mapping -->` and `<!-- END: acg-mapping -->` markers.
   - Fails (exit 1) on rules in ACG with no rationale entry.
   - Warns on orphan rationale entries with no matching ACG rule.
   - Trigger: changes to `skills/setup/SKILL.md`'s `eslint-plugin-agent-code-guard@<spec>` install line.

2. **`skills/typescript/acg-rationale.json`** — 13-rule rationale-map for ACG v0.0.2 (the version `skills/setup/SKILL.md` installs as `^0.0.2`). Each entry: `principle_anchors` (numeric) + one-line `rationale`. Hand-curated.

3. **`skills/typescript/SKILL.md`** — replaces the old 7-rule prose mapping with BEGIN/END markers + the script's first-run output. 13 rules tabulated (12 `recommended` preset + 1 `integrationTests` preset, matching ACG v0.0.2 exports exactly).

## Plan-anchor table (v6 §5 acceptance)

| v6 §5 acceptance | Where it lives in the diff |
|---|---|
| Coverage parity (13 rules from ACG v0.0.2) | The script enforces it programmatically; the generated table covers all 13. |
| Table schema (rule, preset, severity, anchors, rationale, before/after) | Generated by the sync script in `bin/safer-acg-sync` step 5. |
| Hand-curated rationale-map keyed by rule name | `skills/typescript/acg-rationale.json` |
| Single-source trigger (install line in `skills/setup/SKILL.md`) | Hardcoded in the script's step 1; documented in maintenance-note line below the table. |
| Anchor-repair carve-out for PRINCIPLES.md heading rename | Documented in the prose above the BEGIN marker in `skills/typescript/SKILL.md`. |
| Local `node_modules/.../docs/rules/<rule>.md` path canonical | Each rule row lists the local path first; GitHub URL is convenience-only. |
| Diff scope: `bin/` + `skills/typescript/` only | Confirmed; no other files modified. |
| Sync script is runnable as `safer-acg-sync` per existing safer-* binary convention | `bin/safer-acg-sync` is `+x`, parallel to `safer-diff-scope`, `safer-publish`, etc. |
| `safer-diff-scope` reports `senior` tier | Confirmed: tier=senior, files=3, modules=2, exports=0, new_deps=0. |

## Diff scope

3 files, +249 / -9 lines. `safer-diff-scope` reports `senior` tier (cross-module: `bin/` + `skills/typescript/`; 0 new deps; 0 exports changed). New files but no new module added per scope rules.

## Authorship note

Authored directly by team-lead orchestrator under user override. The `impl-senior-210` teammate had been running for ~17 minutes without a published artifact; orchestrator-direct shipped the same shape in less time. `/safer:review-senior` runs before merge as usual.

## Test plan

- [ ] `/safer:review-senior` reads the diff and verifies the v6 §5 acceptance bullets.
- [ ] Run the script: `cd <repo>; ./bin/safer-acg-sync`. Should produce no diff (idempotent on the same install-line). Should print rule count = 13.
- [ ] Spot-check the rationale-map: every rule maps to at least one principle anchor, and the rationale is a complete sentence.
- [ ] Spot-check the table: 12 rows under `recommended`, 1 row under `integrationTests`. No duplicates.
- [ ] Verify no PRINCIPLES.md / README.md / other-skill edits.
- [ ] Verify the BEGIN/END markers in `skills/typescript/SKILL.md` are intact and the rest of the skill body is unchanged.