### PR TITLE
[impl-senior] (sbd#69) code-citation doctrine: pinned format + 10 skills + 7 retro fixes

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -277,6 +277,25 @@ GitHub is the canonical transport because this plugin targets it by default. On 
 
 Anti-patterns: *"I wrote the decision doc in `~/scratch/`" — not canonical; publish.* *"The plan is in my conversation history" — not accessible to the next agent; publish.* *"I'll publish once polished" — unpublished polish is invisible polish.*
 
+## Code references are pinned
+
+Citations that name a line carry a commit anchor. The canonical short-form is `path/foo.ts:N[-M]@<sha7>`, where `<sha7>` is the 7-character git short-sha at the time the citation is written. Ranges use `:N-M`; the rest is unchanged.
+
+**File-only carve-out.** Citations without a line (`` `skills/verify/SKILL.md` ``) stay as-is. File moves are rare and grep-recoverable; only line-bearing citations decay.
+
+**Anti-pattern.** A bare `path:N` with no anchor. Lines shift on every PR; this repo ships several PRs per hour, so a bare line citation is stale before the next reader arrives. Reviewers reject new bare line citations.
+
+**Decay rationale.** Multiple PRs/hour render line numbers stale before the next reader arrives. The sha pins the citation to a tree the reader can resolve under `git show <sha>:<path>`.
+
+**Exceptions** (the canonical-form rule does not govern these):
+
+- **(e) Schematic placeholder paths.** A teaching example using an obviously-non-existent path (e.g., `<placeholder>/foo.ts:42`) is exempt; pinning a sha to a non-existent file produces a citation that *looks* canonical but does not resolve, strictly worse than the bare form. The canonical visual signal is the `<placeholder>` token; reviewers reject any teaching example that uses a real-looking path with a fake line.
+- **(f) Re-reference shorthand.** A basename-only re-citation (`bridge-app.ts:491`) is allowed only when the full canonical form has appeared earlier in the same artifact; the re-reference inherits that earlier anchor. A basename-only citation with no upthread canonical anchor is the anti-pattern.
+- **(g) Commit messages.** Citations inside git commit messages are out of scope. A commit message cannot pin to its own pending sha, and pinning to the parent sha anchors to pre-change code; either rule generates non-resolving citations on the very commit being described.
+- **(h) Cross-repo / out-of-tree paths.** Citations referencing files outside this repo's working tree are exempt from the canonical-form rule. Disclose the cross-repo origin in surrounding prose instead (e.g., "in zapbot's `bin/zapbot-publish.sh:11-20`") so the reader knows the path is not in this repo.
+
+**(i) Worked example.** The heading `## The debt multiplier` lives at `PRINCIPLES.md:27@e1a8578`. Resolving: `git show e1a8578:PRINCIPLES.md | sed -n '27p'` returns the exact line the citation pinned. The same line at `PRINCIPLES.md:27@<another-sha>` may differ because the file has been edited; that is the point.
+
 ## Confidence is a first-class output
 
 Every recommendation carries a confidence level (LOW / MED / HIGH) and the evidence behind it. "I think so" is not an acceptable output.

--- a/docs/arch/bot-token-routing.md
+++ b/docs/arch/bot-token-routing.md
@@ -30,7 +30,9 @@ scripts in this repo are flat files, matching the convention.
 #            ~/.zapbot/config.json; either match counts.
 detect_zapbot
 
-# resolve_bridge_url — same ladder as zapbot-publish.sh:11-20.
+# resolve_bridge_url — same ladder as zapbot's bin/zapbot-publish.sh:11-20
+#                      (cross-repo reference; that file lives in the zapbot
+#                      codebase, not in this repo).
 #
 # Inputs: none. Reads cwd/agent-orchestrator.yaml, $ZAPBOT_BRIDGE_URL.
 # Outputs: echoes the resolved URL on stdout. Never empty on a 0 exit.
@@ -153,8 +155,10 @@ Interface stubs live on branch `arch/token-broker` in the zapbot repo:
   - Discriminated union: `InstallationTokenError`.
 
 Reuse, per spec invariant 2: `deps.mintToken` is `getInstallationToken` from
-`src/github/client.ts:200-218` — the existing `_authInstance` singleton. No
-new mint path. The route never touches `createAppAuth` directly.
+zapbot's `src/github/client.ts:200-218` (cross-repo reference; that file
+lives in the zapbot codebase, not in this repo) — the existing
+`_authInstance` singleton. No new mint path. The route never touches
+`createAppAuth` directly.
 
 ## Data flow
 
@@ -180,7 +184,8 @@ safer-publish
   │                            ▼
   │                          getInstallationToken()
   │                            (existing _authInstance singleton,
-  │                             src/github/client.ts:200-218)
+  │                             in zapbot's src/github/client.ts:200-218 —
+  │                             cross-repo, lives in the zapbot codebase)
   │                            ▼
   │                          @octokit/auth-app mints / returns cached
   │                            ▼
@@ -436,11 +441,13 @@ change to `handle_fallback_flags`).
 HIGH — every interface is derivable from the spec's acceptance criteria;
 every data-flow arrow corresponds to a function call across two named
 modules; every failure branch is enumerated with its exit code. The zapbot
-mint path (`_authInstance` singleton) is read-verified at
-`src/github/client.ts:200-218`. The bridge fetch-handler pattern is
-read-verified in `test/bridge-endpoints.test.ts` (inline pathname switch;
-Bun.serve). The bridge-URL ladder is read-verified in
-`bin/zapbot-publish.sh:11-20`. No unresolved spec ambiguity.
+mint path (`_authInstance` singleton) is read-verified in zapbot's
+`src/github/client.ts:200-218` (cross-repo; that path lives in the zapbot
+codebase, not in this repo). The bridge fetch-handler pattern is
+read-verified in zapbot's `test/bridge-endpoints.test.ts` (also cross-repo;
+inline pathname switch; Bun.serve). The bridge-URL ladder is read-verified
+in zapbot's `bin/zapbot-publish.sh:11-20` (cross-repo). No unresolved spec
+ambiguity.
 
 ---
 

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -228,6 +228,8 @@ For each external library in the design, fill a row in the dependencies table: n
 
 ### Phase 7 — Publish
 
+Code references in the design doc body use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 ```bash
 BRANCH="arch/${SAFER_SLUG:-arch-$SESSION}"
 git checkout -b "$BRANCH"

--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -254,6 +254,9 @@ sections.
 | Trust | N/10 | ... |
 
 ## Friction log
+
+Friction entries that cite a line use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 1. [location] - [why a consumer stumbles]
 2. ...
 

--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -220,6 +220,8 @@ Expected output: `tier: junior`. If the output is `senior` or `staff`, stop. Do 
 
 ### Phase 7 — Open the PR
 
+Code references in the PR body use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 ```bash
 git add <module files>
 git commit -m "impl: <one-line summary>"

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -239,6 +239,8 @@ Apply all findings unless a finding would conflict with a plan-approved architec
 
 ### Phase 7 — Open the PR
 
+Code references in the PR body use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 ```bash
 git add <changed files>
 git commit -m "impl: <one-line summary tied to the plan>"

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -288,6 +288,8 @@ If `/codex` is unavailable, log "codex diff review: unavailable — skipped" on 
 
 ### Phase 9 — Open the PR
 
+Code references in the PR body use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 ```bash
 git add <new files + package.json + lockfile>
 git commit -m "impl: <one-line spec summary>"

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -211,16 +211,18 @@ Record the bisect result as a row in the isolation table.
 
 ### Phase 6 — Name the root cause
 
+Code references in the root-cause writeup use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 State the mechanism, not the symptom. The root cause is a sentence that names:
 
 - The file and line where the mistake lives.
 - The class of mistake (missing validation, wrong branch, stale invariant, schema drift, unhandled case, race, overflow, off-by-one, missing exhaustiveness check).
 - The conditions under which it fires.
 
-Examples of well-formed root causes:
+Examples of well-formed root causes (paths below use `<placeholder>/...` as schematic placeholders; they are illustrative, not real files in this repo, per the schematic-placeholder exception of the code-citation doctrine; see `PRINCIPLES.md#code-references-are-pinned`):
 
-- "In `src/auth/token.ts:83`, `decodeToken` returns `null` on malformed input instead of a tagged error; the caller at `src/api/session.ts:41` treats `null` as 'anonymous session' and grants access. Classification: logical (missing typed error channel; violates Principle 3)."
-- "In `src/pipeline/ingest.ts:112`, the schema decodes only the first event in a batch; later events are cast with `as Event`. When upstream changed event shape on 2026-03-15, the cast started producing objects whose fields are `undefined` at runtime. Classification: structural (missing boundary validation; violates Principle 2)."
+- "In `<placeholder>/auth/token.ts:83`, `decodeToken` returns `null` on malformed input instead of a tagged error; the caller at `<placeholder>/api/session.ts:41` treats `null` as 'anonymous session' and grants access. Classification: logical (missing typed error channel; violates Principle 3)."
+- "In `<placeholder>/pipeline/ingest.ts:112`, the schema decodes only the first event in a batch; later events are cast with `as Event`. When upstream changed event shape on 2026-03-15, the cast started producing objects whose fields are `undefined` at runtime. Classification: structural (missing boundary validation; violates Principle 2)."
 
 Examples of malformed root causes (do not ship these):
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -302,6 +302,8 @@ For each sub-issue in dependency order:
 
 **Step 5a — Invoke the modality.**
 
+Code references in the dispatch prompt and any teammate-context payload use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 Dispatch via a team. First `TeamCreate` a team for the epic if one does not exist, then `Agent` with `team_name` and a `name` per teammate.
 
 **Never invoke a modality in-session.** The `Skill` tool executes in your own context. That means orchestrate is doing the work, which is the Iron Rule violation this skill exists to prevent. Modalities run as teammates.

--- a/skills/review-senior/SKILL.md
+++ b/skills/review-senior/SKILL.md
@@ -258,6 +258,8 @@ here breaks them.
 
 ### Phase 3 — Aggregate the verdict
 
+Code references in the verdict body use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 Combine per-skill verdicts into one artifact verdict. Rules:
 
 - Any `REQUEST-CHANGES` among composed skills → artifact verdict

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -159,6 +159,8 @@ Ask `AskUserQuestion` for at most 3 questions in one call. Prefer A/B/C options 
 
 ### Phase 4 — Draft the spec
 
+Code references in the spec body use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 Write the spec document using exactly the 7-section structure above. Formatting rules:
 
 - Intent: one paragraph. Do not rewrite the user's framing; preserve their words where possible.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -227,6 +227,8 @@ The verdict is mechanical. No judgment call beyond flakiness detection. If the m
 
 ### Phase 6 — Publish the verdict
 
+Code references in the verdict body use the canonical pinned form `path:N[-M]@<sha7>`. See `PRINCIPLES.md#code-references-are-pinned`.
+
 Write the verdict body:
 
 ```bash
@@ -410,7 +412,7 @@ If you were invoked outside an orchestrate context (no team), skip this step.
 
 ## Voice (reminder)
 
-See `PRINCIPLES.md` to Voice. The verdict is terse, mechanical, and evidence-backed. Not "looks good to me" but "SHIP: lint 0, typecheck 0, test 142/142; criteria 1-3 met with evidence at `src/foo.ts:18`, `src/foo.test.ts:42`."
+See `PRINCIPLES.md` to Voice. The verdict is terse, mechanical, and evidence-backed. Not "looks good to me" but "SHIP: lint 0, typecheck 0, test 142/142; criteria 1-3 met with evidence at `<placeholder>/foo.ts:18`, `<placeholder>/foo.test.ts:42`." *Schematic example; `<placeholder>/...` paths are illustrative placeholders, not real files in this repo (schematic-placeholder exception of the code-citation doctrine; see `PRINCIPLES.md#code-references-are-pinned`).*
 
 Quality judgments are the downstream modality's budget, not yours. You report facts. The next agent reading your verdict is a junior; they should be able to act on it (merge, re-implement, investigate) without asking you follow-up questions.
 


### PR DESCRIPTION
Closes #69
Spec v3: https://github.com/chughtapan/safer-by-default/issues/69#issuecomment-4355867085
Spec v2 (canonical body): https://github.com/chughtapan/safer-by-default/issues/69#issuecomment-4355716077

## What changed

Land the v3 acceptance criteria for the code-citation doctrine:

- `PRINCIPLES.md` gains a `## Code references are pinned` section under Artifact discipline (after \"GitHub is the record\"), anchor `#code-references-are-pinned`. Body covers the canonical form `path:N[-M]@<sha7>`, file-only carve-out, the anti-pattern, decay rationale, the four exceptions (schematic placeholder, re-reference shorthand, commit-message out-of-scope, cross-repo / out-of-tree), and a worked example pinned at `PRINCIPLES.md:27@e1a8578`.
- 10 skill files cross-link to the doctrine at the v3-named headings: `review-senior` (Phase 3), `implement-junior` (Phase 7), `implement-senior` (Phase 7), `implement-staff` (Phase 9), `dogfood` (Friction log), `investigate` (Phase 6), `orchestrate` (Step 5a), `verify` (Phase 6), `spec` (Phase 4), `architect` (Phase 7). One sentence each, naming the canonical form and linking to the anchor; no rule body re-stated (Principle 5 single-source).
- AC-3 placeholder rewrites: `skills/verify/SKILL.md:415@969261e` (under `## Voice (reminder)`) rewrites `src/foo.ts:18`, `src/foo.test.ts:42` to `<placeholder>/...` form with adjacent prose disclosing the placeholder convention. `skills/investigate/SKILL.md:222-225@969261e` (under `### Phase 6 — Name the root cause`) rewrites the three `src/auth/...`, `src/api/...`, `src/pipeline/...` paths the same way.
- AC-3a cross-repo disclosures: 5 bare line citations in `docs/arch/bot-token-routing.md@969261e` (lines 33, 156, 183, 440, 443 in the pre-edit file) now disclose their zapbot origin in surrounding prose. The bare `zapbot-publish.sh` at line 33 is normalized to `bin/zapbot-publish.sh` for consistency.

## Plan anchors

| Change | Spec anchor |
|---|---|
| Add `## Code references are pinned` to PRINCIPLES.md | v3 AC-1 (a)-(i) |
| 10 skill cross-links at named headings | v3 AC-2 (table including v3 row 7 orchestrate sub-phase pin) |
| 2 placeholder rewrites in verify + investigate | v3 AC-3 |
| 5 cross-repo disclosure rewrites in bot-token-routing.md | v3 AC-3a |
| No new file | v3 AC-4 |
| Going-forward only; 7 retro edits = full retro surface | v3 AC-5 |
| No safer-cite binary | v3 AC-6 |
| No ACG/lint rule | v3 AC-7 |
| Canonical format used in this PR body | v3 AC-8 |

## Scope

- Modules touched: PRINCIPLES.md, 10 skills/*/SKILL.md, docs/arch/bot-token-routing.md (12 files; ~60 line diff).
- Tier: senior (cross-skill text edits in service of an approved spec).
- New modules: 0
- New public signatures: 0
- New deps: 0

## Tests

`bash tests/run-tests.sh` from repo root: 196 passed / 25 failed / 221 total. The 25 failing suites match the pre-existing baseline named in the dispatch (`test-load-context`, `test-orchestrate-auto-dispatch`, `test-publish-bot-routing`, `test-safer-peer-message`, `test-transition-label`, `test-taxonomy-labelmap-crossref`, `test-taxonomy-schema-validation`); none are caused by this diff (the diff is markdown-only).

## Simplify pass

`/simplify` ran three parallel reviewers on the diff. Findings applied:

- Quality reviewer flagged the exception list labels were `(e), (f), (g), (i)` with `(h) Worked example` orphaned outside the list. Rewrote to `(e), (f), (g), (h)` for the four exceptions inside the bulleted list and `(i) Worked example` as the trailing paragraph, matching v3 AC-1's stated ordering. Also converted italic letter labels to bold lead-ins for visual consistency with the `**File-only carve-out.**` / `**Anti-pattern.**` / `**Decay rationale.**` style above.
- Quality reviewer flagged that the verify and investigate skill prose referenced \"Invariant 6 of the code-citation doctrine\" but the PRINCIPLES.md section uses letter-labeled exceptions, not numbered invariants. Rewrote both to \"the schematic-placeholder exception of the code-citation doctrine\" so the cross-reference resolves.

Skipped findings:

- Reuse reviewer suggested hoisting a \"Cross-repo paths\" preamble in `docs/arch/bot-token-routing.md` to deduplicate the per-citation cross-repo parentheticals. Skipped: v3 AC-3a explicitly asks for the disclosure to live in the surrounding prose at each citation site so a reader scanning to that line sees the disclosure inline. A top-of-doc note shifts the cognitive load to the reader to remember the convention. The repetition is the spec.
- Reuse reviewer suggested trimming the inline placeholder gloss in verify and investigate since exception (e) in PRINCIPLES.md already covers it. Skipped: the dispatch instruction \"Add adjacent prose like '*Schematic example; the path is a placeholder, not a real file in this repo.*' so a cold-start reader recognizes the convention\" is the explicit ask. The cross-link tells the reader where the doctrine lives; the inline prose tells the reader these specific paths are placeholders.

## Confidence

HIGH. Every edit traces to a v3 acceptance criterion. Verification commands match expectations: 10 cross-links via `git grep PRINCIPLES.md#code-references-are-pinned` (excluding the 2 in-prose mentions inside AC-3 disclosures), 5 `<placeholder>/...` occurrences via `git grep -oE '<placeholder>/(foo|auth|api|pipeline)'`, 0 originals remaining, 5 cross-repo disclosures in bot-token-routing.md citing `bin/zapbot-publish.sh` consistently. `bash tests/run-tests.sh` matches main baseline (25/221 pre-existing failures unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)