### PR TITLE
[impl-senior] (sbd#142, sbd#143) toolchain pin + forbidden-paths guard

### DIFF
--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -45,6 +45,16 @@ Read `PRINCIPLES.md` at the plugin root before writing any code. Your projection
 
 The second file is always the first warning. The instinct "it is one line, it is basically the same module, the test lives here anyway" is exactly the debt pattern Principle 6 exists to stop. Cross-module reach is a shape change. Escalate; do not rationalize.
 
+## Forbidden paths
+
+> **Edits to paths containing `.claude/` as a directory component are forbidden.** (sbd#143)
+
+`~/.claude/skills/<repo>/...` is the harness's plugin cache, NOT the project repo. Confusing the two has bitten this team three times: a teammate edits `~/.claude/skills/zapbot/package.json` instead of `/home/tapanc/zapbot/package.json` and corrupts the runtime skill state instead of the project.
+
+Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if any component is exactly `.claude`. Substring match is wrong (`.claude-plugin/` is legitimate); component match is the rule. On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+
+Exception: a teammate explicitly invoked on a sub-issue whose body names `.claude/` in scope (e.g., a meta task editing the plugin itself) may proceed; the sub-issue body must literally contain the string `Scope authorized: .claude/`.
+
 ## Role
 
 You fill in the internals of one module against a clear acceptance criterion. The criterion is either a sub-issue body, a PR description, or an architect stub that says `throw new Error("not implemented")` and names the function you must implement.

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -46,6 +46,14 @@ Read `PRINCIPLES.md` at the plugin root before writing any code. Your projection
 
 The temptation to "just tweak the plan since I'm the one implementing it" is the exact failure the Ratchet rejects. A senior implementer who revises the plan is producing architect-tier work outside the architect modality, which means it is not reviewed, not traced, and not visible in the design doc the next agent reads. Escalate.
 
+## Forbidden paths
+
+> **Edits to paths containing `.claude/` as a directory component are forbidden.** (sbd#143)
+
+`~/.claude/skills/<repo>/...` is the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if any component is exactly `.claude`. Substring match is wrong (`.claude-plugin/` is legitimate); component match is the rule. On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+
+Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/` may proceed.
+
 ## Role
 
 You execute a plan that spans modules. The architect has named the modules, the interfaces, the data flow, and the dependency list. Your job is to fill in the bodies across those modules, and to reshape internals (private helpers, internal types, file layouts, test structure) so the plan fits cleanly. Every edit traces to a line in the plan. Every deviation is an escalation event.

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -45,6 +45,14 @@ Read `PRINCIPLES.md` at the plugin root before writing any code. Your projection
 
 Staff-tier capability is the most dangerous place in the pipeline for scope drift. You can ship a new module and a new public API in one afternoon. That capability is the problem, not the solution. Every module you introduce and every signature you export is a line someone downstream treats as contract. If the spec did not authorize it, someone downstream will later ask, "why is this here?" and the honest answer will be "a staff implementer liked it." That is the debt pattern. Stop.
 
+## Forbidden paths
+
+> **Edits to paths containing `.claude/` as a directory component are forbidden.** (sbd#143)
+
+`~/.claude/skills/<repo>/...` is the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if any component is exactly `.claude`. Substring match is wrong (`.claude-plugin/` is legitimate); component match is the rule. On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+
+Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/` may proceed (rare; meta-tasks editing the plugin itself).
+
 ## Role
 
 You take a spec, optionally an architect plan, and introduce the new architectural territory the spec calls for: new modules, new public interfaces, new dependencies. Every change is anchored to a specific spec line or plan line. Every new module has a named purpose from the spec. Every new public function has its error channel declared. Every new dep has a justification traceable to a spec constraint.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -176,7 +176,51 @@ Do not attempt the migration yourself. That belongs to the user's judgement abou
 
 **If both `LEGACY` and `FLAT_CONFIG` are set:** proceed on the clean-slate path, but warn the user that ESLint 9 flat config takes precedence and the `.eslintrc` file is being ignored. Deleting it later avoids confusion.
 
-**Else (clean slate):** proceed to Step 1.
+**Else (clean slate):** proceed to Step 0b.
+
+### Step 0b: Pin the package-manager toolchain (mandatory; sbd#142)
+
+Lockfile drift between local and CI is a recurring debt pattern (incident: zap#130, three CI-vs-local `bun.lock` mismatch cycles caused by local `bun` and CI `setup-bun@latest` diverging). The fix is to pin the toolchain version in `package.json` `packageManager` field from commit one. Setup writes that field if `package.json` exists.
+
+Idempotent: skip if `packageManager` is already set (any value — do not overwrite the user's choice).
+
+```bash
+if [ -f package.json ]; then
+  CURRENT_PM_PIN=$(jq -r '.packageManager // empty' package.json 2>/dev/null)
+  if [ -z "$CURRENT_PM_PIN" ]; then
+    case "$PM" in
+      pnpm) PM_VERSION=$(pnpm --version 2>/dev/null) ;;
+      npm)  PM_VERSION=$(npm --version 2>/dev/null) ;;
+      yarn) PM_VERSION=$(yarn --version 2>/dev/null) ;;
+      bun)  PM_VERSION=$(bun --version 2>/dev/null) ;;
+    esac
+    if [ -n "$PM_VERSION" ]; then
+      jq --arg pin "${PM}@${PM_VERSION}" '.packageManager = $pin' package.json > package.json.tmp \
+        && mv package.json.tmp package.json
+      echo "TOOLCHAIN_PIN: wrote packageManager=${PM}@${PM_VERSION}"
+    else
+      echo "TOOLCHAIN_PIN: could not detect ${PM} version; skipped (user can pin manually)"
+    fi
+  else
+    echo "TOOLCHAIN_PIN: packageManager already set ($CURRENT_PM_PIN); skipped"
+  fi
+fi
+```
+
+Then probe CI workflow files for unpinned setup actions and warn (advisory only — no auto-edit):
+
+```bash
+if [ -d .github/workflows ]; then
+  UNPINNED=$(grep -nE 'uses: *(actions/setup-(node|bun|python)|pnpm/action-setup|oven-sh/setup-bun)@' .github/workflows/*.{yml,yaml} 2>/dev/null \
+    | grep -E '@(latest|main|master|v[0-9]+) *$' || true)
+  if [ -n "$UNPINNED" ]; then
+    echo "TOOLCHAIN_WARN: unpinned setup action(s) in CI workflows; pin to a version sha:"
+    echo "$UNPINNED" | sed 's/^/  /'
+  fi
+fi
+```
+
+The CI-warning step is advisory only. Editing workflow files belongs to the user (they understand which versions to pin to).
 
 ### Step 1: Check peer dependencies
 


### PR DESCRIPTION
Bundles two deferred backlog items, both doc-only.

## Summary

**Closes #142** — `/safer:setup` Step 0b pins `packageManager` field in `package.json` (idempotent). Probes CI workflows for unpinned `setup-*@latest` actions; advisory only. Closes the zap#130 lockfile-war pattern.

**Closes #143** — `## Forbidden paths` section in all three implement-* skills. Before any `Edit`/`Write`/`MultiEdit`, refuse if the target absolute path has a component exactly equal to `.claude`. Component match (not substring; `.claude-plugin/` is legit). Closes the harness-cache vs project-repo confusion incidents from retro 2026-04-19.

## Diff

| File | Lines | What |
|---|---|---|
| skills/setup/SKILL.md | +46/-1 | Step 0b: detect PM version, write `packageManager` field, warn on unpinned CI workflows |
| skills/implement-junior/SKILL.md | +10 | New `## Forbidden paths` section before `## Role` |
| skills/implement-senior/SKILL.md | +8 | Same; minor wording for senior tier |
| skills/implement-staff/SKILL.md | +8 | Same; staff-tier wording |

## Test plan

- [x] `bash tests/run-tests.sh` — 196/221 pass (matches main baseline; 25 pre-existing failures, no regressions)
- [x] `git grep -nE '## Forbidden paths' skills/` returns 3 hits (junior + senior + staff)
- [x] `git grep -nE 'Step 0b' skills/setup/SKILL.md` returns 1 hit (the new step header)
- [x] `jq '.packageManager' package.json` on a test fixture: setup writes the field; second run is no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)