### PR TITLE
[impl-senior] Phase 6: sfd: tier-stratified decision tables in impl-*

### DIFF
--- a/skills/implement-junior/SKILL.md
+++ b/skills/implement-junior/SKILL.md
@@ -538,18 +538,102 @@ Then defer to user sovereignty if they insist. Name exactly what is being skippe
 
 ## How this modality projects from the doctrine
 
-- **Principle 1 (Types beat tests)** — you are not shipping a unit test when a branded type or discriminated union would make the bug unrepresentable. Check each constraint: does it belong in the type system?
+- **Principle 1 (Types beat tests)** — you are not shipping a unit test when a branded type or discriminated union would make the bug unrepresentable. Check each constraint: does it belong in the type system? The decision table below names the most common forks.
 - **Principle 2 (Validate at every boundary)** — inside the module, trust your types. At the boundary (disk, env, network, another package), decode with a schema.
 - **Principle 3 (Errors are typed, not thrown)** — tagged errors or discriminated results. No raw `throw new Error("bad")`. No `catch {}`. `Promise<T>` on a failing path is a bug by you.
 - **Principle 4 (Exhaustiveness over optionality)** — every switch ends in `default: return absurd(x)`. Every `Option`/`Either`/`Result.match` handles both branches.
 - **Principle 5 (Discipline over capability)** — you do one module. The instinct "while I'm here" is the stop rule.
 - **Principle 6 (Budget Gate)** — shape of change is the budget, not volume. 500 LOC in one module is fine. 2 LOC across two modules is not.
 
+## Decision table
+
+Every row below is a one-module fork where the agent feels pulled toward the human-era shortcut. Pick the agent-era full version. Each row corresponds to a Principle 1–4 decision that lives inside the module body junior owns.
+
+| Scenario | Human-era shortcut | Agent-era full version |
+|---|---|---|
+| Parsing an API response | `(await r.json()) as Record<string, unknown>` | `Schema.decodeUnknown(Body)(await r.json())` |
+| Parsing a JSON string | `JSON.parse(raw) as Payload` | `Schema.decodeUnknown(Payload)(JSON.parse(raw))` |
+| Function that can fail | `throw new Error("bad")` | `return yield* Effect.fail(new BadError({ cause }))` |
+| String union type | `row.status as "a" \| "b" \| "c"` | Import the generated `Status` union |
+| Error in try/catch | `try { op() } catch {}` | `Effect.try({ try: op, catch: e => new OpError({ cause: e }) })` |
+| Env var access | `process.env.FOO!` | Env schema parsed once at boot |
+| Async return type | `async f(): Promise<T>` | `(): Effect.Effect<T, E, R> => Effect.gen(...)` |
+| Identifier type | `string` | `UserId = string & { __brand: "UserId" }` |
+| Switch over union | `case "a": ... case "b": ...` | Final case returns `absurd(x)` where `absurd(x: never): never` |
+| Match chain | `Match.value(x).pipe(Match.when(...))` | Close with `Match.exhaustive` or `Match.orElse(...)` |
+| Throw in Effect code | `throw new Error("bad")` inside `Effect.gen` | `yield* Effect.fail(new TaggedError({ ... }))` |
+| Callback signature | `(x) => Promise<void> \| void` | `(x) => Effect.Effect<void, E>` |
+| Database query | `db.query("SELECT * FROM users WHERE id=?", [id])` | `kysely.selectFrom("users").where("id", "=", id).selectAll().execute()` |
+
+The compression math: each full version costs seconds more to type inside the module body. Each one removes one class of in-module runtime bug. The shortcut's savings compound into next-session debt the module owner has to walk back; the full version's savings compound into no-bug-ever.
+
 ## Iron rule
 
 > **If your diff touches a 2nd module, your stop rule has already fired. Do not "just touch one more file."**
 
 The second file is always the first warning. The instinct "it is one line, it is basically the same module, the test lives here anyway" is exactly the debt pattern Principle 6 exists to stop. Cross-module reach is a shape change. Escalate; do not rationalize.
+
+## Before and after examples
+
+Two Principle 1–4 forks from the decision table expanded to full before/after.
+
+**Parsing an HTTP response.**
+
+Before:
+```ts
+async function getUser(id: string): Promise<User> {
+  const r = await fetch(`/api/users/${id}`);
+  return (await r.json()) as User;
+}
+```
+
+After:
+```ts
+const getUser = (id: UserId): Effect.Effect<User, FetchError | DecodeError> =>
+  Effect.gen(function* () {
+    const r = yield* Effect.tryPromise({
+      try: (signal) => fetch(`/api/users/${id}`, { signal }),
+      catch: (cause) => new FetchError({ cause }),
+    });
+    const body = yield* Effect.tryPromise({
+      try: () => r.json(),
+      catch: (cause) => new DecodeError({ cause }),
+    });
+    return yield* Schema.decodeUnknown(User)(body);
+  });
+```
+
+The before has one `async`, one cast, and zero error types. The after has three typed errors, one schema boundary, and a cancellable `fetch`. Cost: eight extra lines for an agent; hours of debugging saved.
+
+**Exhaustive switch over a union.**
+
+Before:
+```ts
+type Status = "pending" | "active" | "done";
+function icon(s: Status): string {
+  switch (s) {
+    case "pending": return "pending";
+    case "active":  return "active";
+    case "done":    return "done";
+  }
+}
+```
+
+After:
+```ts
+type Status = "pending" | "active" | "done";
+const absurd = (x: never): never => { throw new Error(`unreachable: ${x}`); };
+function icon(s: Status): string {
+  switch (s) {
+    case "pending": return "pending";
+    case "active":  return "active";
+    case "done":    return "done";
+    default:        return absurd(s);
+  }
+}
+```
+
+Add a fourth value to `Status` and the after version turns `absurd(s)` into a compile error at this call site. The before version silently returns `undefined`.
 
 ## Forbidden paths
 
@@ -705,7 +789,7 @@ Write the function bodies. Apply the four craft principles at every decision.
 - Every switch over a union ends in `default: return absurd(x)`. Add `function absurd(x: never): never { throw new Error(\`unreachable: ${JSON.stringify(x)}\`); }` locally if one is not in scope. Prefer importing an existing one.
 - Every `Option`, `Either`, or `Result.match` handles both branches explicitly.
 
-When you are tempted to reach for `any`, `unknown`, `Record<string, unknown>`, `as T`, or `throw new Error(...)`: stop. Ask whether the constraint can live higher up. Usually it can.
+When you are tempted to reach for `any`, `unknown`, `Record<string, unknown>`, `as T`, or `throw new Error(...)`: stop. Consult the decision table above and write the agent-era full version of the matching row. If no row matches, the constraint may need to live higher up than this module; escalate via stop rule 8.
 
 **Comment audit (mandatory before moving on).** Re-read every comment you inserted into the diff. Strip any comment that:
 

--- a/skills/implement-junior/SKILL.tmpl
+++ b/skills/implement-junior/SKILL.tmpl
@@ -34,18 +34,102 @@ allowed-tools:
 
 ## How this modality projects from the doctrine
 
-- **Principle 1 (Types beat tests)** — you are not shipping a unit test when a branded type or discriminated union would make the bug unrepresentable. Check each constraint: does it belong in the type system?
+- **Principle 1 (Types beat tests)** — you are not shipping a unit test when a branded type or discriminated union would make the bug unrepresentable. Check each constraint: does it belong in the type system? The decision table below names the most common forks.
 - **Principle 2 (Validate at every boundary)** — inside the module, trust your types. At the boundary (disk, env, network, another package), decode with a schema.
 - **Principle 3 (Errors are typed, not thrown)** — tagged errors or discriminated results. No raw `throw new Error("bad")`. No `catch {}`. `Promise<T>` on a failing path is a bug by you.
 - **Principle 4 (Exhaustiveness over optionality)** — every switch ends in `default: return absurd(x)`. Every `Option`/`Either`/`Result.match` handles both branches.
 - **Principle 5 (Discipline over capability)** — you do one module. The instinct "while I'm here" is the stop rule.
 - **Principle 6 (Budget Gate)** — shape of change is the budget, not volume. 500 LOC in one module is fine. 2 LOC across two modules is not.
 
+## Decision table
+
+Every row below is a one-module fork where the agent feels pulled toward the human-era shortcut. Pick the agent-era full version. Each row corresponds to a Principle 1–4 decision that lives inside the module body junior owns.
+
+| Scenario | Human-era shortcut | Agent-era full version |
+|---|---|---|
+| Parsing an API response | `(await r.json()) as Record<string, unknown>` | `Schema.decodeUnknown(Body)(await r.json())` |
+| Parsing a JSON string | `JSON.parse(raw) as Payload` | `Schema.decodeUnknown(Payload)(JSON.parse(raw))` |
+| Function that can fail | `throw new Error("bad")` | `return yield* Effect.fail(new BadError({ cause }))` |
+| String union type | `row.status as "a" \| "b" \| "c"` | Import the generated `Status` union |
+| Error in try/catch | `try { op() } catch {}` | `Effect.try({ try: op, catch: e => new OpError({ cause: e }) })` |
+| Env var access | `process.env.FOO!` | Env schema parsed once at boot |
+| Async return type | `async f(): Promise<T>` | `(): Effect.Effect<T, E, R> => Effect.gen(...)` |
+| Identifier type | `string` | `UserId = string & { __brand: "UserId" }` |
+| Switch over union | `case "a": ... case "b": ...` | Final case returns `absurd(x)` where `absurd(x: never): never` |
+| Match chain | `Match.value(x).pipe(Match.when(...))` | Close with `Match.exhaustive` or `Match.orElse(...)` |
+| Throw in Effect code | `throw new Error("bad")` inside `Effect.gen` | `yield* Effect.fail(new TaggedError({ ... }))` |
+| Callback signature | `(x) => Promise<void> \| void` | `(x) => Effect.Effect<void, E>` |
+| Database query | `db.query("SELECT * FROM users WHERE id=?", [id])` | `kysely.selectFrom("users").where("id", "=", id).selectAll().execute()` |
+
+The compression math: each full version costs seconds more to type inside the module body. Each one removes one class of in-module runtime bug. The shortcut's savings compound into next-session debt the module owner has to walk back; the full version's savings compound into no-bug-ever.
+
 ## Iron rule
 
 > **If your diff touches a 2nd module, your stop rule has already fired. Do not "just touch one more file."**
 
 The second file is always the first warning. The instinct "it is one line, it is basically the same module, the test lives here anyway" is exactly the debt pattern Principle 6 exists to stop. Cross-module reach is a shape change. Escalate; do not rationalize.
+
+## Before and after examples
+
+Two Principle 1–4 forks from the decision table expanded to full before/after.
+
+**Parsing an HTTP response.**
+
+Before:
+```ts
+async function getUser(id: string): Promise<User> {
+  const r = await fetch(`/api/users/${id}`);
+  return (await r.json()) as User;
+}
+```
+
+After:
+```ts
+const getUser = (id: UserId): Effect.Effect<User, FetchError | DecodeError> =>
+  Effect.gen(function* () {
+    const r = yield* Effect.tryPromise({
+      try: (signal) => fetch(`/api/users/${id}`, { signal }),
+      catch: (cause) => new FetchError({ cause }),
+    });
+    const body = yield* Effect.tryPromise({
+      try: () => r.json(),
+      catch: (cause) => new DecodeError({ cause }),
+    });
+    return yield* Schema.decodeUnknown(User)(body);
+  });
+```
+
+The before has one `async`, one cast, and zero error types. The after has three typed errors, one schema boundary, and a cancellable `fetch`. Cost: eight extra lines for an agent; hours of debugging saved.
+
+**Exhaustive switch over a union.**
+
+Before:
+```ts
+type Status = "pending" | "active" | "done";
+function icon(s: Status): string {
+  switch (s) {
+    case "pending": return "pending";
+    case "active":  return "active";
+    case "done":    return "done";
+  }
+}
+```
+
+After:
+```ts
+type Status = "pending" | "active" | "done";
+const absurd = (x: never): never => { throw new Error(`unreachable: ${x}`); };
+function icon(s: Status): string {
+  switch (s) {
+    case "pending": return "pending";
+    case "active":  return "active";
+    case "done":    return "done";
+    default:        return absurd(s);
+  }
+}
+```
+
+Add a fourth value to `Status` and the after version turns `absurd(s)` into a compile error at this call site. The before version silently returns `undefined`.
 
 ## Forbidden paths
 
@@ -201,7 +285,7 @@ Write the function bodies. Apply the four craft principles at every decision.
 - Every switch over a union ends in `default: return absurd(x)`. Add `function absurd(x: never): never { throw new Error(\`unreachable: ${JSON.stringify(x)}\`); }` locally if one is not in scope. Prefer importing an existing one.
 - Every `Option`, `Either`, or `Result.match` handles both branches explicitly.
 
-When you are tempted to reach for `any`, `unknown`, `Record<string, unknown>`, `as T`, or `throw new Error(...)`: stop. Ask whether the constraint can live higher up. Usually it can.
+When you are tempted to reach for `any`, `unknown`, `Record<string, unknown>`, `as T`, or `throw new Error(...)`: stop. Consult the decision table above and write the agent-era full version of the matching row. If no row matches, the constraint may need to live higher up than this module; escalate via stop rule 8.
 
 **Comment audit (mandatory before moving on).** Re-read every comment you inserted into the diff. Strip any comment that:
 

--- a/skills/implement-senior/SKILL.md
+++ b/skills/implement-senior/SKILL.md
@@ -546,6 +546,31 @@ Then defer to user sovereignty if they insist. Name exactly what is being skippe
 - **Principle 6 (Budget Gate)** — shape is "multi-module refactor inside one feature area per the plan." New modules and new public contracts are out of scope.
 - **Principle 8 (The Ratchet)** — if the plan needs revision, ratchet back to architect. Never sideways: no boolean flags to patch a plan gap, no workarounds to avoid re-opening the architect step.
 
+The decision table below names the Effect-runtime and testing-strategy forks senior owns. Single-module Principle 1–4 forks live in `/safer:implement-junior`; cross-service contract and CI/mutation gating live in `/safer:implement-staff`.
+
+## Decision table
+
+Every row below is a cross-module fork where the agent feels pulled toward the human-era shortcut. Pick the agent-era full version. Each row corresponds to a runtime-wiring or testing-strategy decision that lives at the seam between modules — the wiring senior coordinates.
+
+| Scenario | Human-era shortcut | Agent-era full version |
+|---|---|---|
+| `Effect.tryPromise` catch | `catch: (err) => err` | `catch: (cause) => new TaggedError({ cause })` |
+| `fetch` inside `Effect.tryPromise` | `try: () => fetch(url, { ... })` | `try: (signal) => fetch(url, { signal, ... })` |
+| Resource in a class | `private ref = Effect.runSync(Ref.make(0))` | Build in `Layer.effect`; inject via constructor |
+| Module-load env read | `const FOO = process.env.FOO!` at top level | `Config.string("FOO")` inside a Layer |
+| Happy-path test | One test asserting success | Happy path, each error path, property-based where applicable |
+| Test double for an external service | `vi.mock("./stripe")` in integration test | Real stripe test mode, or a contract test against a recorded cassette |
+| Positive integer | `function (n: number)` with runtime check | `function (n: PositiveInt)` where `PositiveInt` is branded |
+| Non-empty array | `arr: T[]` with `if (arr.length === 0)` guard | `arr: NonEmptyArray<T>` |
+| Pure function with a nameable algebraic property (roundtrip, idempotence, invariant, oracle agreement) | One example-based happy-path test | Happy path + `fast-check` property encoding the invariant |
+| Pure function with no nameable algebraic property | "Write a property test; think of something" | Example tests covering boundary and each error path; skip property-based |
+| Parser or handler accepting untrusted external input | Example tests for three known-bad inputs | Example tests + `fast-check` property + `Jazzer.js` via `@jazzer.js/jest-runner` when the threat model includes adversarial input |
+| Parser with no adversarial threat model | Reach for `Jazzer.js` anyway | Example tests + `fast-check`; skip the fuzzer (Principle 6: compute is budget) |
+| Test for code that reads a real database | `vi.mock("pg")` or an in-memory stand-in | `testcontainers-node` + `@testcontainers/postgresql`, shared-per-suite lifecycle, dynamic ports |
+| Test for code that reads a real cache or queue | In-memory fake for redis/kafka/rabbitmq | `testcontainers-node` + `@testcontainers/redis` (or matching module); fake only behind a schema-checked contract |
+
+The compression math: each full version costs seconds more to wire at the seam. Each one removes one class of cross-module coordination defect or one class of false-confidence test that mocks the very boundary under test. The shortcut's savings compound into the next refactor finding two modules quietly disagreeing about the same shape; the full version's savings compound into seams the compiler keeps honest.
+
 ## Iron rule
 
 > **If you need to revise the plan, your stop rule has already fired. Escalate, do not revise.**

--- a/skills/implement-senior/SKILL.tmpl
+++ b/skills/implement-senior/SKILL.tmpl
@@ -42,6 +42,31 @@ allowed-tools:
 - **Principle 6 (Budget Gate)** — shape is "multi-module refactor inside one feature area per the plan." New modules and new public contracts are out of scope.
 - **Principle 8 (The Ratchet)** — if the plan needs revision, ratchet back to architect. Never sideways: no boolean flags to patch a plan gap, no workarounds to avoid re-opening the architect step.
 
+The decision table below names the Effect-runtime and testing-strategy forks senior owns. Single-module Principle 1–4 forks live in `/safer:implement-junior`; cross-service contract and CI/mutation gating live in `/safer:implement-staff`.
+
+## Decision table
+
+Every row below is a cross-module fork where the agent feels pulled toward the human-era shortcut. Pick the agent-era full version. Each row corresponds to a runtime-wiring or testing-strategy decision that lives at the seam between modules — the wiring senior coordinates.
+
+| Scenario | Human-era shortcut | Agent-era full version |
+|---|---|---|
+| `Effect.tryPromise` catch | `catch: (err) => err` | `catch: (cause) => new TaggedError({ cause })` |
+| `fetch` inside `Effect.tryPromise` | `try: () => fetch(url, { ... })` | `try: (signal) => fetch(url, { signal, ... })` |
+| Resource in a class | `private ref = Effect.runSync(Ref.make(0))` | Build in `Layer.effect`; inject via constructor |
+| Module-load env read | `const FOO = process.env.FOO!` at top level | `Config.string("FOO")` inside a Layer |
+| Happy-path test | One test asserting success | Happy path, each error path, property-based where applicable |
+| Test double for an external service | `vi.mock("./stripe")` in integration test | Real stripe test mode, or a contract test against a recorded cassette |
+| Positive integer | `function (n: number)` with runtime check | `function (n: PositiveInt)` where `PositiveInt` is branded |
+| Non-empty array | `arr: T[]` with `if (arr.length === 0)` guard | `arr: NonEmptyArray<T>` |
+| Pure function with a nameable algebraic property (roundtrip, idempotence, invariant, oracle agreement) | One example-based happy-path test | Happy path + `fast-check` property encoding the invariant |
+| Pure function with no nameable algebraic property | "Write a property test; think of something" | Example tests covering boundary and each error path; skip property-based |
+| Parser or handler accepting untrusted external input | Example tests for three known-bad inputs | Example tests + `fast-check` property + `Jazzer.js` via `@jazzer.js/jest-runner` when the threat model includes adversarial input |
+| Parser with no adversarial threat model | Reach for `Jazzer.js` anyway | Example tests + `fast-check`; skip the fuzzer (Principle 6: compute is budget) |
+| Test for code that reads a real database | `vi.mock("pg")` or an in-memory stand-in | `testcontainers-node` + `@testcontainers/postgresql`, shared-per-suite lifecycle, dynamic ports |
+| Test for code that reads a real cache or queue | In-memory fake for redis/kafka/rabbitmq | `testcontainers-node` + `@testcontainers/redis` (or matching module); fake only behind a schema-checked contract |
+
+The compression math: each full version costs seconds more to wire at the seam. Each one removes one class of cross-module coordination defect or one class of false-confidence test that mocks the very boundary under test. The shortcut's savings compound into the next refactor finding two modules quietly disagreeing about the same shape; the full version's savings compound into seams the compiler keeps honest.
+
 ## Iron rule
 
 > **If you need to revise the plan, your stop rule has already fired. Escalate, do not revise.**

--- a/skills/implement-staff/SKILL.md
+++ b/skills/implement-staff/SKILL.md
@@ -545,6 +545,24 @@ Then defer to user sovereignty if they insist. Name exactly what is being skippe
 - **Principle 6 (Budget Gate)** — shape is "new modules and new surface traceable to spec lines." No LOC ceiling. Every line traces.
 - **Principle 8 (The Ratchet)** — if the spec needs revision, ratchet up to spec. Never invent scope the spec did not authorize.
 
+The decision table below names the cross-service contract and CI / mutation-gating forks staff owns. Single-module Principle 1–4 forks live in `/safer:implement-junior`; Effect-runtime and testing-strategy forks at the module seam live in `/safer:implement-senior`.
+
+## Decision table
+
+Every row below is a new-surface fork where the agent feels pulled toward the human-era shortcut. Pick the agent-era full version. Each row corresponds to a cross-service contract decision or a CI gate that lives at a new package boundary — the surface staff introduces.
+
+| Scenario | Human-era shortcut | Agent-era full version |
+|---|---|---|
+| Two services in the same repo cross a shape boundary | Hand-written DTO types duplicated on both sides | Generate JSON Schema from the Zod/Effect schema; gate CI on `json-schema-diff` against the last-published schema |
+| Cross-service boundary where a consumer is external or under SLA | Best-effort schema doc in a README | `@pact-foundation/pact` (Pact V4) contract test published to the broker |
+| Critical UI flow (auth, checkout, primary CRUD) | "Unit test the React component" | Playwright E2E scoped to that flow; retry policy; screenshot diff off by default |
+| Non-critical UI surface | Broad Playwright coverage "to be safe" | Component-level tests; skip E2E (Principle 6: scope the ladder to <N critical flows) |
+| Repo has a `test/**/*.test.ts` suite | `"lint"` job in CI, run tests locally | CI runs a `test` job that executes the full suite on every PR. A lint-only CI with tests on disk is Principle 1 corollary item 4 violation: tests that do not run are decoration. |
+| Mutation testing on a critical module (auth, billing, parsing, crypto, webhook signing) | Skip, or run it everywhere | `@stryker-mutator/core` + `@stryker-mutator/typescript-checker`, **required CI gate**; scope the mutate glob to the critical module(s). Thresholds: `{ high: 80, low: 60, break: 50 }` as a starting point. |
+| Mutation testing repo-wide | Run Stryker over every file | Scope the mutate glob to named critical modules. When no critical module is named, the fallback is `src/**` with `ignoreStatic: true` and incremental mode on; compute budget (Principle 6) still caps full-sweep to nightly. PR runs use incremental. |
+
+The compression math: each full version costs hours-to-days to set up. Each one removes one class of contract-drift bug or one class of regression that ships unobserved. The shortcut's savings compound into a service rewrite later; the full version's savings compound into stable contracts that scale across consumers.
+
 ## Iron rule
 
 > **If your work is not traceable to the spec, your stop rule has already fired. Escalate, do not invent scope.**

--- a/skills/implement-staff/SKILL.tmpl
+++ b/skills/implement-staff/SKILL.tmpl
@@ -41,6 +41,24 @@ allowed-tools:
 - **Principle 6 (Budget Gate)** — shape is "new modules and new surface traceable to spec lines." No LOC ceiling. Every line traces.
 - **Principle 8 (The Ratchet)** — if the spec needs revision, ratchet up to spec. Never invent scope the spec did not authorize.
 
+The decision table below names the cross-service contract and CI / mutation-gating forks staff owns. Single-module Principle 1–4 forks live in `/safer:implement-junior`; Effect-runtime and testing-strategy forks at the module seam live in `/safer:implement-senior`.
+
+## Decision table
+
+Every row below is a new-surface fork where the agent feels pulled toward the human-era shortcut. Pick the agent-era full version. Each row corresponds to a cross-service contract decision or a CI gate that lives at a new package boundary — the surface staff introduces.
+
+| Scenario | Human-era shortcut | Agent-era full version |
+|---|---|---|
+| Two services in the same repo cross a shape boundary | Hand-written DTO types duplicated on both sides | Generate JSON Schema from the Zod/Effect schema; gate CI on `json-schema-diff` against the last-published schema |
+| Cross-service boundary where a consumer is external or under SLA | Best-effort schema doc in a README | `@pact-foundation/pact` (Pact V4) contract test published to the broker |
+| Critical UI flow (auth, checkout, primary CRUD) | "Unit test the React component" | Playwright E2E scoped to that flow; retry policy; screenshot diff off by default |
+| Non-critical UI surface | Broad Playwright coverage "to be safe" | Component-level tests; skip E2E (Principle 6: scope the ladder to <N critical flows) |
+| Repo has a `test/**/*.test.ts` suite | `"lint"` job in CI, run tests locally | CI runs a `test` job that executes the full suite on every PR. A lint-only CI with tests on disk is Principle 1 corollary item 4 violation: tests that do not run are decoration. |
+| Mutation testing on a critical module (auth, billing, parsing, crypto, webhook signing) | Skip, or run it everywhere | `@stryker-mutator/core` + `@stryker-mutator/typescript-checker`, **required CI gate**; scope the mutate glob to the critical module(s). Thresholds: `{ high: 80, low: 60, break: 50 }` as a starting point. |
+| Mutation testing repo-wide | Run Stryker over every file | Scope the mutate glob to named critical modules. When no critical module is named, the fallback is `src/**` with `ignoreStatic: true` and incremental mode on; compute budget (Principle 6) still caps full-sweep to nightly. PR runs use incremental. |
+
+The compression math: each full version costs hours-to-days to set up. Each one removes one class of contract-drift bug or one class of regression that ships unobserved. The shortcut's savings compound into a service rewrite later; the full version's savings compound into stable contracts that scale across consumers.
+
 ## Iron rule
 
 > **If your work is not traceable to the spec, your stop rule has already fired. Escalate, do not invent scope.**


### PR DESCRIPTION
Closes #289
Architect plan: https://gist.github.com/chughtapan/dd6eb6eba5da3c061dd98aedb6f46abb (Phase 6 section)

## What changed

The typescript-skill decision table (`skills/typescript/SKILL.tmpl:79-119@f050d82`) and its before/after example pairs (`skills/typescript/SKILL.tmpl:278-338@f050d82`) distribute across the three impl-* templates by tier. Junior owns Principle 1–4 single-module forks plus both before/after pairs. Senior owns Effect-runtime and testing-strategy seam forks. Staff owns cross-service contract and CI / mutation-gating forks. The typescript skill keeps its full table; Phase 8 owns the deletion.

## Plan anchors

| Change | Plan anchor |
|---|---|
| Add Decision table (13 rows) + Before/after pairs to junior tmpl | Phase 6 §"junior — Principle 1–4 forks" + "Both before/after example pairs … lift into junior" |
| Tighten junior Phase 4 "tempted to reach for any" paragraph to reference the new table | Phase 6 §"The 'When tempted to reach for any/unknown/…' paragraph in implement-junior/SKILL.tmpl Phase 4 tightens" |
| Add Decision table (13 rows) to senior tmpl | Phase 6 §"senior — Effect runtime / testing strategies" |
| Add Decision table (7 rows) to staff tmpl | Phase 6 §"staff — Cross-service / mutation" |
| Add "decision table below names …" framing sentence to each tier's How-this-modality-projects section | Phase 6 §"Update each impl-*'s 'How this modality projects from the doctrine' section if needed to reference the embedded table" |
| Run `bin/safer-gen-skills`; regenerated all 17 SKILL.md files | Phase 6 §"Run bin/safer-gen-skills to regenerate SKILL.md files" |
| Leave `skills/typescript/` intact | Phase 6 §"Do NOT delete skills/typescript/ in this phase. Phase 8 owns the deletion." |

## Scope

- Modules touched: `skills/implement-junior`, `skills/implement-senior`, `skills/implement-staff` (3)
- Tier (from safer-diff-scope): senior (\"spans 3 modules\")
- New modules: 0
- New public signatures outside the plan: 0
- New deps: 0
- typescript skill present: yes (`skills/typescript/SKILL.tmpl` and `SKILL.md` unchanged)

## Row distribution (33 total)

- Junior (13): parsing API response, JSON parse, function-can-fail, string union, error in try/catch, env var access, async return, identifier branding, switch over union, match chain, throw in Effect, callback signature, database query.
- Senior (13): `Effect.tryPromise` catch, fetch in tryPromise, resource in class, module-load env, happy-path test, test double, positive int, non-empty array, pure-fn-property (×2), parser/handler (×2), test reading DB/cache (×2).
- Staff (7): two-services-shape, cross-service-SLA, critical-UI (×2), lint-only-CI, mutation-critical, mutation-repo-wide.

`Database query` is the one row the issue body did not explicitly assign; it fits the junior frame (single-module Principle 1–2 fork: typed query builder vs raw SQL cast). Reviewers in the pre-PR review pass concurred.

## Tests

Doc-only. `bin/safer-gen-skills --check` clean after regeneration.

## Simplify skips

simplify: 2 findings applied (junior+senior compression-math closer differentiated for tier identity; junior before/after intro tightened from sentence-fragment).

## Review skips

review: no findings. Both reviewers reported all rows verbatim against source, tier assignments match issue split, acceptance criteria met. Verdict: ship.

## Confidence

HIGH — mechanical row redistribution against an explicit tier split; both reviewers independently confirmed row count (13/13/7), tier placement, and verbatim wording against `skills/typescript/SKILL.tmpl:85-118@f050d82`.