### PR TITLE
[impl-senior] (sbd#264) contracts: explicit autonomy grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased — Contracts: explicit autonomy grants
+
+Default state for the orchestrator and dispatching skills is no longer "all-stages-authorized." Every orchestration is now governed by a contract recorded on the parent epic body.
+
+- `PRINCIPLES.md`: new `## Contracts` section. Four-section format (Goal, Acceptance, Autonomy budget, Always-park), worked examples, lifecycle (dispatch → execution → amendment → stop → done), recommended `Always-park` defaults, ratchet-up always parks, doctrine SHA stamping.
+- `skills/orchestrate/SKILL.md`:
+  - New Phase 1a (Draft the contract). Parses user instruction into the four sections, names back, waits for `OK` before any decomposition.
+  - Phase 3 epic body template now requires `## Contract` and `## Contract history` sections.
+  - New Step 5c.-1 contract-budget check before any auto-transition. Out-of-budget next dispatch parks; ratchet-up always parks regardless of budget. Posts `## Awaiting amendment` block on the parked sub-issue.
+  - Phase 5d cron loop adds Step 1b (contract-comment scan): processes `OK`, `AMEND CONTRACT:`, `STOP CONTRACT:`, `REVISE:`, and 🛠️ reactions on the parent epic. Authorization gated on repo-collaborator status.
+  - New Step 5b (Live `## Status` rewrite). After every state change, rewrites the parent epic's `## Status` section so a cold-start reader sees current state at a glance.
+  - New Step 5c (wake-up digest). Posts a single consolidated digest comment when an autopilot run completes — "I went to bed; here's the night."
+- `docs/contracts/`: four worked-example contract templates (invitation, bug-fix-end-to-end, scrum-master-backlog, architect-and-stop) plus a README pointing at when to use each.
+- Per-skill changes: none. Skills publish artifacts cleanly; the contract check fires orchestrator-side. `safer-escalate --to <higher>` already declares ratchet-up; orchestrator's contract-budget check now reads it as park-mandatory.
+
 ## 0.1.4 — Composition cleanup; opus everywhere
 
 Tightens the per-skill `Composition with gstack` sections introduced in 0.1.3 and consolidates orchestrator dispatch on opus.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -501,6 +501,166 @@ Every skill's final output carries exactly one status marker. Artifacts without 
 
 ---
 
+## Contracts
+
+*Autonomy is granted, not assumed.*
+
+Default state for the orchestrator and every dispatching skill is NOT autonomous. The user's instruction defines what the orchestrator may execute without further confirmation. Skills stay inside the granted scope; crossing the boundary requires explicit re-authorization.
+
+Every orchestration is governed by a **contract** recorded on the parent epic body. The contract is the deal between user and orchestrator. The orchestrator may take any action consistent with the contract; anything inconsistent parks for amendment.
+
+### The four sections
+
+A contract has exactly four parts. Skills load and parse these.
+
+```markdown
+## Contract
+
+**Goal.** <one paragraph: what we're building>
+
+**Acceptance.**
+- [ ] <checklist item: when this is done>
+
+**Autonomy budget.**
+- <permission: what I may do without asking>
+
+**Always-park.**
+- <carve-out: what I must ask about regardless>
+
+Doctrine: <SHA of PRINCIPLES.md at OK time>
+Drafted: <ISO timestamp>
+By: <user@github>
+```
+
+The four sections are doctrine. Drafts that omit any section are malformed; orchestrator parses and rejects with a structured error.
+
+### Worked example — bug fix end-to-end
+
+User instruction: *"fix the day_vote bug end-to-end overnight"*. Orchestrator drafts and names back; user replies `OK`:
+
+```markdown
+## Contract
+
+**Goal.** Fix the day_vote phase regression so DAY_VOTE exits on quorum reached, in the running game and in tests.
+
+**Acceptance.**
+- [ ] Reproducible failure case is fixed (regression test added).
+- [ ] Existing tests stay green.
+- [ ] PR merged to main, dogfood reachable.
+
+**Autonomy budget.**
+- Dispatch /safer:investigate, /safer:implement-junior, /safer:review-senior, /safer:verify in that order.
+- Open draft PRs.
+- Run lint, typecheck, tests; iterate until green.
+- Merge after peer review green AND CI green AND verify SHIP.
+
+**Always-park.**
+- Ratchet-up (investigate→spec, investigate→architect): the original assumption was a routine fix; ratchet means it isn't.
+- Force-push, branch deletion, infra/CI/deploy edits.
+- Adding new sub-issues for follow-up bugs.
+- LOW-confidence root cause.
+- Three-strikes mis-scoping.
+
+Doctrine: <SHA>
+Drafted: 2026-05-04T18:00Z
+By: chughtapan
+```
+
+### Worked example — invitation (dialog only)
+
+User instruction: *"look into the latency on the dashboard route"*. Orchestrator drafts:
+
+```markdown
+## Contract
+
+**Goal.** Understand the source of latency on the dashboard route.
+
+**Acceptance.**
+- [ ] /safer:investigate writeup published with two-layer root cause.
+- [ ] Recommendation routed to user for next-step decision.
+
+**Autonomy budget.**
+- Dispatch /safer:investigate.
+- Read code, run reproductions, examine logs.
+
+**Always-park.**
+- Any modality dispatch beyond investigate.
+- Any code edit.
+- Opening any PR.
+
+Doctrine: <SHA>
+Drafted: <ts>
+By: <user>
+```
+
+After investigate publishes, orchestrator asks what autonomy to grant for any fix. Without that re-authorization, the chain stops.
+
+### Recommended Always-park defaults
+
+Every contract should include these unless the contract explicitly opts out (sandbox repos may opt out of force-push restrictions, etc.):
+
+- Force-push to any branch.
+- Branch deletion.
+- Merging to `main` / `master` / `production` (unless the budget explicitly authorizes merge after peer review + CI + verify).
+- Schema migrations (DROP, destructive ALTER).
+- Mass deletion (>20 files or >500 LOC in one diff).
+- Production deploys.
+- Posting outside the repo (Slack, email, external API).
+- Token / secret operations.
+- Operations marked `careful` by the user's `/careful` skill setup.
+
+These defaults exist because **the asymmetric-cost framing applies**: a wrong autonomous action burns trust and may be irreversible; a wrong park costs one comment. When two interpretations are equally plausible, pick the one with the cheaper undo.
+
+### Lifecycle
+
+**Dispatch.** User sends instruction. Orchestrator parses into a draft contract, posts it to the parent epic, names it back. User confirms (`OK`) or amends (`AMEND CONTRACT: <change>`). Final contract is recorded as `## Contract` on the parent epic body. Execution begins.
+
+If parsing fails or confidence is LOW, the orchestrator asks before drafting; presents 2–3 candidate contract shapes with the most-conservative as recommended default.
+
+**Execution.** At every skill's DONE state, the skill loads the parent epic, reads `## Contract`, identifies the next dispatch the orchestrator would do. If the next dispatch is in the autonomy budget AND not a ratchet-up, transition normally. Otherwise, park: append `## Awaiting amendment` to the artifact body, set sub-issue label to `awaiting-amendment`, return `DONE_PARKED`.
+
+**Amendment.** User comments `AMEND CONTRACT: <change>` (or reacts 🛠️ to a park comment to open a structured dialog). Orchestrator updates the contract body, appends to `## Contract history`, transitions the parked sub-issue label, resumes the chain.
+
+**Stop.** User comments `STOP CONTRACT: <reason>` to halt immediately. Cron tick pauses every in-flight teammate via SendMessage and sets sub-issues to `paused`. No auto-revert; user manually amends or abandons.
+
+**Done.** Contract is satisfied = every Acceptance checkbox is checked = epic transitions to `completed`.
+
+### Ratchet-up always parks
+
+When a downstream modality discovers it must escalate to a higher modality (Principle 8 Ratchet — investigate → spec, architect → spec, implement-* → architect), the original autonomy scope no longer applies. The user authorized X assuming X was the right shape; the ratchet is the system reporting "X is wrong, the right shape is bigger."
+
+Even when the higher modality is technically inside the granted budget, ratchet-up parks. The escalation artifact:
+
+1. Always sets the sub-issue label to `awaiting-amendment`, not the higher modality's `planning` label.
+2. Always appends the `## Awaiting amendment` block with `Reason for park: ratchet-up:<from>→<to>`.
+3. Never auto-dispatches the higher modality.
+
+The lost incident pattern is "investigator finds a spec gap, ratchets to spec, spec revises, architect re-runs, implementation lands — and the user never saw that the spec changed underneath them." The user authorized a fix; what shipped was a spec rewrite. Ratchet-up parks.
+
+### Doctrine SHA stamping
+
+Every contract records the SHA of `PRINCIPLES.md` at OK time. In-flight contracts run against frozen doctrine; subsequent doctrine changes do not retroactively apply. This is reproducibility — any future agent reading the contract can `git checkout <sha>` to see exactly which doctrine governed it.
+
+When doctrine changes during an in-flight contract, the orchestrator may post an advisory comment naming the drift, but never auto-applies. User can opt in via amendment or stay frozen.
+
+### Stop-the-line conditions (separate from contract violations)
+
+These fire regardless of contract — *even within budget, this is wrong*:
+
+- Three-strikes mis-scoping (a sub-task re-triaged 3 times).
+- Confusion protocol (orchestrator can't proceed, doesn't know intent).
+- Peer-review disagreement (review-senior + codex split verdicts on PR).
+- Stamina returns BLOCK on a high-blast-radius artifact.
+- LOW-confidence on a non-junior recommendation.
+
+Each posts a stop-the-line comment to the parent epic and parks. Recovery is user comment with direction.
+
+### Cold-start readability
+
+A future agent picking up a parked epic with no session history reads `## Contract` and `## Awaiting amendment` and knows: what we're building (Goal), when it's done (Acceptance), what's allowed (Autonomy budget), what's never allowed (Always-park), why we're parked (Awaiting amendment, Reason), what user-action would unblock it (recommended action in the park). No git log archeology. No conversation reconstruction. The thread is self-contained.
+
+---
+
 ## Composing with gstack
 
 safer is the SDS modality spine. gstack is a parallel toolbox of interactive workflow skills. They coexist; composition happens at the modality dispatch seam. Each safer skill body names its own composition targets — there is no central routing table to read.

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -1,0 +1,19 @@
+# Contract examples
+
+Worked contract templates for common dispatch shapes. Each example is a real `## Contract` section as it would appear on a parent epic body — copy, adapt, post.
+
+The four-section format is doctrine (`PRINCIPLES.md → Contracts`). These examples show what the sections look like in practice for the dispatch patterns that come up most.
+
+| File | Shape | When to use |
+|---|---|---|
+| [`invitation.md`](./invitation.md) | dialog only | Vague intent; you want to think it through before any execution. |
+| [`bug-fix-end-to-end.md`](./bug-fix-end-to-end.md) | investigate → impl → review → verify → merge | A reproducible bug; you want the chain to ship the fix while you sleep. |
+| [`scrum-master-backlog.md`](./scrum-master-backlog.md) | per-sub-issue execution against an existing epic | A decomposed epic exists; the orchestrator works the backlog without adding scope. |
+| [`architect-and-stop.md`](./architect-and-stop.md) | spec → architect; stop before implement | Spec is settled; you want to read the architect plan before authorizing implementation. |
+
+Two patterns recur across all examples:
+
+- **`Always-park` always includes ratchet-up.** When a downstream modality discovers it needs to escalate (investigate→spec, architect→spec, implement-*→architect), the original contract's assumption was wrong. Always parks for amendment.
+- **`Always-park` always includes the irreversible-action defaults.** Force-push, branch deletion, schema migrations, prod deploys, secret operations, external posts. Even when the budget authorizes "merge", these specific actions still park.
+
+When in doubt, copy [`bug-fix-end-to-end.md`](./bug-fix-end-to-end.md) and trim. It's the most common shape.

--- a/docs/contracts/architect-and-stop.md
+++ b/docs/contracts/architect-and-stop.md
@@ -1,0 +1,48 @@
+# Architect and stop
+
+**When.** The spec is settled (either user-authored or already published). You want to see the architect plan before authorizing implementation.
+
+**User instruction looks like:**
+
+- "architect this spec"
+- "lay out the modules; I'll decide on impl after"
+- "design the shape; stop before any code"
+
+**Granted scope.** A single `/safer:architect` dispatch against an existing spec. The architect publishes its design doc + interface stubs. The chain stops there; orchestrator asks the user what to authorize for implementation.
+
+## Contract
+
+**Goal.** Produce an architect design doc + interface stubs that satisfy the spec at <https://github.com/OWNER/REPO/issues/198#issuecomment-XXX>.
+
+**Acceptance.**
+- [ ] Architect design doc published as a comment on this epic, with all 8 sections filled.
+- [ ] Stub branch + draft PR opened with `[arch]` title prefix.
+- [ ] User-facing summary posted on this epic with "ready for review."
+
+**Autonomy budget.**
+- Dispatch `/safer:architect`.
+- Open one draft PR for the architect's stub branch (no merge).
+- Run `/codex` on the published design doc (architect-internal review-after gate).
+
+**Always-park.**
+- Ratchet-up to spec (architect found a spec gap): the spec is the user's contract; revising it requires their authorization.
+- Any implement-* dispatch.
+- Merging the architect's stub PR.
+- Force-push, branch deletion, infra/CI/deploy edits.
+- Schema migrations, prod deploys, secret operations.
+- Posting outside the repo.
+
+Doctrine: `<SHA>`
+Drafted: `<ts>`
+OK'd: `<ts>` by `<user@github>`
+
+## What happens after the architect publishes
+
+Orchestrator posts: "Architect plan published at `<URL>`. What autonomy do you want to grant for implementation?" Common follow-ups:
+
+- `AMEND CONTRACT: extend to implement-senior + review-senior + verify + merge` — autonomous build against the plan.
+- `AMEND CONTRACT: extend to implement-senior + stop after PR opened` — see the diff before merging.
+- `AMEND CONTRACT: ratchet back to spec; the plan revealed a gap` — re-open the spec dialog.
+- `STOP CONTRACT: I'll dispatch impl in a separate epic` — close this epic; the architect plan is the deliverable.
+
+This shape is the natural midpoint between [`invitation.md`](./invitation.md) (dialog only, no execution) and [`bug-fix-end-to-end.md`](./bug-fix-end-to-end.md) (full autonomy through merge). Pick it when the design choices are load-bearing enough that you want to read them before the implementation depends on them.

--- a/docs/contracts/bug-fix-end-to-end.md
+++ b/docs/contracts/bug-fix-end-to-end.md
@@ -1,0 +1,45 @@
+# Bug fix end-to-end
+
+**When.** A reproducible bug is filed. You want the orchestrator to investigate, fix, verify, and merge — without pinging you on routine progress. Most common dispatch shape.
+
+**User instruction looks like:**
+
+- "fix the day_vote bug end-to-end"
+- "fix this regression overnight"
+- "investigate and ship the fix"
+
+**Granted scope.** Investigate → implement-junior → review-senior → verify → merge. The chain runs autonomously; the orchestrator pings only on `Always-park` hits or ratchet-up.
+
+## Contract
+
+**Goal.** Fix the day_vote phase regression so DAY_VOTE exits on quorum reached, in the running game and in tests.
+
+**Acceptance.**
+- [ ] Reproducible failure case is fixed (regression test added).
+- [ ] Existing tests stay green.
+- [ ] PR merged to `main`, dogfood reachable.
+
+**Autonomy budget.**
+- Dispatch `/safer:investigate`, `/safer:implement-junior`, `/safer:review-senior`, `/safer:verify` in that order.
+- Open draft PRs.
+- Run lint, typecheck, tests; iterate until green.
+- Merge after peer review green AND CI green AND verify SHIP.
+
+**Always-park.**
+- Ratchet-up (investigate→spec, investigate→architect, implement-junior→architect): the original assumption was a routine fix; ratchet means it isn't.
+- Force-push, branch deletion, infra/CI/deploy edits.
+- Adding new sub-issues for follow-up bugs surfaced during investigation.
+- LOW-confidence root cause.
+- Three-strikes mis-scoping.
+- Schema migrations, prod deploys, secret operations.
+- Posting outside the repo.
+
+Doctrine: `<SHA>`
+Drafted: `<ts>`
+OK'd: `<ts>` by `<user@github>`
+
+## Common variants
+
+- **Strict-merge gate.** Add `Always-park: Merging the final PR (require explicit OK before merge)`. The chain runs autonomously through verify, then parks. Use when you want to read the diff yourself before it lands.
+- **Restore-don't-rebuild.** When the bug is a regression in code that was working, the investigate writeup will recommend "restore pre-refactor behavior" routed to `implement-junior`. The contract above already handles this — `implement-junior` is in the budget. No changes needed; the recommendation flows through.
+- **Sleep mode.** When dispatched late in the day with "by morning" framing, the orchestrator runs in digest-notification mode (one wake-up summary at end of session) instead of milestone notifications. No contract change; just an `Autonomy budget` line: `Notification mode: digest-on-completion`.

--- a/docs/contracts/invitation.md
+++ b/docs/contracts/invitation.md
@@ -1,0 +1,48 @@
+# Invitation — dialog only
+
+**When.** The user has a vague idea or open question. They want to think through the problem with the orchestrator before any code or design lands.
+
+**User instruction looks like:**
+
+- "look into the latency on the dashboard route"
+- "what would it take to support multi-region writes?"
+- "is this tractable?"
+- "check this out"
+
+**Granted scope.** A single `/safer:investigate` (or `/safer:spec` / `/safer:research` / `/safer:spike`) dispatch. Nothing downstream. After the artifact publishes, the orchestrator asks the user what to authorize next.
+
+## Contract
+
+**Goal.** Understand the source of latency on the dashboard route.
+
+**Acceptance.**
+- [ ] `/safer:investigate` writeup published with two-layer root cause (Immediate + Underlying).
+- [ ] Recommendation routed to the user for next-step decision.
+
+**Autonomy budget.**
+- Dispatch `/safer:investigate`.
+- Read code, run reproductions, examine logs.
+- Run `git log`, `git blame`, `git bisect` for regression diagnosis.
+
+**Always-park.**
+- Ratchet-up (any modality escalating upstream).
+- Any modality dispatch beyond `/safer:investigate`.
+- Any code edit on tracked files.
+- Opening any PR.
+- Force-push, branch deletion, infra/CI/deploy edits.
+- Schema migrations, prod deploys, secret operations.
+- Posting outside the repo (Slack, email, external API).
+
+Doctrine: `<SHA>`
+Drafted: `<ts>`
+OK'd: `<ts>` by `<user@github>`
+
+## What happens after publish
+
+After the investigate writeup lands, orchestrator posts a follow-up question: "Investigation done. What autonomy do you want to grant for the fix?" Options typically include:
+
+- `AMEND CONTRACT: extend to vp-engg through-merge` — autonomous fix end-to-end (see [`bug-fix-end-to-end.md`](./bug-fix-end-to-end.md)).
+- `AMEND CONTRACT: extend to architect → stop` — see the design before implementation (see [`architect-and-stop.md`](./architect-and-stop.md)).
+- `STOP CONTRACT: handing off to a human` — close the epic; investigation is the deliverable.
+
+The orchestrator never auto-advances from invitation; the user explicitly grants the next phase.

--- a/docs/contracts/scrum-master-backlog.md
+++ b/docs/contracts/scrum-master-backlog.md
@@ -1,0 +1,48 @@
+# Scrum-master backlog
+
+**When.** A parent epic already exists with a decomposition table of sub-issues. You want the orchestrator to drive each sub-issue to its planned exit state, without adding new work.
+
+**User instruction looks like:**
+
+- "process the open sub-issues on epic #198"
+- "work through the backlog"
+- "churn through these"
+
+**Granted scope.** Per-sub-issue planned exits. The orchestrator dispatches the modality each sub-issue specifies, runs the verify gate where the plan calls for it, and updates the parent's `## Progress` section. No new sub-issues, no decomposition-table edits.
+
+## Contract
+
+**Goal.** Drive each open sub-issue on epic <https://github.com/OWNER/REPO/issues/198> to its planned exit state per the decomposition table.
+
+**Sub-issues in scope (8):**
+- #200, #201, #205, #207, #208, #211, #214, #218.
+- Anything not currently in the decomposition table is out of scope.
+
+**Acceptance.**
+- [ ] Each in-scope sub-issue closed at its planned state (per the table's "Acceptance" column).
+- [ ] Parent epic's `## Progress` section reflects all closures.
+
+**Autonomy budget.**
+- Dispatch the modality each sub-issue's label specifies.
+- Run the verify gate when the sub-issue's plan calls for it.
+- Update the parent epic's `## Progress` section after each close.
+- Merge implement-* PRs after their planned review chain passes.
+
+**Always-park.**
+- Adding a new sub-issue (even a follow-up surfaced by investigate or impl).
+- Editing the decomposition table (adding rows, changing dependency order, changing acceptance criteria).
+- Ratchet-up from any sub-issue.
+- Three-strikes on any sub-issue.
+- Force-push, branch deletion, infra/CI/deploy edits.
+- Schema migrations, prod deploys, secret operations.
+- Posting outside the repo.
+
+Doctrine: `<SHA>`
+Drafted: `<ts>`
+OK'd: `<ts>` by `<user@github>`
+
+## What this contract is for
+
+Scrum-master is the tightest of the common shapes. The decomposition table is the contract; the orchestrator's job is to execute it faithfully. Anything that would expand the backlog parks for explicit user authorization — the user retains exclusive say over what counts as "in this epic."
+
+Compare with [`bug-fix-end-to-end.md`](./bug-fix-end-to-end.md), where the budget is shape-defined ("any modality in this chain"); here the budget is enumeration-defined ("these 8 specific sub-issues, period").

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -187,6 +187,60 @@ When in doubt, ask the user:
 
 Emit `safer.skill_run` with `modality=orchestrate` only if you proceed.
 
+### Phase 1a — Draft the contract (mandatory)
+
+Once you've decided to orchestrate, draft the contract before any decomposition or sub-issue creation. The contract is the load-bearing artifact; everything downstream reads it.
+
+Read `PRINCIPLES.md → Contracts` for the four-section format, the worked examples, and the recommended `Always-park` defaults.
+
+**Parse the user's instruction into a draft.** Map intent to:
+
+- **Goal** — restate the user's intent in one paragraph. Use their words where possible.
+- **Acceptance** — convert "done" signals from the instruction into a checklist. If the instruction names a deliverable (PR merged, dogfood green, spec published), that's an item. If acceptance is implicit, ask once before drafting; do not invent criteria.
+- **Autonomy budget** — list the modality dispatches, label transitions, and merge/deploy permissions the instruction authorizes. Default to the most-conservative reading. "Fix this bug" with no other qualifier authorizes investigate + implement-junior + review-senior + verify; merge requires explicit authorization in the instruction.
+- **Always-park** — start from the recommended defaults in `PRINCIPLES.md → Contracts`. Add ratchet-up as a default park reason. Add any irreversible action the instruction implies the user cares about.
+
+**Confidence gate.** If parsing leaves you unsure on any of the four sections, present 2–3 candidate contract shapes to the user via `AskUserQuestion`, recommended-default first. Do NOT silently pick a shape; the asymmetric cost framing favors over-asking. A wrong autonomous draft burns trust; a wrong question costs one reply.
+
+**Name it back.** Post the draft as a comment on the parent epic (or, if the epic doesn't exist yet, in your reply to the user). Use this template:
+
+```markdown
+## Contract (draft)
+
+**Goal.** <draft>
+
+**Acceptance.**
+- [ ] <draft item>
+
+**Autonomy budget.**
+- <draft permission>
+
+**Always-park.**
+- Ratchet-up (any modality escalating upstream)
+- <recommended defaults from PRINCIPLES.md>
+- <any user-implied carve-out>
+
+Doctrine: <SHA of PRINCIPLES.md at draft time>
+Drafted: <ISO timestamp>
+By: <user@github>
+
+---
+
+Reply `OK` to proceed. Reply `AMEND CONTRACT: <change>` to revise. Reply `STOP CONTRACT: <reason>` to abort.
+
+If you do not reply, the chain does not advance.
+```
+
+**Wait for `OK` before any decomposition or sub-issue creation.** This is the gate. The orchestrator does not proceed without the contract being explicitly accepted.
+
+On `OK`, the contract becomes the parent epic's `## Contract` section (Phase 3) and the orchestrator continues to Phase 2.
+
+On `AMEND CONTRACT:`, redraft per the user's direction; post the revised draft; wait for `OK` again.
+
+On `STOP CONTRACT:`, abort orchestration. No epic is created. Tell the user the chain did not start.
+
+The contract MUST stamp the doctrine SHA at draft time (run `git rev-parse HEAD -- PRINCIPLES.md` against the safer-by-default repo, or the equivalent pointer the runtime exposes). Future agents reconstruct doctrine state from this.
+
 ### Phase 2 — Decompose
 
 Build the decomposition table. Columns:
@@ -234,6 +288,29 @@ Epic body template:
 - **Prior artifacts:** <bullet list of full URLs to every spec, issue, comment, PR, or doc this epic depends on. If none, write "none.">
 
 This section is the cold-start reader's anchor. A teammate opening this epic with zero session context must be able to start from here alone.
+
+## Contract
+
+**Goal.** <from Phase 1a draft, after user OK>
+
+**Acceptance.**
+- [ ] <from draft>
+
+**Autonomy budget.**
+- <from draft>
+
+**Always-park.**
+- Ratchet-up (any modality escalating upstream)
+- <recommended defaults>
+- <any user-implied carve-out>
+
+Doctrine: <SHA at OK time>
+Drafted: <ISO timestamp>
+OK'd: <ISO timestamp> by <user@github>
+
+## Contract history
+
+<empty until first amendment; each amendment appends an entry with timestamp + user + change>
 
 ## Decomposition
 
@@ -364,6 +441,46 @@ Then cascade forward per modality lifecycle:
 - `implement-*` → `plan-approved` → `implementing` (the PR is merged) → `verifying` (verify sub-task runs) → `done`.
 - `investigate` / `spike` / `research` → `plan-approved` → `done` (these produce writeups, not code).
 
+**Step 5c.-1 — Contract-budget check (mandatory; runs before everything else in this step).**
+
+Before any label transition or downstream dispatch, load the parent epic and read its `## Contract` section. The contract is the deal between user and orchestrator (`PRINCIPLES.md → Contracts`). The orchestrator may take any action consistent with the contract; anything inconsistent parks for amendment.
+
+```bash
+gh issue view "$PARENT" --json body --jq '.body' | awk '/^## Contract$/,/^## /{print}' | head -n -1 > /tmp/contract.md
+```
+
+Identify the next dispatch you would do (the next sub-issue's modality, the merge of a PR, the close of an epic). Three checks fire in order:
+
+1. **Is this a ratchet-up?** Did the upstream modality emit `safer-escalate --to <higher-modality>`? Ratchet-up always parks regardless of contract budget. Skip to the park procedure below.
+2. **Is the next dispatch in the autonomy budget?** Read the budget bullets. Match the proposed dispatch against them. If no bullet authorizes this action, park.
+3. **Is the next dispatch in `Always-park`?** Even if it's in the budget, if it's also in `Always-park`, the carve-out wins. Park.
+
+**On match → proceed.** Continue to Step 5c.0 (reviewer-body check). The contract authorizes this dispatch.
+
+**On park → halt this dispatch and append `## Awaiting amendment`.** The sub-issue stops at its current state; do not transition the label past `review`. Set sub-issue label to `awaiting-amendment` (in addition to its current label). Append this block to the sub-issue body:
+
+```markdown
+---
+
+## Awaiting amendment
+
+The next dispatch is outside the parent epic's `## Contract` autonomy budget.
+
+Recommended next: `<modality>`
+Reason for park: <out-of-budget | ratchet-up:<from>→<to> | always-park-hit:<which carve-out>>
+
+To amend the contract, comment on the parent epic:
+> AMEND CONTRACT: <change, e.g., "add architect to autonomy budget", "approve this specific merge">
+
+To revise this sub-issue's artifact instead, comment on this sub-issue:
+> REVISE: <reason>
+
+To stop the chain entirely, comment on the parent epic:
+> STOP CONTRACT: <reason>
+```
+
+Post a one-line status comment on the parent epic naming the parked sub-issue and the reason. Update the parent's `## Status` section (Step 5d.5 below). Do not re-park on subsequent ticks; the `awaiting-amendment` label is the idempotency key.
+
 **Step 5c.0 — Read reviewer body before merging.**
 
 Before transitioning a sub-issue out of `review` (`review → plan-approved` on the
@@ -371,7 +488,7 @@ manual path in Step 5c, or `review → plan-approved` on the auto-gate path in
 Phase 5d loop body item 5), team-lead MUST read the full reviewer body on
 GitHub. The teammate's `SendMessage` summary is a one-line compression; gating
 conditions live in the body, not in the summary. Acting on the summary alone is
-how the verify gate gets skipped (incident: 2026-04-19, acg#27).
+how the verify gate gets skipped.
 
 Fetch the most recent review body:
 
@@ -566,6 +683,34 @@ Record the returned job id on the parent epic (comment) so the next operator can
     - Never auto-respond. The Phase 5e protocol below defines the team-lead's response mechanisms; this step only surfaces the anomaly.
     - If `$SWARM_SOCKET` is empty (claude-swarm not running, or socket name changed upstream), log `swarm_socket_missing` and skip the step. Do not fall back to the `default` socket — that would scan the wrong panes.
 
+1b. **Contract-comment scan (mandatory).** Before any state-collection step, scan every parent epic this team owns for new contract-related comments since the last tick. Contract amendments must be applied first because they reshape the autonomy budget every other step reads.
+
+```bash
+for epic in $(jq -r '.epics[]?' ~/.claude/teams/<team-name>/config.json 2>/dev/null); do
+  # Fetch comments since last tick (cursor stored at ~/.claude/teams/<team-name>/contract-cursor-<epic>.txt)
+  CURSOR=$(cat ~/.claude/teams/<team-name>/contract-cursor-${epic//\//_}.txt 2>/dev/null || echo "1970-01-01T00:00:00Z")
+  gh issue view "$epic" --json comments --jq \
+    ".comments[] | select(.createdAt > \"$CURSOR\") | select(.author.login | IN(\$collaborators[]))" \
+    --argjson collaborators "$(gh api repos/$REPO/collaborators --jq '[.[].login]')" \
+    > /tmp/new-contract-comments.jsonl
+  date -u +%Y-%m-%dT%H:%M:%SZ > ~/.claude/teams/<team-name>/contract-cursor-${epic//\//_}.txt
+done
+```
+
+For each comment body, scan in priority order:
+
+   - **`STOP CONTRACT: <reason>`** — highest priority. Pause every in-flight teammate on this epic via SendMessage. Set every open sub-issue label to `paused`. Post a confirmation comment on the epic naming the stop reason and the user. Do not process subsequent steps for this epic on this tick. The user must comment `AMEND CONTRACT:` or `STOP CONTRACT: abandon` to either resume or close the chain.
+
+   - **`AMEND CONTRACT: <change>`** — read the change. Update the parent epic's `## Contract` section: re-derive Goal / Acceptance / Autonomy budget / Always-park reflecting the change. Append a new entry to `## Contract history` with the timestamp, user, and original comment URL. If the amendment unblocks a sub-issue currently labeled `awaiting-amendment`, remove that label so the next contract-budget check reads green. Post a confirmation comment on the epic naming what changed.
+
+   - **`OK`** — only meaningful on a draft contract that has not yet been recorded (Phase 1a awaiting confirmation). Move the draft contract from `## Contract (draft)` to `## Contract` with `OK'd: <ts> by <user>` line; create the parent-epic decomposition (Phase 2) and first sub-issues (Phase 4). Do not respond to `OK` after the contract is already recorded.
+
+   - **`REVISE: <reason>`** posted on a sub-issue (not the epic) — route per Phase 6 (Backtrack) back to the artifact's authoring modality with the user's revision note in the brief.
+
+   - **🛠️ reaction on a park comment** — detect via `gh api repos/$REPO/issues/$N/comments/$CID/reactions`. If a 🛠️ reaction was added since last tick from an authorized user, post a numbered-options comment offering the most-likely amendments derived from the park reason. The user replies with a number; the next tick's contract-comment scan picks up the reply, converts to canonical `AMEND CONTRACT: <change>`, applies, and removes the placeholder comment. The user-facing UX is reaction → reply with `1` (or `2`, etc.) → orchestrator amends. The audit trail records the canonical `AMEND CONTRACT:` entry.
+
+   Authorization: only repo collaborators can amend, stop, or OK. Comments matching the grammar from non-collaborators are surfaced to the team-lead via SendMessage but otherwise ignored.
+
 2. **Review-ready sub-issues.** `gh issue list --label review --json number,title,url,labels` for this repo. Any hit is a candidate for Step 5c.
 3. **Open PRs.** `gh pr list --json number,url,isDraft,mergeable,statusCheckRollup` to see which draft PRs are green.
    - **Linear project sync (if configured).** Run `safer-linear-setup assign-projects --since 5m --quiet` to backfill any issues filed in the last 5 minutes to their correct Linear project. Requires `LINEAR_API_KEY` env var; silently skips if not set.
@@ -625,6 +770,67 @@ Record the returned job id on the parent epic (comment) so the next operator can
    The failure mode this rule prevents: a teammate completes the assigned task, gets a clean APPROVE, the user moves on — and the friction the teammate hit recurs on every subsequent dispatch because no one ever named it. The orchestrator is the only seat that sees enough dispatches to spot the pattern; if the orchestrator buries it, no one fixes it.
 
    "Empty" (`Process issues: none`) is a valid value and not surfaced. The rule fires only on non-empty entries.
+
+5b. **Live `## Status` section rewrite (mandatory).** After every state-change in this tick (label transition, dispatch, contract amendment, park, stop), rewrite the parent epic's `## Status` section. The section is the cold-start reader's at-a-glance view; a fresh agent landing on the epic at any moment should read this section and know current state without scrolling comments.
+
+   Format:
+
+   ```markdown
+   ## Status
+
+   **Updated:** <ISO timestamp>
+
+   **Contract:** <one-line summary derived from Goal>; <budget summary, e.g., "investigate → impl-junior → review → verify → merge"> (`OK'd <ts>`).
+
+   **In flight:**
+   - #<N> <modality> — <state, e.g., "implementing">; teammate: <name>; PR: <url or none>.
+   - #<N> <modality> — <state>; teammate: <name>.
+
+   **Awaiting amendment:** <list of sub-issues labeled `awaiting-amendment`, with reason in one line each>; or "none".
+
+   **Last 3 actions:**
+   - <ts> dispatched <modality> on #<N>
+   - <ts> auto-gated #<N> review → plan-approved
+   - <ts> opened PR #<M> for #<N>
+
+   **Next action:** <what the next cron tick will do, in one line>.
+   ```
+
+   The section is replaced wholesale on every rewrite (no diff-merge complexity). Rewrite the parent epic body in place via `gh issue edit "$EPIC" --body "$NEW_BODY"`. Idempotency: if no state changed this tick, do not rewrite; the timestamp would change for nothing.
+
+5c. **Wake-up digest on autopilot completion.** When every sub-issue is in `done` or `abandoned` state AND the parent epic is in autopilot mode (the contract authorized merge without parking), post one consolidated digest comment on the epic before closing it. The digest is the user's "I went to bed; here's the night" artifact.
+
+   Digest template:
+
+   ```markdown
+   ## Wake-up digest
+
+   **Session:** <SESSION>
+   **Started:** <epic created ts> · **Finished:** <ts>
+   **Duration:** <human-readable>
+
+   **Contract goal.** <Goal from contract, one paragraph>
+
+   **What shipped.**
+   - <PR URL>: <one-line PR title> (verify: <SHIP|HOLD>)
+   - <PR URL>: <title> (verify: <verdict>)
+
+   **Contract events.**
+   - <ts> contract OK'd
+   - <ts> AMEND CONTRACT: <one-line change> by <user>
+   - <ts> sub-issue #<N> parked (reason: <one-line>); resumed <ts>
+   - <ts> wake-up digest
+
+   **Process issues seen.** <bulleted list of non-empty Process issues entries from teammate SendMessages, deduplicated; or "none">.
+
+   **Acceptance.**
+   - [x] <criterion> — <evidence URL>
+   - [x] <criterion> — <evidence URL>
+
+   **Health note.** <one line: any flake, transient infra, or recurring friction worth flagging next session; or "clean run">.
+   ```
+
+   Post once per epic; subsequent ticks read the existing digest comment and skip. Idempotency key: presence of a comment whose body starts with `## Wake-up digest` and matches this epic's session.
 
 6. **Auto-dispatch pending work (work-queue scan).** The prior steps react to state the loop already knows about. Step 6 is the proactive scan: enumerate pending sub-issues across every repo this team serves, filter out the ones that are already in flight, prioritize what is left, and dispatch up to the per-tick cap. Without this step the orchestrator idles between user prompts even when work is queued. Step 6 is mandatory once a team is installed.
 


### PR DESCRIPTION
Closes #264.

## Summary

Default state for the orchestrator is no longer "all-stages-authorized." Every orchestration is now governed by a **contract** recorded on the parent epic body. The contract is the deal between user and orchestrator: four sections (Goal / Acceptance / Autonomy budget / Always-park) that the orchestrator reads before any dispatch.

Solo-only scope per the locked plan in [#264](https://github.com/chughtapan/safer-by-default/issues/264#issuecomment-4369421324). Multi-user / multiplayer features are deferred to #272.

## What's in this PR

### Doctrine
- `PRINCIPLES.md` gains `## Contracts` top-level section. Four-section format, worked examples, lifecycle (dispatch → execution → amendment → stop → done), recommended `Always-park` defaults, ratchet-up always parks, doctrine SHA stamping.

### Orchestrate skill
- **Phase 1a** — Draft the contract. Parses user instruction into the four sections, names back, waits for `OK` before any decomposition or sub-issue creation.
- **Phase 3** — Epic body template requires `## Contract` and `## Contract history` sections.
- **Step 5c.-1** — Contract-budget check before any auto-transition. Out-of-budget next dispatch parks; ratchet-up always parks regardless of budget. Appends `## Awaiting amendment` to the parked sub-issue's body.
- **Phase 5d Step 1b** — Cron-side contract-comment scan. Processes `OK` / `AMEND CONTRACT:` / `STOP CONTRACT:` / `REVISE:` and 🛠️ reactions on the parent epic. Authorization gated on repo-collaborator status.
- **Phase 5d Step 5b** — Live `## Status` section rewrite. Cold-start visibility for any reader landing on the epic.
- **Phase 5d Step 5c** — Wake-up digest comment when an autopilot run completes.

### Worked examples
- `docs/contracts/{invitation, bug-fix-end-to-end, scrum-master-backlog, architect-and-stop}.md` — four contract templates.
- `docs/contracts/README.md` — when to use each.

## Per-skill changes: zero

Cleaner separation than the original plan suggested: skills publish artifacts; the contract check fires orchestrator-side. `safer-escalate --to <higher>` already declares ratchet-up; orchestrator's new contract-budget check reads it as park-mandatory.

## What's deferred

- 🛠️ reaction → live `AskUserQuestion` dialog (cron is non-interactive; this PR posts a numbered-options comment that the user replies to with a number, picked up by the next tick). Live dialog is a follow-up.
- Telemetry events (`contract.drafted`, `contract.ok`, ...) and weekly digest skill — punted for follow-up; the doctrine establishes the events conceptually but the wiring through `safer-telemetry-log` is a separate change.
- Structured error templates beyond what the contract-comment scan already handles (malformed-contract, amendment-conflict standalone helpers).
- Multiplayer addendum — #272.

## Tests

- `bash tests/run-tests.sh` → 221 passed, 0 failed.
- Doctrine-only repo; no code paths to add tests against.

## Confidence

HIGH on the doctrine and orchestrate Phase 1a / 3 / 5c.-1 — these are the load-bearing pieces and they're consistent with existing label-machine behavior.

MED on Step 1b cron scan — the bash sketch shows the shape but the actual implementation lives in the orchestrator's tick prompt. Real test is dispatching an epic and watching `AMEND CONTRACT:` round-trip on the next 2-min tick.

MED on Steps 5b/5c (status rewrite + digest) — same caveat; the doctrine names the behavior, the cron prompt is what executes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)