### PR TITLE
[impl-junior] Phase 5: PRINCIPLES.md absorbs shortcut phrases + voice

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -467,3 +467,37 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -501,6 +501,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -499,6 +499,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/docs-reader/SKILL.md
+++ b/skills/docs-reader/SKILL.md
@@ -500,6 +500,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/dogfood/SKILL.md
+++ b/skills/dogfood/SKILL.md
@@ -502,6 +502,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -501,6 +501,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -501,6 +501,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -500,6 +500,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -500,6 +500,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -502,6 +502,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/review-senior/SKILL.md
+++ b/skills/review-senior/SKILL.md
@@ -497,6 +497,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -505,6 +505,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -497,6 +497,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/spike/SKILL.md
+++ b/skills/spike/SKILL.md
@@ -498,6 +498,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/stamina/SKILL.md
+++ b/skills/stamina/SKILL.md
@@ -500,6 +500,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -500,6 +500,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/ux-audit/SKILL.md
+++ b/skills/ux-audit/SKILL.md
@@ -504,6 +504,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -498,6 +498,40 @@ Quality judgments are direct. *"This is a debt pattern."* *"This violates the Ra
 
 End with what to do. Every output names its status marker and, where applicable, the next action.
 
+When the output is code, the type system is the voice. A signature that encodes the constraint speaks louder than a comment that describes it. Prefer the signature.
+
+A comment explains a hidden constraint or a workaround, never the shape the reader can already see. *"This branch handles the legacy V1 envelope that pre-2024 clients still send"* is worth writing. *"This function parses JSON"* is not.
+
+The next agent touching the code is a junior. The type system is the document that junior reads first. Make it say the right thing.
+
+---
+
+## Phrases to reject
+
+The following phrases signal that a human-era shortcut is about to happen. Catch them when they appear in your own output or in the user's request. Pause. Rewrite toward the full version.
+
+- "This is just a prototype."
+- "Not worth it for MVP."
+- "We will add types later."
+- "We will add tests later."
+- "We will add validation later."
+- "Good enough for now."
+- "I will just cast it to `any`."
+- "I will just cast it to `unknown`."
+- "I will just cast it to `Record<string, unknown>`."
+- "Let me silence the linter for this one."
+- "The happy path is the important part."
+- "Users will pass the right shape; do not worry about malformed input."
+- "Do not over-engineer it."
+- "Let me stub this for now and come back to it."
+- "This is internal code, it does not need types."
+
+When the user is the one asking for the shortcut, surface the compression cost in concrete numbers. Something like:
+
+> That is (human: ~2 weeks / CC: ~30 min). The shortcut saves twenty-five minutes now and costs hours of debugging next sprint. Do you want the full version?
+
+Then defer to user sovereignty if they insist. Name exactly what is being skipped, file it as a TODO that references this skill, and proceed. Never silently skip.
+
 
 ## How this modality projects from the doctrine
 


### PR DESCRIPTION
Closes #285
Parent: chughtapan/agent-code-guard#71
Plan: https://gist.github.com/chughtapan/dd6eb6eba5da3c061dd98aedb6f46abb (Phase 5 section)

## What changed

`PRINCIPLES.md` absorbs two pieces of content from `skills/typescript/SKILL.tmpl` so they load via `{{> principles}}` in every skill, not only the TypeScript skill:

1. **New `## Phrases to reject` H2** placed after `## Write for the cold-start reader` in Part 4. Verbatim from the typescript skill: the shortcut-phrase list ("This is just a prototype.", "We will add types later.", etc.) plus the user-sovereignty deferral phrasing (the `(human: ~2 weeks / CC: ~30 min)` compression-cost framing and the "defer to user sovereignty if they insist...never silently skip" follow-up).
2. **Code-voice paragraphs merged into the existing `### Voice` subsection.** The typescript-skill framing ("This skill's output is code") is rephrased as "When the output is code" so the guidance applies to any code-producing skill while preserving the substance: signature over comment, why-comments only, the next reader is a junior.

Regenerated `bin/safer-gen-skills`; 17 SKILL.md files updated.

## Scope

- Module: `PRINCIPLES.md` (+ auto-regenerated `skills/*/SKILL.md`)
- Tier (intended): junior — doc-only fold
- New exported signatures: none
- New deps: none

## Hard constraint honored

Existing `## N. <title>` headings unchanged. The 8 principles (Types beat tests, Validate at every boundary, Errors are typed, Exhaustiveness over optionality, Discipline over capability, The Budget Gate, The Brake, The Ratchet) keep their slugs so Phase 2's `meta.docs.url` anchor derivation still resolves.

Out of scope per the plan: `skills/typescript/` (Phase 8 deletes the now-duplicated sections from the typescript template and fixes the `<!-- BEGIN: acg-mapping -->` table's broken anchors). Until Phase 8 lands, `skills/typescript/SKILL.md` carries each section twice — once from `{{> principles}}` and once from the still-unchanged TS template body. Expected.

## Acceptance

- [x] `PRINCIPLES.md` has `## Phrases to reject` between `## Write for the cold-start reader` and any closing sections, with the verbatim list + deferral phrasing.
- [x] `### Voice` content folded into Part 4 → Communication; no duplicate subsection added.
- [x] Existing `## N. <title>` headings NOT renumbered or renamed.
- [x] `bin/safer-gen-skills` runs clean (rendered 17 of 17 skills).
- [x] Draft PR titled `[impl-junior] Phase 5: PRINCIPLES.md absorbs shortcut phrases + voice` opened; PR body cites the plan gist + sub-issue.

## Pre-PR hygiene

- simplify: no findings (doc-only verbatim paste; no code logic, no duplications introduced).
- review: no findings (no existing principle heading renamed; merge content extends rather than duplicates; `---` separator before the new H2 matches the Part 4 convention; no bare `path:N` citations introduced).

## Confidence

HIGH — verbatim paste of an already-shipped list, plus a small portability rewording in the Voice fold (verified non-duplicate against the existing `### Voice` subsection). Regeneration confirms every skill renders cleanly.

## Process issues

none.