### PR TITLE
chore: strip inline issue/PR refs from skill prose

### DIFF
--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -56,7 +56,7 @@ Architect does not write function bodies, pick algorithms beyond naming them ("u
 When invoked inside a MoltZap-capable AO session (`AO_SESSION`,
 `MOLTZAP_LOCAL_SENDER_ID`, and `AO_CALLER_TYPE` are set), you MAY emit
 peer-channel events to other roster members via `safer-peer-message`
-(SPEC r4.1 §5(d); architect plan #148 §3.7). This is the ONLY transport
+(SPEC r4.1 §5(d)). This is the ONLY transport
 primitive this skill may use for peer coordination. Do NOT import
 `@moltzap/app-sdk`, `@modelcontextprotocol/sdk`, `src/bridge.ts`, or
 `src/moltzap/*`; the grep-purity test

--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -68,7 +68,7 @@ You do not change exported signatures, add exported types the architect did not 
 When invoked inside a MoltZap-capable AO session (`AO_SESSION`,
 `MOLTZAP_LOCAL_SENDER_ID`, and `AO_CALLER_TYPE` are set), you MAY emit
 peer-channel events to other roster members via `safer-peer-message`
-(SPEC r4.1 §5(d); architect plan #148 §3.7). This is the ONLY transport
+(SPEC r4.1 §5(d)). This is the ONLY transport
 primitive this skill may use for peer coordination. Do NOT import
 `@moltzap/app-sdk`, `@modelcontextprotocol/sdk`, `src/bridge.ts`, or
 `src/moltzap/*`; the grep-purity test

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -67,7 +67,7 @@ You are explicitly allowed to: consolidate private helpers that the plan scatter
 When invoked inside a MoltZap-capable AO session (`AO_SESSION`,
 `MOLTZAP_LOCAL_SENDER_ID`, and `AO_CALLER_TYPE` are set), you MAY emit
 peer-channel events to other roster members via `safer-peer-message`
-(SPEC r4.1 §5(d); architect plan #148 §3.7). This is the ONLY transport
+(SPEC r4.1 §5(d)). This is the ONLY transport
 primitive this skill may use for peer coordination. Do NOT import
 `@moltzap/app-sdk`, `@modelcontextprotocol/sdk`, `src/bridge.ts`, or
 `src/moltzap/*`; the grep-purity test

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -68,7 +68,7 @@ Staff is allowed to: pick concrete libraries within a spec-authorized category, 
 When invoked inside a MoltZap-capable AO session (`AO_SESSION`,
 `MOLTZAP_LOCAL_SENDER_ID`, and `AO_CALLER_TYPE` are set), you MAY emit
 peer-channel events to other roster members via `safer-peer-message`
-(SPEC r4.1 §5(d); architect plan #148 §3.7). This is the ONLY transport
+(SPEC r4.1 §5(d)). This is the ONLY transport
 primitive this skill may use for peer coordination. Do NOT import
 `@moltzap/app-sdk`, `@modelcontextprotocol/sdk`, `src/bridge.ts`, or
 `src/moltzap/*`; the grep-purity test

--- a/skills/investigate/SKILL.md
+++ b/skills/investigate/SKILL.md
@@ -61,7 +61,7 @@ You do not edit source files. You do not commit. You do not open a PR. You read,
 When invoked inside a MoltZap-capable AO session (`AO_SESSION`,
 `MOLTZAP_LOCAL_SENDER_ID`, and `AO_CALLER_TYPE` are set), you MAY emit
 peer-channel events to other roster members via `safer-peer-message`
-(SPEC r4.1 §5(d); architect plan #148 §3.7). This is the ONLY transport
+(SPEC r4.1 §5(d)). This is the ONLY transport
 primitive this skill may use for peer coordination. Do NOT import
 `@moltzap/app-sdk`, `@modelcontextprotocol/sdk`, `src/bridge.ts`, or
 `src/moltzap/*`; the grep-purity test

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -63,7 +63,7 @@ You are a scrum master who reads `gh issue list` instead of a Jira board, and wh
 When invoked inside a MoltZap-capable AO session (`AO_SESSION`,
 `MOLTZAP_LOCAL_SENDER_ID`, and `AO_CALLER_TYPE` are set), you MAY emit
 peer-channel events to other roster members via `safer-peer-message`
-(SPEC r4.1 §5(d); architect plan #148 §3.7). This is the ONLY transport
+(SPEC r4.1 §5(d)). This is the ONLY transport
 primitive this skill may use for peer coordination. Do NOT import
 `@moltzap/app-sdk`, `@modelcontextprotocol/sdk`, `src/bridge.ts`, or
 `src/moltzap/*`; the grep-purity test
@@ -310,7 +310,7 @@ Dispatch via a team. First `TeamCreate` a team for the epic if one does not exis
 
 **Never dispatch via `Agent` without `team_name`.** Standalone subagents are fire-and-forget; teammates are the unit of orchestration. Teams provide shared task lists, peer DM, idle notifications to the team lead, and persistent config at `~/.claude/teams/<team-name>/`.
 
-**Always dispatch with `isolation: "worktree"`.** Default-on, not opt-in. Without it, every dispatched teammate inherits the orchestrator's working directory; concurrent implementers share a worktree and their `git checkout` commands stomp each other's branches (incident: 2026-04-30, sbd#240, moltzap-arena#198). Each teammate gets its own worktree; the harness cleans it up automatically when the agent exits without changes. Override only with explicit user authorization for a specific dispatch where shared state is required.
+**Always dispatch with `isolation: "worktree"`.** Default-on, not opt-in. Without it, every dispatched teammate inherits the orchestrator's working directory; concurrent implementers share a worktree and their `git checkout` commands stomp each other's branches. Each teammate gets its own worktree; the harness cleans it up automatically when the agent exits without changes. Override only with explicit user authorization for a specific dispatch where shared state is required.
 
 Teammate prompt template:
 
@@ -391,7 +391,7 @@ Scan the body for these four condition patterns. Any match blocks the merge:
    not-yet-met but acceptable to defer past this review, with a stated condition
    for closing the deferral: *"accept as DRAFT pending CI green"*, *"merge after
    the linked Linear ticket lands"*.
-4. **CI-pending verdicts (sbd#244)** — phrases like *"APPROVE-PENDING-CI"*,
+4. **CI-pending verdicts** — phrases like *"APPROVE-PENDING-CI"*,
    *"CI status: pending"*, *"CI status: failing"*. The reviewer ran the diff-static
    review but CI was not green at review time. The team-lead must withhold merge
    until CI clears (re-fetch `gh pr view --json statusCheckRollup`); on `failing`
@@ -607,7 +607,7 @@ Record the returned job id on the parent epic (comment) so the next operator can
 
 5. **Auto-gate + update epic progress.** For each sub-issue whose acceptance is mechanically verifiable (clean draft PR green on CI, review-ready comment matching the acceptance criterion, etc.), run **Step 5c.1 and Step 5c.2**: transition `review → plan-approved`, post the gating comment, close the sub-issue, then rewrite the parent epic's `## Progress` section. Skip the sub-issue when tests are red, CI is pending, or the acceptance artifact requires human judgment (any criterion the modality delegates to `/safer:review-senior`). Before any auto-gate transition fires, run **Step 5c.0** against the linked PR's reviewer body; skip the sub-issue if any of the four condition patterns matches.
 
-   **Implement-\* gate carries a mandatory verify dispatch (sbd#241).** For sub-issues with `safer:implement-*` modality, the auto-gate does NOT close at `plan-approved`. The full lifecycle is:
+   **Implement-\* gate carries a mandatory verify dispatch.** For sub-issues with `safer:implement-*` modality, the auto-gate does NOT close at `plan-approved`. The full lifecycle is:
 
    1. `review → plan-approved` (this auto-gate step) — review verdict accepted, PR is merge-ready.
    2. PR is merged (team-lead-driven, possibly user-authorized; not auto-merged by this loop).

--- a/skills/review-senior/SKILL.md
+++ b/skills/review-senior/SKILL.md
@@ -234,9 +234,9 @@ Classify the artifact per the inference rules above (or honour
 skill set in a comment on the artifact thread; that comment is the
 audit trail even if the dispatch itself fails.
 
-### Phase 1a — CI status gate (PR mode only; sbd#244)
+### Phase 1a — CI status gate (PR mode only)
 
-> **For PR-kind artifacts: CI must be green before any APPROVE verdict.** Diff-static review (this skill, `/codex review`, `/simplify`, `/review`) is blind to runtime regressions; CI is the runtime check. Real incident: moltzap PR #295 passed three diff-static reviewers but had 5 red CI tests because a Stream/Fiber refactor turned `client.close()` async.
+> **For PR-kind artifacts: CI must be green before any APPROVE verdict.** Diff-static review (this skill, `/codex review`, `/simplify`, `/review`) is blind to runtime regressions; CI is the runtime check. Real incident: a PR passed three diff-static reviewers but had 5 red CI tests because a Stream/Fiber refactor turned `client.close()` async.
 
 ```bash
 PR_NUMBER=$(echo "$ARTIFACT" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+')

--- a/skills/safer-docs-reader/SKILL.md
+++ b/skills/safer-docs-reader/SKILL.md
@@ -37,9 +37,9 @@ Read `PRINCIPLES.md` at the plugin root before invoking this skill. The projecti
 - **Principle 6 (Budget Gate).** One artifact per run. One team per run. N=3 rounds maximum. Round 3 requires explicit user approval. No exceptions.
 - **Principle 7 (Brake).** Any persona reporting "I needed context outside the artifact" is the iron rule firing. That is the finding, not an error.
 
-## Invariants (from sbd#125 §4)
+## Invariants
 
-These are the spec invariants this skill enforces. Every reference to `Invariant §4.N` in the prose below resolves here.
+These are the spec invariants this skill enforces. Every reference to `Invariant §N` in the prose below resolves here.
 
 1. **One skill.** No new per-persona skill directories. A persona is a prompt file plus an ephemeral sub-agent.
 2. **Ephemeral sub-agents.** A persona sub-agent exists for exactly one feedback pass; its team is deleted at run end on every exit path.
@@ -117,7 +117,7 @@ If the invocation did not specify `--issue`, `--pr`, or `--file`, ask. No artifa
 - Opening a PR with suggested rewrites.
 - Reading the surrounding project (sibling issues, related docs, source files) to enrich the persona payload.
 - Passing session history to the sub-agents. They run cold.
-- Inferring a score or severity a persona did not emit. The aggregator never introduces novel judgments (Invariant §4.5).
+- Inferring a score or severity a persona did not emit. The aggregator never introduces novel judgments (Invariant §5).
 - Dispatching personas via in-session `Skill` calls or standalone `Agent` without `team_name`. Team lifecycle is mandatory.
 - Running more than 3 rounds, or running round 3 without explicit user approval recorded at dispatch.
 - Shipping personas as separate skill directories. A persona is a prompt file plus a sub-agent, never a `skills/<persona>/SKILL.md`.
@@ -221,8 +221,8 @@ Agent({
 
 Invariants:
 
-- `team_name` is always set. Standalone `Agent` is forbidden (Invariant §4.3).
-- `model: "opus"` is always set (Invariant §4.3: opus orchestrator, opus personas).
+- `team_name` is always set. Standalone `Agent` is forbidden (Invariant §3).
+- `model: "opus"` is always set (Invariant §3: opus orchestrator, opus personas).
 - `description` is generic — it must not leak project identifiers into the sub-agent's bootstrap.
 - `name` is `persona-<slug>`, unique within the team; collisions fail the dispatch.
 
@@ -289,7 +289,7 @@ The aggregate report contains:
 - **Round 2** runs only on explicit user trigger: the user applies revisions to the artifact and re-invokes the skill (updating the issue/PR body or supplying `--file` with the revised path). The orchestrator re-reads the artifact payload at round start. **The orchestrator does not revise the artifact itself.** Round 2 re-runs the same 4 personas against the revised artifact. If round 1 ends with a non-empty must-fix list and the user does not re-invoke, the run ends with `DONE_WITH_CONCERNS` and the must-fix list is the hand-off.
 - **Round 3** runs only if `--allow-round-3` was passed at dispatch AND round 2's must-fix list is still non-empty. Absent `--allow-round-3`, round 2 is the last round; if the must-fix list is still non-empty, the run ends with `DONE_WITH_CONCERNS` and the caller routes upstream.
 
-Round limit is Invariant §4.4: the constant is fixed at N=3 and cannot be overridden without the explicit dispatch flag.
+Round limit is Invariant §4: the constant is fixed at N=3 and cannot be overridden without the explicit dispatch flag.
 
 ### Phase 8 — Publish + tear down
 
@@ -328,7 +328,7 @@ Tear down the team on every exit path — success, stop rule fired, crash handle
 TeamDelete({ team_name: "$TEAM_NAME" })
 ```
 
-Invariant §4.2: the team is ephemeral; it does not outlive the run.
+Invariant §2: the team is ephemeral; it does not outlive the run.
 
 ### Phase 9 — Close out
 
@@ -407,13 +407,13 @@ One status marker on the last line of the final reply.
 
 - **"I'll pass the parent epic alongside the artifact so the personas have context."** Iron rule violation. Context is the bug, not the fix.
 - **"One persona said REVISE, three said SHIP — call it SHIP."** No. A single BLOCK is must-fix. Severity-weighted consensus is not majority vote.
-- **"Round 3 is right there; just run it."** `--allow-round-3` is the gate, not a suggestion. Running round 3 without the flag is an Invariant §4.4 violation.
-- **"I'll re-word the persona's FRICTION finding so it's clearer."** No. The aggregator relays persona text verbatim. Rewording is inventing judgments the persona did not emit (Invariant §4.5).
+- **"Round 3 is right there; just run it."** `--allow-round-3` is the gate, not a suggestion. Running round 3 without the flag is an Invariant §4 violation.
+- **"I'll re-word the persona's FRICTION finding so it's clearer."** No. The aggregator relays persona text verbatim. Rewording is inventing judgments the persona did not emit (Invariant §5).
 - **"Two personas disagreed — I'll pick the more experienced persona's side."** No. Direct contradictions are `ESCALATED`. The user resolves.
 - **"I'll add a 5th persona `non-engineer-pm` since the spec mentioned it."** Spec Q1 defaulted to 4 personas for v1. Adding a 5th is a new spec, not a staff call.
 - **"The team cleanup failed — I'll leave it; the next run will collide."** No. Team lifecycle is mandatory. If `TeamDelete` fails, escalate with cause `TEAM_TEARDOWN_FAILED`.
 - **"The artifact scope is obvious; skip fetch, just hand the personas the file path."** No. Personas read cold. They read the payload, not a path.
-- **"I'll invoke the persona via in-session Skill instead of Agent — easier."** Invariant §4.3 violation. Personas are out-of-session sub-agents; in-session Skill leaks the caller's context.
+- **"I'll invoke the persona via in-session Skill instead of Agent — easier."** Invariant §3 violation. Personas are out-of-session sub-agents; in-session Skill leaks the caller's context.
 
 ## Checklist before declaring status
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -178,9 +178,9 @@ Do not attempt the migration yourself. That belongs to the user's judgement abou
 
 **Else (clean slate):** proceed to Step 0b.
 
-### Step 0b: Pin the package-manager toolchain (mandatory; sbd#142)
+### Step 0b: Pin the package-manager toolchain (mandatory)
 
-Lockfile drift between local and CI is a recurring debt pattern (incident: zap#130, three CI-vs-local `bun.lock` mismatch cycles caused by local `bun` and CI `setup-bun@latest` diverging). The fix is to pin the toolchain version in `package.json` `packageManager` field from commit one. Setup writes that field if `package.json` exists.
+Lockfile drift between local and CI is a recurring debt pattern: three CI-vs-local `bun.lock` mismatch cycles caused by local `bun` and CI `setup-bun@latest` diverging. The fix is to pin the toolchain version in `package.json` `packageManager` field from commit one. Setup writes that field if `package.json` exists.
 
 Idempotent: skip if `packageManager` is already set (any value — do not overwrite the user's choice).
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -52,7 +52,7 @@ You do not skip questions. Every ambiguity you notice is named and either resolv
 When invoked inside a MoltZap-capable AO session (`AO_SESSION`,
 `MOLTZAP_LOCAL_SENDER_ID`, and `AO_CALLER_TYPE` are set), you MAY emit
 peer-channel events to other roster members via `safer-peer-message`
-(SPEC r4.1 §5(d); architect plan #148 §3.7). This is the ONLY transport
+(SPEC r4.1 §5(d)). This is the ONLY transport
 primitive this skill may use for peer coordination. Do NOT import
 `@moltzap/app-sdk`, `@modelcontextprotocol/sdk`, `src/bridge.ts`, or
 `src/moltzap/*`; the grep-purity test

--- a/skills/stamina/SKILL.md
+++ b/skills/stamina/SKILL.md
@@ -175,9 +175,9 @@ Emit `safer.stamina_gate` at start with the chosen N, N-source (`table` | `user-
 
 ## Workflow
 
-### Phase 0 — CI status gate (PR mode only; sbd#244)
+### Phase 0 — CI status gate (PR mode only)
 
-> **CI must be green on the PR head before any aggregate APPROVE verdict.** Diff-static reviewers (`/safer:review-senior`, `/codex review`, `/simplify`) are blind to runtime regressions; CI is the runtime check. Real incident: moltzap PR #295 passed N=3 stamina with green diff-static review but had 5 red CI tests from a Stream/Fiber refactor.
+> **CI must be green on the PR head before any aggregate APPROVE verdict.** Diff-static reviewers (`/safer:review-senior`, `/codex review`, `/simplify`) are blind to runtime regressions; CI is the runtime check. Real incident: a PR passed N=3 stamina with green diff-static review but had 5 red CI tests from a Stream/Fiber refactor.
 
 ```bash
 [ "$MODE" = "pr" ] || skip_phase_0=1   # plan-mode skips this phase


### PR DESCRIPTION
## Why

Inline `(sbd#NNN)`, `moltzap PR #NNN`, `zap#NNN`, `architect plan #148` provenance citations don't belong in `skills/*/SKILL.md` runtime doctrine. They add visual noise, force the reader to context-switch on unfamiliar shorthand, and rot as numbering changes across forks/migrations. The rule is what matters; provenance lives in commit messages and PR bodies.

Companion to PR #269 (which strips refs from the implement-* forbidden-paths block as part of the #261 fix).

## Sweep

| File | Change |
|---|---|
| `review-senior/SKILL.md` | Drop `(PR mode only; sbd#244)`; rephrase `moltzap PR #295` incident as `a PR` |
| `stamina/SKILL.md` | Same as above |
| `setup/SKILL.md` | Drop `(mandatory; sbd#142)` + `(incident: zap#130, ...)` parenthetical |
| `safer-docs-reader/SKILL.md` | Drop `(from sbd#125 §4)` heading anchor; renumber inline `Invariant §4.N` → `Invariant §N` to match local 1-7 numbering |
| `orchestrate/SKILL.md` | Drop `(incident: 2026-04-30, sbd#240, moltzap-arena#198)`; `(sbd#244)` CI-pending parenthetical; `(sbd#241)` verify-dispatch parenthetical |
| `architect`, `spec`, `investigate`, `orchestrate`, `implement-{junior,senior,staff}` | Strip `; architect plan #148 §3.7` from MoltZap peer-channel preamble (keep `SPEC r4.1 §5(d)` — versioned spec doc, not an issue) |

## Kept on purpose

- `Invariant §N` style (in-file section refs are navigation aids, not external provenance — user explicitly preferred this form)
- `SPEC r4.1 §5(d)` (versioned spec doc, not an issue/PR number)
- `orchestrate/SKILL.md:270` `#5, PR #12 are invalid` (teaching anti-format)
- `orchestrate/SKILL.md:469` `"PR #42 merged"` (example status-note format)

## Tests

- `bash tests/run-tests.sh` → 221 passed, 0 failed

## Confidence

HIGH — pure doctrine prose edits. No code paths, no test changes, no rule semantics changed (only attribution stripped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)