### PR TITLE
[impl-senior] doctrine: process issues are first-class artifacts

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -296,6 +296,16 @@ Citations that name a line carry a commit anchor. The canonical short-form is `p
 
 **(i) Worked example.** The heading `## The debt multiplier` lives at `PRINCIPLES.md:27@e1a8578`. Resolving: `git show e1a8578:PRINCIPLES.md | sed -n '27p'` returns the exact line the citation pinned. The same line at `PRINCIPLES.md:27@<another-sha>` may differ because the file has been edited; that is the point.
 
+## Process issues are first-class artifacts
+
+Every teammate's final output carries TWO artifacts: the substantive verdict (the spec / PR / review / etc.) AND a `Process issues` log of any pipeline-level friction encountered while producing it. The orchestrator's job is to surface the latter to the user proactively — buried in a verdict body, a process issue is a debt pattern that recurs because no one upstream ever sees it.
+
+Examples of process issues: a `gh` write was sandbox-blocked and the teammate had to relay the body via SendMessage; an idle notification fired before the work actually finished; a dispatch instruction was ambiguous and required a clarifying nudge; a CI status was not surfaced when it should have been; a pre-PR `/review` flagged a class of finding that no skill body anticipates; a tool returned an unexpected output shape. Anything that made the work harder than the doctrine says it should be.
+
+Surfacing rule: every teammate appends a `Process issues` section to the SendMessage that closes their turn. Empty is a valid value (`Process issues: none`). The orchestrator scans those sections each tick and either (a) surfaces them to the user as a one-line summary in the next status update, or (b) files a follow-up sub-issue when the issue is structural enough to warrant doctrine change.
+
+The failure mode this rule prevents: a teammate completes the assigned task, gets a clean APPROVE, the user moves on — and the friction the teammate hit recurs on every subsequent dispatch because no one ever named it. The orchestrator is the only seat that sees enough dispatches to spot the pattern; if the orchestrator buries it, no one fixes it.
+
 ## Confidence is a first-class output
 
 Every recommendation carries a confidence level (LOW / MED / HIGH) and the evidence behind it. "I think so" is not an acceptable output.

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -386,9 +386,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -486,9 +486,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -407,9 +407,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -426,9 +426,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -490,9 +490,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -399,9 +399,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -615,6 +615,17 @@ Record the returned job id on the parent epic (comment) so the next operator can
    4. `verifying → done` (after verify emits SHIP): post the gating comment with the verify verdict URL, close the sub-issue. On HOLD: route per Phase 6 (typically back to `/safer:implement-*` with the verify findings).
 
    The auto-gate never skips verify on implement-\* sub-issues. A sub-issue at `plan-approved` whose PR is merged and has no verify verdict on the merge commit is a candidate for auto-dispatch to verify on every tick until the verdict lands.
+
+5a. **Surface process issues from teammate SendMessages (mandatory).** Per PRINCIPLES.md → Process issues are first-class artifacts, every teammate's closing SendMessage carries a `Process issues:` field. The orchestrator scans the SendMessage stream each tick and:
+
+   - Aggregates non-empty `Process issues` entries from this tick's teammates.
+   - Surfaces them to the user as a one-line summary in the next status update — NOT buried in a verdict body, NOT silently dropped because the substantive verdict was APPROVE.
+   - For structural issues (the same `Process issues:` line recurring across multiple dispatches), files a follow-up sub-issue against the parent epic so the doctrine catches the pattern.
+
+   The failure mode this rule prevents: a teammate completes the assigned task, gets a clean APPROVE, the user moves on — and the friction the teammate hit recurs on every subsequent dispatch because no one ever named it. The orchestrator is the only seat that sees enough dispatches to spot the pattern; if the orchestrator buries it, no one fixes it.
+
+   "Empty" (`Process issues: none`) is a valid value and not surfaced. The rule fires only on non-empty entries.
+
 6. **Auto-dispatch pending work (work-queue scan).** The prior steps react to state the loop already knows about. Step 6 is the proactive scan: enumerate pending sub-issues across every repo this team serves, filter out the ones that are already in flight, prioritize what is left, and dispatch up to the per-tick cap. Without this step the orchestrator idles between user prompts even when work is queued. Step 6 is mandatory once a team is installed.
 
 **Step 6a — enumerate pending work.** Scan every repo this team watches (`~/.claude/teams/<team-name>/config.json` carries `repos: []`; fall back to the current repo if the field is absent). For each, list open sub-issues whose labels name a dispatchable modality:

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -371,9 +371,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/review-senior/SKILL.md
+++ b/skills/review-senior/SKILL.md
@@ -385,9 +385,11 @@ Before you post a status marker or close your turn, **SendMessage to
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Aggregate verdict: <X>."
+  message: "STATUS: DONE. Artifact: <URL>. Aggregate verdict: <X>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 If invoked outside an orchestrate context (no team), skip this step.
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -278,9 +278,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/spike/SKILL.md
+++ b/skills/spike/SKILL.md
@@ -356,9 +356,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -401,9 +401,11 @@ Before you post a status marker or close your turn, **SendMessage to `team-lead`
 SendMessage({
   to: "team-lead",
   summary: "<3-8 word summary>",
-  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>."
+  message: "STATUS: DONE. Artifact: <URL>. Next: <modality or handoff>. Process issues: <none | one-line list>."
 })
 ```
+
+The `Process issues` field is mandatory (per PRINCIPLES.md → Process issues are first-class artifacts). If the run hit no friction, write `Process issues: none`. If it hit any — a sandbox-blocked command, an ambiguous dispatch instruction, an unexpected tool output, a flaky idle notification, anything that made the work harder than the doctrine implies — list each one as a short clause. The orchestrator surfaces these to the user proactively.
 
 Emit the `SendMessage` before your final-reply output. The final reply is for the harness; the `SendMessage` is for the team-lead who dispatched you.
 


### PR DESCRIPTION
Meta-rule: when teammates encounter process-level friction (sandbox-blocked tool, ambiguous dispatch, flaky idle notification, unexpected tool output, etc.), they must surface it alongside their substantive verdict. The orchestrator's job is to surface those to the user proactively — not bury them in a verdict body where they recur on every subsequent dispatch.

## Why

Real session evidence: dogfood-69 hit a sandbox block on `gh issue comment` (silent until probed); codex-69 emitted multiple false-positive idle notifications; review-senior-229 stalled 45+ min. None were surfaced by the teammate's verdict — only visible because team-lead happened to notice.

## Diff

| File | Lines | What |
|---|---|---|
| PRINCIPLES.md | +10 | New section 'Process issues are first-class artifacts' under Artifact discipline. Names the doctrine, surfacing rule, and failure mode. |
| skills/{architect,dogfood,implement-{junior,senior,staff},investigate,research,review-senior,spec,spike,verify}/SKILL.md | +44/-11 | Communication discipline updated: SendMessage `message:` template now requires `Process issues: <none \| one-line list>`. New paragraph explaining the field's mandatory scope. |
| skills/orchestrate/SKILL.md | +11 | New Step 5a in Phase 5d auto-monitor loop: scan teammate SendMessages, aggregate non-empty Process issues, surface to user, file follow-up on recurring structural issues. Empty (`Process issues: none`) is valid and not surfaced. |

## Test plan

- [x] `bash tests/run-tests.sh` — 196/221 pass (matches main baseline)
- [x] `git grep -nE 'Process issues are first-class' PRINCIPLES.md` returns 1 hit
- [x] `git grep -nE 'Process issues:' skills/` returns ≥11 hits across all teammate skills
- [x] `git grep -nE 'Step 5a — Surface' skills/orchestrate/SKILL.md` returns 1 hit (or substring match for the new step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)