### PR TITLE
[impl-junior] (sbd#165) safer-publish: drop dead .env probe

### DIFF
--- a/bin/safer-publish
+++ b/bin/safer-publish
@@ -48,8 +48,9 @@ SAFER_ATTRIBUTE_TO_USER=0
 ZAPBOT_DETECTED=0
 
 # detect_zapbot — filesystem probe. Sets ZAPBOT_DETECTED. Always exits 0.
+# config.json is the only source post-#160; .env is no longer probed.
 detect_zapbot() {
-  if [ -f "$HOME/.zapbot/.env" ] || [ -f "$HOME/.zapbot/config.json" ]; then
+  if [ -f "$HOME/.zapbot/config.json" ]; then
     ZAPBOT_DETECTED=1
   else
     ZAPBOT_DETECTED=0
@@ -349,8 +350,7 @@ case "$IDENTITY_MODE" in
       14) probe_desc="schema_invalid" ;;
       *)  probe_desc="unknown" ;;
     esac
-    detected_path="$HOME/.zapbot/.env"
-    [ -f "$HOME/.zapbot/config.json" ] && [ ! -f "$HOME/.zapbot/.env" ] && detected_path="$HOME/.zapbot/config.json"
+    detected_path="$HOME/.zapbot/config.json"
     {
       echo ""
       echo "safer-publish: cannot reach zapbot token broker."


### PR DESCRIPTION
Closes #165. Trivial dead-branch cleanup: PR #160 made `config.json` the only zapbot config source; the `.env` probe in `detect_zapbot` (line 51) and the path-fallback at line 352 are unreachable. Drop both.

Single file, 3 lines net change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)