### PR TITLE
[impl-senior] (sbd#208) WS1: principle re-frame aligned with gstack ETHOS + third iron law

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -64,7 +64,7 @@ Every principle below cost humans hours or days to apply consistently. It costs 
 
 **Rule.** Every constraint you can encode in the type system is a test you do not have to write and a bug that cannot ship.
 
-**Why.** A test catches a bug that exists. A type makes the bug impossible to write. Type-level constraints run at compile time, on every call site, for every reader, forever — with no test execution cost. Runtime checks catch only what runs; the type system catches everything the compiler sees.
+**Why.** A test catches a bug that exists. A type makes the bug impossible to write. Type-level constraints run at compile time, on every call site, for every reader, forever — with no test execution cost. Runtime checks catch only what runs; the type system catches everything the compiler sees. ETHOS §1 "Boil the Lake" (`~/.claude/skills/gstack/ETHOS.md`) frames completeness as near-zero marginal cost; moving constraints into the type system is the compiler-tier application of that same principle (see § Composing with gstack).
 
 **Anti-patterns.**
 - `string` where `type UserId = string & { __brand: "UserId" }` would prevent confusing user ids with org ids.
@@ -96,7 +96,7 @@ Every principle below cost humans hours or days to apply consistently. It costs 
 
 **Rule.** Data crossing a boundary is decoded by a schema. Inside the boundary, your types are truths. Outside the boundary, they are wishes.
 
-**Why.** Static types are an assertion about shape. Runtime data is a fact. Assertions that contradict facts produce the worst class of bug: runtime behavior that disagrees with the type system. The only way to make types truths is to validate at the boundary. Once validated, the rest of the code path can trust the type.
+**Why.** Static types are an assertion about shape. Runtime data is a fact. Assertions that contradict facts produce the worst class of bug: runtime behavior that disagrees with the type system. The only way to make types truths is to validate at the boundary. Once validated, the rest of the code path can trust the type. ETHOS §2 "Search Before Building" names this pattern at the knowledge layer: know what is actually coming in before deciding what to do with it; boundary validation is the runtime expression of the same discipline.
 
 **The boundaries.** Data from disk. From the network. From environment variables. From user input. From dynamic imports. From any other package. Every one of those is a boundary. Pick a schema library once — Effect Schema, Zod, Valibot — and use it at all of them.
 
@@ -116,7 +116,7 @@ Every principle below cost humans hours or days to apply consistently. It costs 
 
 **Why.** A raw throw hides three facts: which call sites it can happen at, which callers know how to handle it, what the user actually sees. Those facts surface at runtime, usually in production, usually with bad error messages. A typed error channel makes the failure modes exhaustive at the call site; you cannot forget to handle a case the compiler knows about. `Promise<T>` erases the error channel entirely; `Effect<T, E, R>` does not.
 
-An untyped throw is the assembly-language way of doing error handling. You have better tools available.
+An untyped throw is the assembly-language way of doing error handling. You have better tools available. Tagged errors and typed results encode every failure mode at the call site; that is the "do the complete thing" expectation from ETHOS §1 applied to the error channel.
 
 **Anti-patterns.**
 - `throw new Error("something went wrong")` — no type, no handling contract, no receipt for the caller.
@@ -134,7 +134,7 @@ An untyped throw is the assembly-language way of doing error handling. You have 
 
 **Why.** An unhandled branch is a bug the compiler can catch — but only if you make the compiler look. `absurd(x: never): never` is the function that makes the compiler look. Leave it out and every future addition to the union silently skips the new case.
 
-"Probably not reached" becomes "definitely not handled" and then "broken at 2 AM."
+"Probably not reached" becomes "definitely not handled" and then "broken at 2 AM." Exhaustiveness IS completeness in the type-system register; a switch that skips a case is as incomplete as a feature that skips an edge case.
 
 **Anti-patterns.**
 - `switch (s) { case "a": ...; case "b": ...; }` with no default — implicit fallthrough.
@@ -174,7 +174,7 @@ Even a perfect compiler has scope — it translates functions, not programs. Whe
 
 **Rule.** The question is not "can I do this." The question is "is this mine to do."
 
-**Why.** You can type 500 lines of correct-looking code in two minutes. That capability is the problem, not the solution. Capability without scope discipline produces fast-compounding debt, not fast-shipping code. The SDS paper is explicit: industry copes with the junior-developer error rate by limiting scope, not by making juniors senior. You are a junior developer in this model. Accept the limit.
+**Why.** You can type 500 lines of correct-looking code in two minutes. That capability is the problem, not the solution. Capability without scope discipline produces fast-compounding debt, not fast-shipping code. The SDS paper is explicit: industry copes with the junior-developer error rate by limiting scope, not by making juniors senior. You are a junior developer in this model. Accept the limit. ETHOS §3 "User Sovereignty" names the same principle at the decision layer: when scope is unclear, the user decides; the agent presents and asks, it does not assume and act.
 
 **Anti-patterns.**
 - "I can just touch this other file real quick." *(That is the scope boundary. Stop.)*
@@ -189,7 +189,7 @@ Even a perfect compiler has scope — it translates functions, not programs. Whe
 
 **Rule.** Every modality has an explicit budget naming the shape of change in scope and out of scope. Budget violations are escalation triggers, never negotiated compromises.
 
-**Why.** The budget is about *shape of change* (what boundaries you cross), not *volume of change* (how much you type). An AI-era `implement-junior` task can legitimately produce 500 LOC. It still cannot change a module's public surface. Shape, not volume.
+**Why.** The budget is about *shape of change* (what boundaries you cross), not *volume of change* (how much you type). An AI-era `implement-junior` task can legitimately produce 500 LOC. It still cannot change a module's public surface. Shape, not volume. ETHOS §1 "Boil the Lake" draws the lake vs. ocean line: a budget names exactly what is boilable (the lake) and what is out of scope (the ocean); violating the budget means boiling an ocean, not a lake.
 
 **The shape table.**
 
@@ -220,7 +220,7 @@ Even a perfect compiler has scope — it translates functions, not programs. Whe
 
 **Why.** Stop rules exist to interrupt momentum. Momentum is the enemy of discipline. The instinct "I'll just finish this function first" is the exact failure mode the stop rule prevents — because finishing the function locks in the wrong shape, and then the escalation has to argue against shipped code instead of an unmade decision.
 
-Stop rules are not advisory. They are binary. Fired means stopped.
+Stop rules are not advisory. They are binary. Fired means stopped. ETHOS §3 frames this as the generation-verification loop: the agent generates, the user verifies and decides; stop rules are the agent-side half of that loop, the mechanism that keeps the user in the seat.
 
 **Anti-patterns.**
 - "I'll finish this function first and then escalate." *(The function is downstream of the stop.)*
@@ -242,7 +242,7 @@ user ← spec ← architect ← senior ← junior
               └────── ratchet ───────┘
 ```
 
-Up is legal. Forward is legal (when the upstream artifact is ready). Sideways is forbidden.
+Up is legal. Forward is legal (when the upstream artifact is ready). Sideways is forbidden. ETHOS §3 "User Sovereignty" is the parallel principle at the human layer: handing work back to the upstream modality is the safer-pipeline expression of "ask, don't decide for the user."
 
 **Anti-patterns.**
 - "I'll add a boolean flag to handle this edge case." *(Boolean flags are the canonical shape of sidestepping a design flaw.)*
@@ -470,6 +470,8 @@ Every skill's final output carries exactly one status marker. Artifacts without 
 **On craft.** *Every error you can put in the type system is one that cannot ship.* If you are about to accept `any`, a raw throw, a bare catch, or an unchecked cast, stop. The question is whether the constraint can live higher up.
 
 **On scope.** *Capability is not an instruction. Scope is.* If you are about to act because you are able to, stop. The question is whether the action is in your scope.
+
+**On composition.** Inside an active safer modality, *safer wins on scope; gstack ETHOS wins on quality-within-scope*. The two doctrines sit at orthogonal layers: safer governs the pipeline (what work is yours), ETHOS governs construction defaults (how to do that work). Outside safer modalities, ETHOS governs unmodified.
 
 ---
 


### PR DESCRIPTION
Closes #208

## What changed

Adds ETHOS-aligned bridge prose (one sentence) to each of the 8 principles in `PRINCIPLES.md`, plus a new third iron law `**On composition.**` immediately after `**On scope.**`. Total diff: +10/-8 lines in `PRINCIPLES.md` only.

The WS1 spec v2 ([#223 comment 4348947562](https://github.com/chughtapan/safer-by-default/issues/223#issuecomment-4348947562)) is the binding plan. WS3 v2 ([commit `55476b0`](https://github.com/chughtapan/safer-by-default/commit/55476b0494d326d989e0132c715cb56e8bffaf60)) landed the `## Composing with gstack` section that this PR builds on; this PR does NOT modify that section.

## Plan-anchor table

| Spec v2 §5 acceptance row | Diff line(s) | Status |
|---|---|---|
| File scope: one file (`PRINCIPLES.md`) | full diff | ✓ |
| Structural preservation (Part 1/Part 2 headings, principle titles, SDS citation) | unchanged | ✓ |
| New third iron law `**On composition.**` after `**On scope.**` | line 474 | ✓ |
| Iron law contains literal fragment (Invariant 4 — at least twice) | line 474 + existing § Composing with gstack | ✓ (count=2) |
| Iron law body 2-4 sentences naming rule + scope qualifier + layer split | line 474 | ✓ (3 sentences) |
| P1: ETHOS §1 "Boil the Lake" cited | Principle 1 Why | ✓ |
| P2: ETHOS §2 "Search Before Building" cited | Principle 2 Why | ✓ |
| P3: light alignment ("do the complete thing") | Principle 3 Why | ✓ |
| P4: exhaustiveness IS completeness | Principle 4 Why | ✓ |
| P5: ETHOS §3 "User Sovereignty" cited | Principle 5 Why | ✓ |
| P6: ETHOS §1 lake-vs-ocean | Principle 6 Why | ✓ |
| P7: ETHOS §3 generation-verification loop | Principle 7 Why | ✓ |
| P8: ETHOS §3 ask-don't-decide | Principle 8 Why | ✓ |
| SDS citation byte-for-byte unchanged | Principle 5 quote | ✓ |
| `## Composing with gstack` body unchanged (Non-goal 6) | section unchanged | ✓ |
| Net line growth ≤ 50 | +10/-8 = +2 net | ✓ |

## Stamina-r2 concerns (review-senior, non-blocking) — disposition

| # | Concern | Disposition |
|---|---|---|
| 1 | Invariant 4 wording could tighten "at least twice" to "exactly twice" | v2.1 amendment territory; current spec wording is satisfied. |
| 2 | Iron law body length "2-4 sentences" with 3-named formula has a 4th sentence ceiling not described | Used 3 sentences; matches the formula. Optional 4th not used. |
| 3 | "at least once" rows have no upper cap | One sentence per principle per spec § 8 line cap; observed in this PR. |
| 4 | "lake vs ocean" referenced as citable phrase vs literal heading | Cited literally as `ETHOS §1 "Boil the Lake"`; lake-vs-ocean is the prose application, not the cite. |
| 5 | §6 Assumption 7 ETHOS-rename clause vs §5 hardcoded titles | Acknowledged; titles current at commit time. v2.1 amendment if ETHOS renames. |
| 6 | Markdown-lint not in §5 acceptance | No markdown-lint config in repo; diff parses as valid markdown. |
| 7 | §8 v2 spec drafting estimate below anchor | Acknowledged on epic; not a code-side concern. |

## Spec deviation (documented)

Spec v2 § 4 Invariant 4 wrote the fragment as `safer wins on scope; ETHOS wins on quality-within-scope` (without "gstack"). The existing § Composing with gstack section in `PRINCIPLES.md` (landed by WS3 v2) uses the italicized form `*safer wins on scope; gstack ETHOS wins on quality-within-scope*`. Aligned the new iron law to the existing wording so the literal fragment appears verbatim in both places (count = 2, satisfying Invariant 4's intent). This is a v2.1 amendment item: spec wording should be updated to match `PRINCIPLES.md` reality.

## diff-scope

`safer-diff-scope --head HEAD` reports:
```
{"tier":"junior","files":1,"modules":1,"exports":0,"new_deps":0,"rationale":"single module, no exported-signature changes, no new deps"}
```

The tool tier-classifies code by file count + exports + deps. For a doc-only change, junior is the natural classification. The WS1 sub-issue carries `safer:implement-senior` because `PRINCIPLES.md` is public-surface (every agent reads it at session start) and stamina N=3 is mandated. The blast-radius framing is the senior gate, not the diff-scope output.

## Tests

No code change. No test files added or modified. Markdown parses (no broken tables, no unclosed code fences). There is no markdown-lint config in this repo (stamina-r2 concern #6).

## Confidence

**HIGH** — the diff is mechanical against the spec's §5 checklist. Every literal-text fragment, every cite, every count is verifiable from `grep` output. The new iron law uses the same wording as the existing § Composing with gstack section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
