### PR TITLE
[impl-junior] (sbd#261) scope .claude/ path-edit refusal to harness cache only

### DIFF
--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -47,13 +47,13 @@ The second file is always the first warning. The instinct "it is one line, it is
 
 ## Forbidden paths
 
-> **Edits to paths containing `.claude/` as a directory component are forbidden.** (sbd#143)
+> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.** (sbd#143, sbd#261)
 
-`~/.claude/skills/<repo>/...` is the harness's plugin cache, NOT the project repo. Confusing the two has bitten this team three times: a teammate edits `~/.claude/skills/zapbot/package.json` instead of `/home/tapanc/zapbot/package.json` and corrupts the runtime skill state instead of the project.
+`~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two has bitten this team three times: a teammate edits `~/.claude/skills/zapbot/package.json` instead of `/home/tapanc/zapbot/package.json` and corrupts the runtime skill state instead of the project.
 
-Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if any component is exactly `.claude`. Substring match is wrong (`.claude-plugin/` is legitimate); component match is the rule. On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...` (sbd#261). Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
 
-Exception: a teammate explicitly invoked on a sub-issue whose body names `.claude/` in scope (e.g., a meta task editing the plugin itself) may proceed; the sub-issue body must literally contain the string `Scope authorized: .claude/`.
+Exception: a teammate explicitly invoked on a sub-issue whose body names the harness cache in scope (e.g., a meta task editing the plugin itself) may proceed; the sub-issue body must literally contain the string `Scope authorized: .claude/skills/` or `Scope authorized: .claude/plugins/`.
 
 ## Role
 

--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -47,11 +47,11 @@ The second file is always the first warning. The instinct "it is one line, it is
 
 ## Forbidden paths
 
-> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.** (sbd#143, sbd#261)
+> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.**
 
 `~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two has bitten this team three times: a teammate edits `~/.claude/skills/zapbot/package.json` instead of `/home/tapanc/zapbot/package.json` and corrupts the runtime skill state instead of the project.
 
-Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...` (sbd#261). Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...`. Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
 
 Exception: a teammate explicitly invoked on a sub-issue whose body names the harness cache in scope (e.g., a meta task editing the plugin itself) may proceed; the sub-issue body must literally contain the string `Scope authorized: .claude/skills/` or `Scope authorized: .claude/plugins/`.
 

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -48,11 +48,11 @@ The temptation to "just tweak the plan since I'm the one implementing it" is the
 
 ## Forbidden paths
 
-> **Edits to paths containing `.claude/` as a directory component are forbidden.** (sbd#143)
+> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.** (sbd#143, sbd#261)
 
-`~/.claude/skills/<repo>/...` is the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if any component is exactly `.claude`. Substring match is wrong (`.claude-plugin/` is legitimate); component match is the rule. On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+`~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...` (sbd#261). Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
 
-Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/` may proceed.
+Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/skills/` or `Scope authorized: .claude/plugins/` may proceed.
 
 ## Role
 

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -48,9 +48,9 @@ The temptation to "just tweak the plan since I'm the one implementing it" is the
 
 ## Forbidden paths
 
-> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.** (sbd#143, sbd#261)
+> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.**
 
-`~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...` (sbd#261). Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+`~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...`. Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
 
 Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/skills/` or `Scope authorized: .claude/plugins/` may proceed.
 

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -47,11 +47,11 @@ Staff-tier capability is the most dangerous place in the pipeline for scope drif
 
 ## Forbidden paths
 
-> **Edits to paths containing `.claude/` as a directory component are forbidden.** (sbd#143)
+> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.** (sbd#143, sbd#261)
 
-`~/.claude/skills/<repo>/...` is the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if any component is exactly `.claude`. Substring match is wrong (`.claude-plugin/` is legitimate); component match is the rule. On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+`~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...` (sbd#261). Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
 
-Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/` may proceed (rare; meta-tasks editing the plugin itself).
+Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/skills/` or `Scope authorized: .claude/plugins/` may proceed (rare; meta-tasks editing the plugin itself).
 
 ## Role
 

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -47,9 +47,9 @@ Staff-tier capability is the most dangerous place in the pipeline for scope drif
 
 ## Forbidden paths
 
-> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.** (sbd#143, sbd#261)
+> **Edits to paths under the harness plugin cache (`.claude/skills/` or `.claude/plugins/`) are forbidden.**
 
-`~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...` (sbd#261). Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
+`~/.claude/skills/<repo>/...` and `~/.claude/plugins/...` are the harness's plugin cache, NOT the project repo. Confusing the two corrupts the runtime skill state instead of the project. Before any `Edit`, `Write`, or `MultiEdit` call: split the target absolute path on `/` and refuse if it contains the adjacent pair `.claude/skills/` or `.claude/plugins/`. The adjacent-pair check catches the harness cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on project worktrees that legitimately live under `.claude/worktrees/<slug>/...`. Single-component match (any `.claude` component) is too broad; substring match is wrong in the other direction (`.claude-plugin/` is legitimate). On refusal, emit `BLOCKED` with `cause=forbidden_path:<full-target-path>` and SendMessage the team-lead.
 
 Exception: a teammate explicitly invoked on a sub-issue whose body literally contains `Scope authorized: .claude/skills/` or `Scope authorized: .claude/plugins/` may proceed (rare; meta-tasks editing the plugin itself).
 


### PR DESCRIPTION
Closes #261

## Problem

The implement-{junior,senior,staff} forbidden-paths rule refused any path with `.claude` as a directory component. This over-fires on project worktrees that legitimately live under `.claude/worktrees/<slug>/...` — surfaced in arena PR #221 when a teammate was placed in such a worktree by Agent isolation and would have refused every edit to project files.

## Fix

Tighten to **adjacent-pair match** (Option 2 from the issue): refuse only if the path contains `.claude/skills/` or `.claude/plugins/` as adjacent components. This catches the actual harness plugin cache (typically `$HOME/.claude/skills/...` and `$HOME/.claude/plugins/...`) without over-firing on `.claude/worktrees/`. Robust against `HOME` rebasing in container deployments.

Updated the rule in all three implement-* skill files. Exception clause now requires `Scope authorized: .claude/skills/` or `Scope authorized: .claude/plugins/` (was `Scope authorized: .claude/`).

## Plan anchors

| Change | Anchor |
|---|---|
| Tighten rule wording in implement-junior/SKILL.md | sbd#261 fix proposal Option 2 |
| Same in implement-senior/SKILL.md | sbd#261 |
| Same in implement-staff/SKILL.md | sbd#261 |

## Scope

- Files: 3 doctrine `SKILL.md` files
- Tier: junior (mechanical doctrine update, identical pattern across three files)
- No new modules, no new public surface, no new deps
- No code logic changes (prompt-level rule only)

## Tests

- `bash tests/run-tests.sh` → 221 passed, 0 failed (no test references this rule; it's prompt-level discipline)

## Confidence

HIGH — surgical wording change; the rule's existing structure (split path on `/`, match component) is preserved, only the matching predicate is tightened. The triggering case (`.../moltzap-arena/.claude/worktrees/lazy-purring-turing/`) no longer matches; the original concern (`~/.claude/skills/zapbot/...`) still matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)