### PR TITLE
[impl-staff] Phase 3: sfd: absorb architecture analyzer + LSP server

### DIFF
--- a/.github/workflows/lsp-architecture.yml
+++ b/.github/workflows/lsp-architecture.yml
@@ -1,0 +1,32 @@
+name: lsp-architecture
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "lsp/architecture/**"
+      - ".github/workflows/lsp-architecture.yml"
+  pull_request:
+    paths:
+      - "lsp/architecture/**"
+      - ".github/workflows/lsp-architecture.yml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lsp/architecture
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: lsp/architecture/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 # Skill-creator workspaces (run artifacts; reproducible from evals.json)
 skills/*-workspace/
 skills/*/evals/iteration-*/
+
+# Per-package node modules and build output for nested LSP packages.
+lsp/*/node_modules/
+lsp/*/dist/

--- a/lsp/architecture/analyzer/README.md
+++ b/lsp/architecture/analyzer/README.md
@@ -1,0 +1,33 @@
+# Architecture Rules
+
+This folder owns graph-backed architecture diagnostics. These rules analyze
+the whole TypeScript project, not only the currently linted file.
+
+The implementation is organized by analysis surface:
+
+- `exports/` inspects index and public export curation.
+- `folder-shape/` inspects folder size, README, and facade pressure.
+- `imports/` builds and analyzes local import topology.
+- `module-shape/` inspects accidental boundary modules and shared kernels.
+- `package-api/` inspects `package.json` public entries.
+- `project/` builds the source model, config, cache, and diagnostic contracts.
+- `type-surface/` inspects public API type ownership.
+
+`index.ts` is the architecture analyzer facade. It exports
+`analyzeWorkspace(options)`, which the LSP server, CI shim, and tests
+call to get the full `ArchitectureReport` for a project root.
+
+## Performance
+
+The architecture analyzer runs once per project and is cached. The cache
+TTL defaults to 5 seconds so long-lived hosts (LSP, VS Code) see fixes
+promptly. CI lints finish in one pass, so a longer TTL is safe:
+
+```ts
+analyzeWorkspace({
+  projectRoot,
+  cacheTtlMs: Infinity, // CI: never rebuild within a single lint run
+});
+```
+
+Valid range: `0` (always rebuild) through `Infinity`.

--- a/lsp/architecture/analyzer/architecture-exceptions.test.ts
+++ b/lsp/architecture/analyzer/architecture-exceptions.test.ts
@@ -1,0 +1,135 @@
+import { expect, it } from "vitest";
+import { ARCHITECTURE_DIAGNOSTIC_RULE_IDS as architectureDiagnosticRuleIds } from "./rule-ids.js";
+import * as h from "./test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+const loadParser = async () => import("./architecture-exceptions.js");
+const RULE_IDS = architectureDiagnosticRuleIds;
+
+// Preamble that may appear before a directive: license headers, imports,
+// blank lines, prior comments — anything except a comment line that itself
+// starts with the directive marker.
+const preambleArb = fc.array(
+  fc.oneof(
+    fc.constant("// SPDX-License-Identifier: MIT"),
+    fc.constant("// Copyright (c) 2026"),
+    fc.constant('import { foo } from "bar";'),
+    fc.constant('"use strict";'),
+    fc.constant(""),
+    fc.constant("/* block license comment */"),
+    fc
+      .string({ minLength: 1, maxLength: 30 })
+      .filter((s) => !s.includes("@agent-code-guard"))
+      .map((s) => `// ${s}`),
+  ),
+  { minLength: 0, maxLength: 8 },
+);
+
+function makeSourceFile(name: string, source: string): ts.SourceFile {
+  return ts.createSourceFile(name, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+it("Property: directives parse regardless of leading file content", async () => {
+  const { parseDirectivesFromSourceFile } = await loadParser();
+  fc.assert(
+    fc.property(
+      preambleArb,
+      fc.constantFrom(...RULE_IDS),
+      fc.string({ minLength: 1, maxLength: 60 }).filter((s) => s.trim().length > 0),
+      (preamble, ruleId, reason) => {
+        const source =
+          preamble.join("\n") +
+          (preamble.length > 0 ? "\n\n" : "") +
+          `// @agent-code-guard/architecture-exception: ${ruleId}\n` +
+          `// reason: ${reason.replace(/\r?\n/g, " ")}\n\n` +
+          "export const value = 1;\n";
+        const result = parseDirectivesFromSourceFile(makeSourceFile("test.ts", source));
+        expect(result.errors).toEqual([]);
+        expect(result.directives).toHaveLength(1);
+        expect(result.directives[0]?.ruleId).toBe(ruleId);
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: a marker-prefixed line that doesn't match the strict pattern is always flagged", async () => {
+  const { parseDirectivesFromSourceFile } = await loadParser();
+  fc.assert(
+    fc.property(
+      // Either: trailing junk after a real rule-id, OR garbage instead of a rule-id.
+      fc.oneof(
+        fc.tuple(
+          fc.constantFrom(...RULE_IDS),
+          fc.string({ minLength: 1, maxLength: 30 }).filter((s) => /\S/.test(s)),
+        ).map(([rule, junk]) => `${rule} ${junk}`),
+        fc
+          .string({ minLength: 1, maxLength: 40 })
+          .filter((s) => /\S/.test(s) && !/^[\w-]+$/.test(s.trim())),
+      ),
+      (badPayload) => {
+        const source =
+          `// @agent-code-guard/architecture-exception: ${badPayload}\n` +
+          `// reason: should not reach here\n\n` +
+          "export const value = 1;\n";
+        const result = parseDirectivesFromSourceFile(makeSourceFile("malformed.ts", source));
+        expect(result.directives).toEqual([]);
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(result.errors.some((e) => /Malformed|Unknown/.test(e.message))).toBe(true);
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: unknown rule-ids are always rejected", async () => {
+  const { parseDirectivesFromSourceFile } = await loadParser();
+  const knownIds = new Set<string>(RULE_IDS);
+  fc.assert(
+    fc.property(
+      fc
+        .string({ minLength: 1, maxLength: 30 })
+        .filter((s) => /^[a-z][a-z0-9-]*$/.test(s) && !knownIds.has(s)),
+      (unknownRule) => {
+        const source =
+          `// @agent-code-guard/architecture-exception: ${unknownRule}\n` +
+          `// reason: typo\n\n` +
+          "export const value = 1;\n";
+        const result = parseDirectivesFromSourceFile(makeSourceFile("typo.ts", source));
+        expect(result.directives).toEqual([]);
+        expect(
+          result.errors.some((e) => e.message.includes("Unknown architecture rule id")),
+        ).toBe(true);
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: any non-matching comment between rule and reason terminates the pending directive", async () => {
+  const { parseDirectivesFromSourceFile } = await loadParser();
+  const interveningLineArb = fc
+    .string({ minLength: 1, maxLength: 40 })
+    .filter((s) => /\S/.test(s) && !/^reason\b/i.test(s.trim()) && !s.includes("@agent-code-guard"))
+    .map((s) => `// ${s}`);
+  fc.assert(
+    fc.property(
+      fc.constantFrom(...RULE_IDS),
+      fc.array(interveningLineArb, { minLength: 1, maxLength: 4 }),
+      (ruleId, intervening) => {
+        const source =
+          `// @agent-code-guard/architecture-exception: ${ruleId}\n` +
+          intervening.join("\n") +
+          `\n// reason: too-late\n\n` +
+          "export const value = 1;\n";
+        const result = parseDirectivesFromSourceFile(makeSourceFile("carry.ts", source));
+        expect(result.directives).toEqual([]);
+        expect(
+          result.errors.some((e) => e.message.includes("missing a 'reason:' follow-up")),
+        ).toBe(true);
+      },
+    ),
+    { numRuns: 40 },
+  );
+});

--- a/lsp/architecture/analyzer/architecture-exceptions.ts
+++ b/lsp/architecture/analyzer/architecture-exceptions.ts
@@ -1,0 +1,301 @@
+import ts from "typescript";
+import {
+  ARCHITECTURE_DIAGNOSTIC_RULE_IDS,
+  type ArchitectureDiagnosticRuleId,
+} from "./rule-ids.js";
+
+const DIRECTIVE_MARKER = "@agent-code-guard/architecture-exception";
+const RULE_ID_SET: ReadonlySet<string> = new Set(ARCHITECTURE_DIAGNOSTIC_RULE_IDS);
+
+export interface ArchitectureDirective {
+  readonly ruleId: ArchitectureDiagnosticRuleId;
+  readonly reason: string;
+}
+
+export interface FileDirectives {
+  readonly file: string;
+  readonly directives: ReadonlyArray<ArchitectureDirective>;
+}
+
+export interface DirectiveParseError {
+  readonly file: string;
+  readonly line: number;
+  readonly ruleId: ArchitectureDiagnosticRuleId | null;
+  readonly message: string;
+}
+
+export interface DirectiveParseResult {
+  readonly directives: ReadonlyArray<ArchitectureDirective>;
+  readonly errors: ReadonlyArray<DirectiveParseError>;
+}
+
+const missingReasonError = (
+  filePath: string,
+  line: number,
+  ruleId: ArchitectureDiagnosticRuleId,
+): DirectiveParseError => ({
+  file: filePath,
+  line,
+  ruleId,
+  message: `Directive '${DIRECTIVE_MARKER}: ${ruleId}' is missing a 'reason:' follow-up line.`,
+});
+
+interface CommentLine {
+  readonly line: number;
+  readonly content: string;
+}
+
+interface PendingDirective {
+  readonly ruleId: ArchitectureDiagnosticRuleId;
+  readonly line: number;
+}
+
+interface ParseState {
+  pending: PendingDirective | null;
+  readonly directives: ArchitectureDirective[];
+  readonly errors: DirectiveParseError[];
+}
+
+export function parseDirectivesFromSourceFile(
+  sourceFile: ts.SourceFile,
+): DirectiveParseResult {
+  const commentLines = collectCommentLines(sourceFile);
+  return parseCommentLines(sourceFile.fileName, commentLines);
+}
+
+function collectCommentLines(sourceFile: ts.SourceFile): CommentLine[] {
+  const text = sourceFile.text;
+  const lineOf = (pos: number) =>
+    sourceFile.getLineAndCharacterOfPosition(pos).line + 1;
+  const comments = new Map<number, ts.CommentRange>();
+  collectCommentRanges(sourceFile, text, comments);
+  return [...comments.entries()]
+    .sort(([left], [right]) => left - right)
+    .flatMap(([, comment]) => commentLinesFromRange(text, lineOf, comment));
+}
+
+function collectCommentRanges(
+  sourceFile: ts.SourceFile,
+  text: string,
+  comments: Map<number, ts.CommentRange>,
+): void {
+  const addComment = (pos: number, end: number, kind: ts.CommentKind) => {
+    comments.set(pos, { end, hasTrailingNewLine: false, kind, pos });
+  };
+  const visit = (node: ts.Node) => {
+    ts.forEachLeadingCommentRange(text, node.pos, addComment);
+    ts.forEachTrailingCommentRange(text, node.end, addComment);
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+}
+
+function commentLinesFromRange(
+  text: string,
+  lineOf: (pos: number) => number,
+  comment: ts.CommentRange,
+): readonly CommentLine[] {
+  const raw = text.slice(comment.pos, comment.end);
+  return comment.kind === ts.SyntaxKind.SingleLineCommentTrivia
+    ? [{ line: lineOf(comment.pos), content: raw.slice(2).trim() }]
+    : blockCommentLines(raw, comment.pos, lineOf);
+}
+
+function blockCommentPrefixLength(raw: string): number {
+  let cursor = raw.startsWith("/*") ? 2 : 0;
+  while (raw[cursor] === "*") cursor += 1;
+  return cursor;
+}
+
+function blockCommentContentEnd(raw: string): number {
+  let end = raw.endsWith("/") ? raw.length - 1 : raw.length;
+  while (raw[end - 1] === "*") end -= 1;
+  return end;
+}
+
+function stripBlockLinePrefix(segment: string): string {
+  const trimmed = segment.trimStart();
+  return trimmed.startsWith("*") ? trimmed.slice(1).trim() : trimmed.trim();
+}
+
+function blockCommentLines(
+  raw: string,
+  start: number,
+  lineOf: (pos: number) => number,
+): readonly CommentLine[] {
+  const prefixLength = blockCommentPrefixLength(raw);
+  const inner = raw.slice(prefixLength, blockCommentContentEnd(raw));
+  let cursor = 0;
+  return inner.split(/\r?\n/).map((segment) => {
+    const line = {
+      line: lineOf(start + prefixLength + cursor),
+      content: stripBlockLinePrefix(segment),
+    };
+    cursor += segment.length + 1;
+    return line;
+  });
+}
+
+function parseCommentLines(
+  filePath: string,
+  commentLines: ReadonlyArray<CommentLine>,
+): DirectiveParseResult {
+  const state: ParseState = { directives: [], errors: [], pending: null };
+  const strictMatcher = new RegExp(
+    `^${escapeForRegExp(DIRECTIVE_MARKER)}\\s*:\\s*([\\w-]+)\\s*$`,
+  );
+
+  for (const commentLine of commentLines) handleCommentLine(state, filePath, commentLine, strictMatcher);
+  flushPendingDirective(state, filePath);
+  return { directives: state.directives, errors: state.errors };
+}
+
+function handleCommentLine(
+  state: ParseState,
+  filePath: string,
+  commentLine: CommentLine,
+  strictMatcher: RegExp,
+): void {
+  const candidate = strictDirectiveRuleId(commentLine.content, strictMatcher);
+  if (candidate !== null) {
+    handleDirectiveLine(state, filePath, commentLine.line, candidate);
+    return;
+  }
+  if (commentLine.content.startsWith(DIRECTIVE_MARKER)) {
+    handleMalformedDirectiveLine(state, filePath, commentLine.line);
+    return;
+  }
+  if (state.pending !== null) handlePotentialReasonLine(state, filePath, commentLine);
+}
+
+function strictDirectiveRuleId(content: string, strictMatcher: RegExp): string | null {
+  const ruleMatch = content.match(strictMatcher);
+  return ruleMatch?.[1] ?? null;
+}
+
+function handleDirectiveLine(
+  state: ParseState,
+  filePath: string,
+  line: number,
+  candidate: string,
+): void {
+  flushPendingDirective(state, filePath);
+  if (!RULE_ID_SET.has(candidate)) {
+    state.errors.push(unknownRuleError(filePath, line, candidate));
+    return;
+  }
+  state.pending = { line, ruleId: candidate as ArchitectureDiagnosticRuleId };
+}
+
+function handleMalformedDirectiveLine(
+  state: ParseState,
+  filePath: string,
+  line: number,
+): void {
+  flushPendingDirective(state, filePath);
+  state.errors.push({
+    file: filePath,
+    line,
+    ruleId: null,
+    message: `Malformed '${DIRECTIVE_MARKER}' directive. Expected '${DIRECTIVE_MARKER}: <rule-id>' on its own line.`,
+  });
+}
+
+function handlePotentialReasonLine(
+  state: ParseState,
+  filePath: string,
+  commentLine: CommentLine,
+): void {
+  const reason = parseReason(commentLine.content);
+  if (reason === null) {
+    flushPendingDirective(state, filePath);
+    return;
+  }
+  addReasonResult(state, filePath, commentLine.line, reason);
+}
+
+function parseReason(content: string): string | null {
+  const separator = content.indexOf(":");
+  if (separator < 0) return null;
+  const key = content.slice(0, separator).trim().toLowerCase();
+  return key === "reason" ? content.slice(separator + 1).trim() : null;
+}
+
+function addReasonResult(
+  state: ParseState,
+  filePath: string,
+  line: number,
+  reason: string,
+): void {
+  const pending = state.pending;
+  if (pending === null) return;
+  if (reason.length === 0) {
+    state.errors.push(emptyReasonError(filePath, line, pending.ruleId));
+  } else {
+    state.directives.push({ ruleId: pending.ruleId, reason });
+  }
+  state.pending = null;
+}
+
+function flushPendingDirective(state: ParseState, filePath: string): void {
+  if (state.pending === null) return;
+  state.errors.push(
+    missingReasonError(filePath, state.pending.line, state.pending.ruleId),
+  );
+  state.pending = null;
+}
+
+function unknownRuleError(
+  filePath: string,
+  line: number,
+  candidate: string,
+): DirectiveParseError {
+  return {
+    file: filePath,
+    line,
+    ruleId: null,
+    message: `Unknown architecture rule id '${candidate}' in directive. Expected one of: ${ARCHITECTURE_DIAGNOSTIC_RULE_IDS.join(", ")}.`,
+  };
+}
+
+function emptyReasonError(
+  filePath: string,
+  line: number,
+  ruleId: ArchitectureDiagnosticRuleId,
+): DirectiveParseError {
+  return {
+    file: filePath,
+    line,
+    ruleId,
+    message: `Empty 'reason:' for directive '${DIRECTIVE_MARKER}: ${ruleId}'. Provide a written reason.`,
+  };
+}
+
+function escapeForRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildDirectiveIndex(
+  fileDirectives: ReadonlyArray<FileDirectives>,
+): ReadonlyMap<string, ReadonlySet<ArchitectureDiagnosticRuleId>> {
+  const index = new Map<string, Set<ArchitectureDiagnosticRuleId>>();
+  for (const { file, directives } of fileDirectives) {
+    let set = index.get(file);
+    if (!set) {
+      set = new Set();
+      index.set(file, set);
+    }
+    for (const d of directives) {
+      set.add(d.ruleId);
+    }
+  }
+  return index;
+}
+
+export function isDirectiveSuppressed(
+  index: ReadonlyMap<string, ReadonlySet<ArchitectureDiagnosticRuleId>>,
+  file: string,
+  ruleId: ArchitectureDiagnosticRuleId,
+): boolean {
+  return index.get(file)?.has(ruleId) ?? false;
+}

--- a/lsp/architecture/analyzer/exports/inventory-barrels.diagnostics.test.ts
+++ b/lsp/architecture/analyzer/exports/inventory-barrels.diagnostics.test.ts
@@ -1,0 +1,281 @@
+import { expect, it } from "vitest";
+import type { SourceFile } from "typescript";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+type InventoryDiagnostic = ReturnType<typeof inventoryBarrelDiagnostic>[number];
+type InventoryThresholdContext = {
+  readonly eligibleCount: number;
+  readonly exportedCount: number;
+  readonly root: string;
+  readonly sourceFile: SourceFile;
+};
+
+it("Property: inventory barrel diagnostics follow count and ratio thresholds", () => {
+  expect.hasAssertions();
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1, max: 12 }),
+      fc.integer({ min: 0, max: 12 }),
+      fc.integer({ min: 1, max: 12 }),
+      fc.constantFrom(0, 0.25, 0.5, 0.6, 0.75, 1),
+      assertInventoryThresholdCase,
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: inventory diagnostics only run on index files with eligible siblings", () => {
+  expect.hasAssertions();
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1, max: 8 }),
+      fc.integer({ min: 1, max: 8 }),
+      assertInventoryRequiresIndexWithEligibleSiblings,
+    ),
+    { numRuns: 60 },
+  );
+});
+
+it("Property: inventory barrel ratio is inclusive at the exact configured boundary", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1, max: 12 }),
+      fc.integer({ min: 1, max: 12 }),
+      (eligibleCount, rawExportedCount) => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-inventory-ratio-"));
+        try {
+          const exportedCount = Math.min(rawExportedCount, eligibleCount);
+          const sourceFile = writeSiblingModules(
+            path.join(root, "src", "widgets"),
+            eligibleCount,
+            exportedCount,
+          );
+
+          expect(
+            inventoryBarrelDiagnostic(
+              sourceFile,
+              resolveArchitectureOptions({
+                projectRoot: root,
+                minExportedSiblingModules: exportedCount,
+                maxExportedSiblingRatio: exportedCount / eligibleCount,
+              }),
+            ).length > 0,
+          ).toBe(true);
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: inventory barrels count only exported siblings that exist as eligible modules", () => {
+  expect.hasAssertions();
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1, max: 8 }),
+      fc.integer({ min: 1, max: 8 }),
+      assertInventoryCountsOnlyExistingSiblings,
+    ),
+    { numRuns: 60 },
+  );
+});
+
+function assertInventoryThresholdCase(
+  eligibleCount: number,
+  rawExportedCount: number,
+  minExportedSiblingModules: number,
+  maxExportedSiblingRatio: number,
+): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-inventory-property-"));
+  try {
+    const exportedCount = Math.min(rawExportedCount, eligibleCount);
+    const sourceFile = writeSiblingModules(
+      path.join(root, "src", "widgets"),
+      eligibleCount,
+      exportedCount,
+    );
+    const diagnostics = inventoryBarrelDiagnostic(
+      sourceFile,
+      resolveArchitectureOptions({
+        projectRoot: root,
+        minExportedSiblingModules,
+        maxExportedSiblingRatio,
+      }),
+    );
+
+    expectInventoryThresholdDiagnostics(
+      diagnostics,
+      { eligibleCount, exportedCount, root, sourceFile },
+      exportedCount >= minExportedSiblingModules &&
+        exportedCount / eligibleCount >= maxExportedSiblingRatio,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function assertInventoryRequiresIndexWithEligibleSiblings(
+  eligibleCount: number,
+  exportedCount: number,
+): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-inventory-boundary-"));
+  try {
+    const directory = path.join(root, "src", "widgets");
+    expectInventoryIgnoresNonIndexFile(root, directory, eligibleCount, exportedCount);
+    expectInventoryIgnoresIndexWithoutExistingSiblings(root, directory);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function assertInventoryCountsOnlyExistingSiblings(
+  eligibleCount: number,
+  extraExportCount: number,
+): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-inventory-intersect-"));
+  try {
+    const sourceFile = writeMixedSiblingIndex(root, eligibleCount, extraExportCount);
+    expect(
+      inventoryBarrelDiagnostic(
+        sourceFile,
+        resolveArchitectureOptions({
+          projectRoot: root,
+          minExportedSiblingModules: eligibleCount + 1,
+          maxExportedSiblingRatio: 0,
+        }),
+      ),
+    ).toEqual([]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function expectInventoryThresholdDiagnostics(
+  diagnostics: readonly InventoryDiagnostic[],
+  context: InventoryThresholdContext,
+  shouldFlag: boolean,
+): void {
+  if (!shouldFlag) {
+    expect(diagnostics).toEqual([]);
+    return;
+  }
+
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.message).toContain(
+    path.relative(context.root, context.sourceFile.fileName),
+  );
+  expect(diagnostics[0]?.message).toContain(
+    `${context.exportedCount} of ${context.eligibleCount}`,
+  );
+  expect(diagnostics[0]?.message).toContain(
+    "This exports inventory, not an abstraction",
+  );
+  expect(diagnostics[0]?.message).toContain(
+    "ports, factories, and stable types only",
+  );
+}
+
+function expectInventoryIgnoresNonIndexFile(
+  root: string,
+  directory: string,
+  eligibleCount: number,
+  exportedCount: number,
+): void {
+  const indexSourceFile = writeSiblingModules(
+    directory,
+    eligibleCount,
+    Math.min(exportedCount, eligibleCount),
+  );
+  const nonIndexSourceFile = ts.createSourceFile(
+    path.join(directory, "facade.ts"),
+    indexSourceFile.text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  expect(inventoryBarrelDiagnostic(nonIndexSourceFile, strictInventoryOptions(root)))
+    .toEqual([]);
+}
+
+function expectInventoryIgnoresIndexWithoutExistingSiblings(
+  root: string,
+  directory: string,
+): void {
+  fs.rmSync(directory, { recursive: true, force: true });
+  fs.mkdirSync(directory, { recursive: true });
+  const emptyIndexPath = path.join(directory, "index.ts");
+  const emptyIndexText = 'export { Ghost } from "./ghost";';
+  fs.writeFileSync(emptyIndexPath, emptyIndexText);
+  const emptyIndexSourceFile = ts.createSourceFile(
+    emptyIndexPath,
+    emptyIndexText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  expect(inventoryBarrelDiagnostic(emptyIndexSourceFile, strictInventoryOptions(root)))
+    .toEqual([]);
+}
+
+function writeMixedSiblingIndex(
+  root: string,
+  eligibleCount: number,
+  extraExportCount: number,
+): SourceFile {
+  const directory = path.join(root, "src", "widgets");
+  fs.mkdirSync(directory, { recursive: true });
+  const indexPath = path.join(directory, "index.ts");
+  const sourceText = [
+    ...moduleExportLines("M", "m", eligibleCount),
+    ...moduleExportLines("Ghost", "ghost", extraExportCount),
+  ].join("\n");
+  fs.writeFileSync(indexPath, sourceText);
+
+  for (let index = 0; index < eligibleCount; index += 1) {
+    fs.writeFileSync(path.join(directory, `m${index}.ts`), `export const M${index} = ${index};\n`);
+  }
+
+  return ts.createSourceFile(indexPath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+}
+
+function moduleExportLines(
+  exportedPrefix: string,
+  modulePrefix: string,
+  count: number,
+): readonly string[] {
+  return Array.from(
+    { length: count },
+    (_, index) => `export { ${exportedPrefix}${index} } from "./${modulePrefix}${index}";`,
+  );
+}
+
+function strictInventoryOptions(root: string): ReturnType<typeof resolveArchitectureOptions> {
+  return resolveArchitectureOptions({
+    projectRoot: root,
+    minExportedSiblingModules: 1,
+    maxExportedSiblingRatio: 0,
+  });
+}
+
+it("collects eligible sibling module keys from source files and indexed folders only", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-eligible-siblings-"));
+  try {
+    fs.writeFileSync(path.join(root, "feature.ts"), "export const feature = true;\n");
+    fs.writeFileSync(path.join(root, ".hidden.ts"), "export const hidden = true;\n");
+    fs.writeFileSync(path.join(root, "feature.test.ts"), "export const testOnly = true;\n");
+    fs.mkdirSync(path.join(root, "foldered"), { recursive: true });
+    fs.writeFileSync(path.join(root, "foldered", "index.ts"), "export const foldered = true;\n");
+    fs.mkdirSync(path.join(root, "not-module"), { recursive: true });
+    fs.writeFileSync(path.join(root, "not-module", "value.ts"), "export const value = true;\n");
+
+    expect(eligibleSiblingModuleKeys(root)).toEqual(new Set(["feature", "foldered"]));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/lsp/architecture/analyzer/exports/inventory-barrels.syntax.test.ts
+++ b/lsp/architecture/analyzer/exports/inventory-barrels.syntax.test.ts
@@ -1,0 +1,174 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+it("uses the package root when reporting package.json diagnostics", () => {
+  const root = path.resolve("/repo");
+  expect(packageReportPath(root)).toBe(path.join(root, "package.json"));
+});
+
+it("maps source and output extensions deterministically", () => {
+  expect(hasSourceExtension("foo.ts")).toBe(true);
+  expect(hasSourceExtension("foo.js")).toBe(false);
+  expect(stripKnownExtension("foo.ts")).toBe("foo");
+  expect(stripKnownExtension("foo.mjs")).toBe("foo");
+  expect(stripKnownExtension("foo.css")).toBe("foo.css");
+  expect(replaceKnownExtension("dist/index.d.ts", ".ts")).toBe("dist/index.ts");
+  expect(replaceKnownExtension("dist/index.js", ".tsx")).toBe("dist/index.tsx");
+  expect(replaceKnownExtension("dist/no-extension", ".ts")).toBe("dist/no-extension.ts");
+  const fixturePath = path.join(path.sep, "repo", "demo");
+  expect(withTrailingSeparator(fixturePath)).toBe(`${fixturePath}${path.sep}`);
+  expect(withTrailingSeparator(`${fixturePath}${path.sep}`)).toBe(`${fixturePath}${path.sep}`);
+});
+
+it("Property: known extension replacement removes exactly one terminal known extension", () => {
+  fc.assert(
+    fc.property(
+      fc.array(segmentArb, { minLength: 1, maxLength: 4 }),
+      fc.constantFrom(...SOURCE_EXTENSIONS, ...OUTPUT_EXTENSIONS, ".d.ts"),
+      fc.constantFrom(...SOURCE_EXTENSIONS),
+      (segments, currentExtension, nextExtension) => {
+        const basePath = segments.join("/");
+        expect(stripKnownExtension(`${basePath}${currentExtension}`)).toBe(
+          basePath,
+        );
+        expect(replaceKnownExtension(`${basePath}${currentExtension}`, nextExtension)).toBe(
+          `${basePath}${nextExtension}`,
+        );
+      },
+    ),
+    { numRuns: 100 },
+  );
+});
+
+it("Property: source extension detection only accepts terminal TypeScript source extensions", () => {
+  fc.assert(
+    fc.property(
+      fc.array(segmentArb, { minLength: 1, maxLength: 4 }),
+      sourceExtensionArb,
+      fc.constantFrom(...OUTPUT_EXTENSIONS, ".css", ".json", ".txt"),
+      (segments, sourceExtension, nonSourceExtension) => {
+        const basePath = segments.join("/");
+        expect(hasSourceExtension(`${basePath}${sourceExtension}`)).toBe(true);
+        expect(hasSourceExtension(`${basePath}${nonSourceExtension}`)).toBe(false);
+        expect(hasSourceExtension(`${basePath}${sourceExtension}.map`)).toBe(false);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("recognizes eligible sibling source modules and exported sibling specifiers", () => {
+  expect(sourceModuleKey("feature.ts")).toBe("feature");
+  expect(sourceModuleKey("feature.txt")).toBeNull();
+  expect(sourceModuleKey("feature.d.ts")).toBeNull();
+  expect(sourceModuleKey("feature.test.ts")).toBeNull();
+  expect(sourceModuleKey("feature.generated.ts")).toBeNull();
+  expect(isExcludedSourceFile("index.ts")).toBe(true);
+  expect(isExcludedSourceFile("feature.test.ts.extra")).toBe(false);
+  expect(isExcludedSourceFile("feature.test.xts")).toBe(false);
+  expect(isExcludedSourceFile("feature.generated.ts.extra")).toBe(false);
+  expect(isExcludedSourceFile("feature.generated.xts")).toBe(false);
+  expect(siblingModuleKeyFromSpecifier("./feature")).toBe("feature");
+  expect(siblingModuleKeyFromSpecifier("./feature/index.js")).toBe("feature");
+  expect(siblingModuleKeyFromSpecifier("./feature\\index.js")).toBe("feature");
+  expect(siblingModuleKeyFromSpecifier("./feature//index.js")).toBe("feature");
+  expect(siblingModuleKeyFromSpecifier("./index")).toBeNull();
+  expect(siblingModuleKeyFromSpecifier("../feature")).toBeNull();
+  expect(siblingModuleKeyFromSpecifier("./nested/deeper")).toBeNull();
+  expect(siblingModuleKeyFromSpecifier("./nested/index/deeper")).toBeNull();
+
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    [
+      'export type { A } from "./a";',
+      'export { B } from "./b";',
+      'export * from "./nested/index";',
+    ].join("\n"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const firstExport = sourceFile.statements[0];
+  expect(ts.isExportDeclaration(firstExport)).toBe(true);
+  expect(exportDeclarationIsTypeOnly(firstExport as ts.ExportDeclaration)).toBe(true);
+  expect(exportedSiblingModuleKeys(sourceFile, { countTypeOnlyExports: true })).toEqual(
+    new Set(["a", "b", "nested"]),
+  );
+  expect(exportedSiblingModuleKeys(sourceFile, { countTypeOnlyExports: false })).toEqual(
+    new Set(["b", "nested"]),
+  );
+});
+
+it("Property: only index source files are treated as boundary barrels", () => {
+  expect(isIndexSourceFile("index.css")).toBe(false);
+  expect(isIndexSourceFile("index.js.map")).toBe(false);
+
+  fc.assert(
+    fc.property(segmentArb, sourceExtensionArb, (name, extension) => {
+      const fileName = `${name}${extension}`;
+      expect(isIndexSourceFile(fileName)).toBe(name === "index");
+    }),
+    { numRuns: 100 },
+  );
+
+  fc.assert(
+    fc.property(
+      segmentArb,
+      fc.constantFrom(".js.map", ".css", ".json", ".txt"),
+      (name, extension) => {
+        expect(isIndexSourceFile(`${name}${extension}`)).toBe(false);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: sibling export collection follows module specifiers and type-only options", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 1, maxLength: 8 }),
+      (modules) => {
+        const runtimeExports = exportSourceFileFor(modules, false);
+        const typeExports = exportSourceFileFor(modules, true);
+        const expected = new Set(modules);
+
+        for (const moduleName of modules) {
+          expect(siblingModuleKeyFromSpecifier(`./${moduleName}`)).toBe(moduleName);
+          expect(siblingModuleKeyFromSpecifier(`./${moduleName}/index.js`)).toBe(moduleName);
+        }
+
+        expect(exportedSiblingModuleKeys(runtimeExports, { countTypeOnlyExports: true }))
+          .toEqual(expected);
+        expect(exportedSiblingModuleKeys(runtimeExports, { countTypeOnlyExports: false }))
+          .toEqual(expected);
+        expect(exportedSiblingModuleKeys(typeExports, { countTypeOnlyExports: true }))
+          .toEqual(expected);
+        expect(exportedSiblingModuleKeys(typeExports, { countTypeOnlyExports: false }))
+          .toEqual(new Set());
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("distinguishes mixed type-only export clauses from fully type-only clauses", () => {
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    [
+      'export { type A, B } from "./mixed";',
+      'export { type C, type D } from "./types";',
+    ].join("\n"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  const [mixedExport, typeOnlyExport] = sourceFile.statements;
+  expect(ts.isExportDeclaration(mixedExport)).toBe(true);
+  expect(ts.isExportDeclaration(typeOnlyExport)).toBe(true);
+  expect(exportDeclarationIsTypeOnly(mixedExport as ts.ExportDeclaration)).toBe(false);
+  expect(exportDeclarationIsTypeOnly(typeOnlyExport as ts.ExportDeclaration)).toBe(true);
+});

--- a/lsp/architecture/analyzer/exports/inventory-barrels.ts
+++ b/lsp/architecture/analyzer/exports/inventory-barrels.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import { SOURCE_EXTENSIONS, stripKnownExtension } from "../project/api/index.js";
+import type { ResolvedArchitectureOptions, ArchitectureDiagnostic } from "../project/api/index.js";
+
+export function checkInventoryBarrels(
+  sourceFiles: readonly ts.SourceFile[],
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return sourceFiles.flatMap((sourceFile) =>
+    inventoryBarrelDiagnostic(sourceFile, options),
+  );
+}
+
+export function inventoryBarrelDiagnostic(
+  sourceFile: ts.SourceFile,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  if (!isIndexSourceFile(sourceFile.fileName)) return [];
+
+  const eligibleSiblingModules = eligibleSiblingModuleKeys(path.dirname(sourceFile.fileName));
+  const exportedEligibleSiblingModules = intersectSets(
+    exportedSiblingModuleKeys(sourceFile, options),
+    eligibleSiblingModules,
+  );
+  const exportedCount = exportedEligibleSiblingModules.size;
+  const eligibleCount = eligibleSiblingModules.size;
+
+  if (eligibleCount === 0) return [];
+  if (exportedCount < options.minExportedSiblingModules) return [];
+  if (exportedCount / eligibleCount < options.maxExportedSiblingRatio) return [];
+
+  return [
+    {
+      ruleId: "no-inventory-barrel",
+      file: sourceFile.fileName,
+      severity: "warn",
+      message:
+        `${path.relative(options.projectRoot, sourceFile.fileName)} exports ` +
+        `${exportedCount} of ${eligibleCount} eligible sibling modules. ` +
+        "This exports inventory, not an abstraction. Export a smaller facade: " +
+        "ports, factories, and stable types only.",
+    },
+  ];
+}
+
+export function isIndexSourceFile(fileName: string): boolean {
+  const parsed = path.parse(fileName);
+  return (
+    parsed.name === "index" &&
+    SOURCE_EXTENSIONS.some((extension) => parsed.ext === extension)
+  );
+}
+
+export function eligibleSiblingModuleKeys(directory: string): ReadonlySet<string> {
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  const keys = new Set<string>();
+
+  for (const entry of entries) {
+    const moduleKey = eligibleSiblingEntryKey(directory, entry);
+    if (moduleKey !== null) keys.add(moduleKey);
+  }
+
+  return keys;
+}
+
+function eligibleSiblingEntryKey(
+  directory: string,
+  entry: fs.Dirent,
+): string | null {
+  if (entry.name.startsWith(".")) return null;
+  if (!entry.isDirectory()) return sourceModuleKey(entry.name);
+  return directoryHasIndexSource(path.join(directory, entry.name))
+    ? entry.name
+    : null;
+}
+
+function directoryHasIndexSource(directory: string): boolean {
+  return SOURCE_EXTENSIONS.some((extension) =>
+    fs.existsSync(path.join(directory, `index${extension}`)),
+  );
+}
+
+export function sourceModuleKey(fileName: string): string | null {
+  if (isExcludedSourceFile(fileName)) return null;
+
+  const extension = SOURCE_EXTENSIONS.find((candidate) => fileName.endsWith(candidate));
+  return extension ? fileName.slice(0, -extension.length) : null;
+}
+
+export function isExcludedSourceFile(fileName: string): boolean {
+  return (
+    fileName.startsWith("index.") ||
+    fileName.endsWith(".d.ts") ||
+    /\.(test|spec|stories)\.[cm]?[tj]sx?$/.test(fileName) ||
+    /\.generated\.[cm]?[tj]sx?$/.test(fileName)
+  );
+}
+
+export function exportedSiblingModuleKeys(
+  sourceFile: ts.SourceFile,
+  options: Pick<ResolvedArchitectureOptions, "countTypeOnlyExports">,
+): ReadonlySet<string> {
+  const keys = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    const moduleKey = exportedSiblingModuleKey(statement, options);
+    if (moduleKey !== null) keys.add(moduleKey);
+  }
+
+  return keys;
+}
+
+function exportedSiblingModuleKey(
+  statement: ts.Statement,
+  options: Pick<ResolvedArchitectureOptions, "countTypeOnlyExports">,
+): string | null {
+  if (!ts.isExportDeclaration(statement)) return null;
+  if (!options.countTypeOnlyExports && exportDeclarationIsTypeOnly(statement)) return null;
+  const moduleSpecifier = statement.moduleSpecifier;
+  if (moduleSpecifier === undefined) return null;
+  if (!ts.isStringLiteral(moduleSpecifier)) return null;
+  return siblingModuleKeyFromSpecifier(moduleSpecifier.text);
+}
+
+export function exportDeclarationIsTypeOnly(statement: ts.ExportDeclaration): boolean {
+  if (statement.isTypeOnly) return true;
+  if (!statement.exportClause || !ts.isNamedExports(statement.exportClause)) return false;
+  return statement.exportClause.elements.every((specifier) => specifier.isTypeOnly);
+}
+
+export function siblingModuleKeyFromSpecifier(specifier: string): string | null {
+  if (!specifier.startsWith("./")) return null;
+
+  const segments = stripKnownExtension(specifier.slice(2))
+    .replaceAll("\\", "/")
+    .split("/")
+    .filter((segment) => segment.length > 0);
+
+  if (segments.length === 1) return segments[0] === "index" ? null : segments[0] ?? null;
+  if (segments.length === 2 && segments[1] === "index") return segments[0] ?? null;
+  return null;
+}
+
+function intersectSets<T>(left: ReadonlySet<T>, right: ReadonlySet<T>): ReadonlySet<T> {
+  return new Set([...left].filter((value) => right.has(value)));
+}

--- a/lsp/architecture/analyzer/folder-shape/README.md
+++ b/lsp/architecture/analyzer/folder-shape/README.md
@@ -1,0 +1,14 @@
+# Folder Shape
+
+This folder owns diagnostics about how large folders expose and document their
+children.
+
+- `large-folder.ts` enforces direct semantic-child budgets.
+- `index.ts` requires boundary documentation once a folder has enough
+  semantic children (the README-required check).
+- `explicit-api.ts` flags folders consumed through multiple concrete files.
+- `children/` contains shared semantic-child counting used by the folder-shape
+  diagnostics.
+
+Folder-shape rules should share counting logic through `children/` so threshold
+rules agree on what a semantic child means.

--- a/lsp/architecture/analyzer/folder-shape/children/index.ts
+++ b/lsp/architecture/analyzer/folder-shape/children/index.ts
@@ -1,0 +1,158 @@
+/**
+ * @file Folder-children analysis. Computes the direct production /
+ * test child sets for every folder in the project graph; consumed by
+ * folder-shape and shared-kernel cohesion checks.
+ */
+
+import path from "node:path";
+import {
+  explicitFacadeModule,
+  generatedModule,
+  type ProjectArchitectureGraph,
+  type SourceModule,
+} from "../../project/index.js";
+import {
+  stripKnownExtension,
+  type ResolvedArchitectureOptions,
+} from "../../project/api/index.js";
+
+interface MutableFolderChildren {
+  readonly folder: string;
+  readonly productionChildren: Set<string>;
+  readonly testChildren: Set<string>;
+  readonly files: Set<string>;
+}
+
+/**
+ * Snapshot of a folder's direct children, split by whether they are
+ * production or test-like modules.
+ */
+export interface FolderChildren {
+  /** Folder path relative to `src/`; the root folder is `.`. */
+  readonly folder: string;
+  /** Names of production children (subfolders + production file stems). */
+  readonly productionChildren: ReadonlySet<string>;
+  /** Names of test-like children (subfolders + test file stems). */
+  readonly testChildren: ReadonlySet<string>;
+  /** Absolute file names that contributed to this folder's child sets. */
+  readonly files: ReadonlySet<string>;
+}
+
+/**
+ * Compute the direct-child snapshot for every folder in the project
+ * graph. Walks each module's folder ancestry so an intermediate folder
+ * with no source files still appears if descendants live below it.
+ * Generated modules are skipped. Explicit facade modules are not
+ * counted as a direct file child of their own folder.
+ * @param graph Project architecture graph (modules, folders, edges).
+ * @param options Resolved architecture options used to identify
+ * explicit facade modules.
+ * @returns Folder-child snapshots sorted by folder path.
+ */
+export function folderChildren(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly FolderChildren[] {
+  const byFolder = new Map<string, MutableFolderChildren>();
+  for (const module of graph.modules) addModuleChildren(byFolder, module, options);
+  return [...byFolder.values()].sort(compareFolderChildren);
+}
+
+function addModuleChildren(
+  byFolder: Map<string, MutableFolderChildren>,
+  module: SourceModule,
+  options: ResolvedArchitectureOptions,
+): void {
+  if (generatedModule(module)) return;
+  const folderSegments = module.folder === "." ? [] : module.folder.split("/");
+  addAncestorFolderChildren(byFolder, module, folderSegments);
+  if (!explicitFacadeModule(module, options)) addDirectFileChild(byFolder, module);
+}
+
+function addAncestorFolderChildren(
+  byFolder: Map<string, MutableFolderChildren>,
+  module: SourceModule,
+  folderSegments: readonly string[],
+): void {
+  for (let index = 0; index < folderSegments.length; index += 1) {
+    const child = folderSegments[index];
+    if (child !== undefined) {
+      addChild(byFolder, folderFromSegments(folderSegments.slice(0, index)), child, module);
+    }
+  }
+}
+
+function addDirectFileChild(
+  byFolder: Map<string, MutableFolderChildren>,
+  module: SourceModule,
+): void {
+  addChild(byFolder, module.folder, fileChildName(module), module);
+}
+
+function addChild(
+  byFolder: Map<string, MutableFolderChildren>,
+  folder: string,
+  child: string,
+  module: SourceModule,
+): void {
+  const children = mutableFolderChildren(byFolder, folder);
+  const target = module.isTestLike ? children.testChildren : children.productionChildren;
+  target.add(child);
+  children.files.add(module.fileName);
+}
+
+function mutableFolderChildren(
+  byFolder: Map<string, MutableFolderChildren>,
+  folder: string,
+): MutableFolderChildren {
+  const existing = byFolder.get(folder);
+  if (existing) return existing;
+  const children = {
+    folder,
+    productionChildren: new Set<string>(),
+    testChildren: new Set<string>(),
+    files: new Set<string>(),
+  };
+  byFolder.set(folder, children);
+  return children;
+}
+
+function fileChildName(module: SourceModule): string {
+  const fileStem = stripKnownExtension(path.basename(module.fileName));
+  return module.isTestLike ? stripTestSuffix(fileStem) : fileStem;
+}
+
+function stripTestSuffix(fileStem: string): string {
+  return fileStem.replace(/\.(test|spec)$/, "");
+}
+
+function folderFromSegments(segments: readonly string[]): string {
+  return segments.length === 0 ? "." : segments.join("/");
+}
+
+function compareFolderChildren(
+  left: FolderChildren,
+  right: FolderChildren,
+): number {
+  return left.folder.localeCompare(right.folder);
+}
+
+/**
+ * First element of `values` after lexicographic sorting, or `null` if
+ * the set is empty. Used to produce stable, deterministic diagnostics.
+ * @param values Set of strings to sort.
+ * @returns Lexicographically smallest element, or `null` when empty.
+ */
+export function firstSorted(values: ReadonlySet<string>): string | null {
+  return [...values].sort()[0] ?? null;
+}
+
+/**
+ * Convert a folder key from the project graph (relative to `src/`, with
+ * the root encoded as `.`) into its display path under `src/`.
+ * @param folder Folder key as stored on `SourceModule.folder`.
+ * @returns Display path rooted at `src/`.
+ */
+export function sourceFolderPath(folder: string): string {
+  return folder === "." ? "src" : `src/${folder}`;
+}

--- a/lsp/architecture/analyzer/folder-shape/explicit-api.ts
+++ b/lsp/architecture/analyzer/folder-shape/explicit-api.ts
@@ -1,0 +1,229 @@
+import path from "node:path";
+import {
+  explicitFacadeModule,
+  generatedModule,
+} from "../project/index.js";
+import type {
+  LocalModuleEdge,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+interface FolderApiEvidence {
+  readonly folder: string;
+  readonly consumerFiles: ReadonlySet<string>;
+  readonly concreteTargetFiles: ReadonlySet<string>;
+  readonly facadeConsumerFiles: ReadonlySet<string>;
+}
+
+interface MutableFolderApiEvidence {
+  readonly folder: string;
+  readonly consumerFiles: Set<string>;
+  readonly concreteTargetFiles: Set<string>;
+  readonly facadeConsumerFiles: Set<string>;
+}
+
+interface ModulePair {
+  readonly fromModule: SourceModule;
+  readonly toModule: SourceModule;
+}
+
+export function explicitFolderApiDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return folderApiEvidence(graph, options).flatMap((evidence) =>
+    explicitFolderApiDiagnostic(evidence, graph, options)
+  );
+}
+
+function folderApiEvidence(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly FolderApiEvidence[] {
+  const evidenceByFolder = new Map<string, MutableFolderApiEvidence>();
+  for (const edge of graph.localEdges) {
+    addFolderApiEdgeEvidence(evidenceByFolder, graph, options, edge);
+  }
+  addFacadeConsumerEvidence(evidenceByFolder, graph, options);
+  return [...evidenceByFolder.values()].sort(compareFolderEvidence);
+}
+
+function addFolderApiEdgeEvidence(
+  evidenceByFolder: Map<string, MutableFolderApiEvidence>,
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+  edge: LocalModuleEdge,
+): void {
+  if (edge.kind !== "import") return;
+  const pair = modulePair(graph, edge);
+  if (pair === null || !concreteFolderApiTarget(pair.toModule, options)) return;
+  for (const folder of candidateApiFolders(pair.toModule.folder)) {
+    addFolderApiCandidate(evidenceByFolder, options, pair, folder);
+  }
+}
+
+function addFolderApiCandidate(
+  evidenceByFolder: Map<string, MutableFolderApiEvidence>,
+  options: ResolvedArchitectureOptions,
+  pair: ModulePair,
+  folder: string,
+): void {
+  if (ignoredFolderApiCandidate(pair, folder, options)) return;
+  const evidence = mutableFolderApiEvidence(evidenceByFolder, folder);
+  evidence.consumerFiles.add(pair.fromModule.fileName);
+  evidence.concreteTargetFiles.add(pair.toModule.fileName);
+}
+
+function mutableFolderApiEvidence(
+  evidenceByFolder: Map<string, MutableFolderApiEvidence>,
+  folder: string,
+): MutableFolderApiEvidence {
+  const existing = evidenceByFolder.get(folder);
+  if (existing) return existing;
+  const evidence = {
+    folder,
+    concreteTargetFiles: new Set<string>(),
+    consumerFiles: new Set<string>(),
+    facadeConsumerFiles: new Set<string>(),
+  };
+  evidenceByFolder.set(folder, evidence);
+  return evidence;
+}
+
+function addFacadeConsumerEvidence(
+  evidenceByFolder: ReadonlyMap<string, MutableFolderApiEvidence>,
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): void {
+  for (const edge of graph.localEdges) {
+    const pair = modulePair(graph, edge);
+    if (pair !== null) addFacadeConsumerPairEvidence(evidenceByFolder, pair, options);
+  }
+}
+
+function addFacadeConsumerPairEvidence(
+  evidenceByFolder: ReadonlyMap<string, MutableFolderApiEvidence>,
+  pair: ModulePair,
+  options: ResolvedArchitectureOptions,
+): void {
+  const evidence = evidenceByFolder.get(pair.toModule.folder);
+  if (!evidence || !explicitFacadeModule(pair.toModule, options)) return;
+  if (!outsideFolder(pair.fromModule, pair.toModule.folder)) return;
+  evidence.facadeConsumerFiles.add(pair.fromModule.fileName);
+}
+
+function explicitFolderApiDiagnostic(
+  evidence: FolderApiEvidence,
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  if (evidence.concreteTargetFiles.size < options.minExplicitApiConcreteFiles) return [];
+  if (hasDominantFacadeConsumers(evidence)) return [];
+  const file = firstSorted(evidence.concreteTargetFiles) ?? graph.reportFile;
+  return [folderApiDiagnostic(file, evidence, graph.projectRoot)];
+}
+
+function folderApiDiagnostic(
+  file: string,
+  evidence: FolderApiEvidence,
+  projectRoot: string,
+): ArchitectureDiagnostic {
+  const folderPath = sourceFolderPath(evidence.folder);
+  return {
+    ruleId: "folder-explicit-api-required",
+    file,
+    severity: "warn",
+    message:
+      `${folderPath} is being consumed as a folder API through ` +
+      `${evidence.concreteTargetFiles.size} concrete files. Add ` +
+      `${folderPath}/index.ts, or list a deliberate non-index facade in ` +
+      `architecture facadeFiles and make outside code import it. Project root: ` +
+      `${path.basename(projectRoot)}.`,
+  };
+}
+
+const DOMINANT_FACADE_RATIO = 0.8;
+
+function hasDominantFacadeConsumers(evidence: FolderApiEvidence): boolean {
+  if (evidence.consumerFiles.size === 0) return false;
+  const overlap = setIntersectionSize(evidence.consumerFiles, evidence.facadeConsumerFiles);
+  return overlap / evidence.consumerFiles.size >= DOMINANT_FACADE_RATIO;
+}
+
+function concreteFolderApiTarget(
+  module: SourceModule,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  return !explicitFacadeModule(module, options) &&
+    !module.isTestLike &&
+    !generatedModule(module);
+}
+
+function ignoredFolderApiCandidate(
+  pair: ModulePair,
+  folder: string,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  return !outsideFolder(pair.fromModule, folder) ||
+    sharedFolder(options, folder) ||
+    pair.fromModule.isTestLike ||
+    generatedModule(pair.fromModule);
+}
+
+function compareFolderEvidence(
+  left: FolderApiEvidence,
+  right: FolderApiEvidence,
+): number {
+  return left.folder.localeCompare(right.folder);
+}
+
+function modulePair(
+  graph: ProjectArchitectureGraph,
+  edge: LocalModuleEdge,
+): ModulePair | null {
+  const fromModule = graph.modulesByFileName.get(edge.from);
+  const toModule = graph.modulesByFileName.get(edge.to);
+  return fromModule && toModule ? { fromModule, toModule } : null;
+}
+
+function candidateApiFolders(folder: string): readonly string[] {
+  if (folder === ".") return [];
+  const segments = folder.split("/");
+  return segments.map((_, index) => segments.slice(0, index + 1).join("/"));
+}
+
+function outsideFolder(module: SourceModule, folder: string): boolean {
+  return !folderContains(folder, module.folder);
+}
+
+function folderContains(parent: string, child: string): boolean {
+  return parent === child || child.startsWith(`${parent}/`);
+}
+
+function sharedFolder(
+  options: ResolvedArchitectureOptions,
+  folder: string,
+): boolean {
+  return options.sharedFolderNames.some((entry) => folderContains(entry.folder, folder));
+}
+
+function firstSorted(values: ReadonlySet<string>): string | null {
+  return [...values].sort()[0] ?? null;
+}
+
+function sourceFolderPath(folder: string): string {
+  return folder === "." ? "src" : `src/${folder}`;
+}
+
+function setIntersectionSize<T>(
+  left: ReadonlySet<T>,
+  right: ReadonlySet<T>,
+): number {
+  let count = 0;
+  for (const value of left) {
+    if (right.has(value)) count += 1;
+  }
+  return count;
+}

--- a/lsp/architecture/analyzer/folder-shape/folder-shape.analyzer.test.ts
+++ b/lsp/architecture/analyzer/folder-shape/folder-shape.analyzer.test.ts
@@ -1,0 +1,210 @@
+import * as fc from "fast-check";
+import { afterEach, expect, it } from "vitest";
+import { folderDistance } from "../imports/folder-distance.js";
+import {
+  cleanupArchitectureFixtures,
+  diagnosticsByRule,
+  makeProject,
+  segmentArb,
+} from "../test-support/analyzer-fixtures.js";
+
+afterEach(cleanupArchitectureFixtures);
+
+it("Property: large folder diagnostics follow semantic and unpaired test budgets", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 5 }),
+      fc.integer({ min: 0, max: 5 }),
+      (productionCount, unpairedTestCount) => {
+        const root = makeProject(folderSizeFiles(productionCount, unpairedTestCount));
+        const diagnostics = diagnosticsByRule(root, "no-large-folder", {
+          maxFolderChildren: 3,
+          maxFolderChildrenIncludingTests: 6,
+          maxUnpairedTestChildren: 2,
+        });
+        const testCount = productionCount + unpairedTestCount;
+        expect(diagnostics.length > 0)
+          .toBe(
+            productionCount > 3 ||
+            productionCount + testCount > 6 ||
+            unpairedTestCount > 2,
+          );
+      },
+    ),
+    { numRuns: 24 },
+  );
+});
+
+it("Property: flat test folders follow the including-tests budget", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 24 }),
+      fc.integer({ min: 1, max: 20 }),
+      (testCount, maxFolderChildrenIncludingTests) => {
+        const root = makeProject({
+          "tsconfig.json": fixtureTsconfig(["src/**/*", "tests/**/*"]),
+          ...standaloneTestFiles(testCount),
+        });
+        const diagnostics = diagnosticsByRule(root, "no-large-folder", {
+          maxFolderChildren: 10,
+          maxFolderChildrenIncludingTests,
+          maxUnpairedTestChildren: 24,
+        });
+        expect(diagnostics.length > 0).toBe(testCount > maxFolderChildrenIncludingTests);
+      },
+    ),
+    { numRuns: 16 },
+  );
+});
+
+it("lint tsconfig includes tests even when the production tsconfig excludes them", () => {
+  const root = makeProject({
+    "tsconfig.json": fixtureTsconfig(["src/**/*"], ["src/**/*.test.ts"]),
+    "tsconfig.lint.json": fixtureTsconfig(["src/**/*"], []),
+    ...unpairedTestFiles("src/rules", 4),
+  });
+  const options = {
+    maxFolderChildren: 10,
+    maxFolderChildrenIncludingTests: 3,
+    maxUnpairedTestChildren: 10,
+  };
+
+  expect(diagnosticsByRule(root, "no-large-folder", options)).toHaveLength(0);
+  expect(diagnosticsByRule(root, "no-large-folder", {
+    ...options,
+    tsconfigPath: "tsconfig.lint.json",
+  }).length).toBeGreaterThan(0);
+});
+
+it("default folder child budgets are 10 production and 20 including tests", () => {
+  expect(diagnosticsByRule(makeProject(folderSizeFiles(10, 0)), "no-large-folder"))
+    .toHaveLength(0);
+  expect(diagnosticsByRule(makeProject(folderSizeFiles(11, 0)), "no-large-folder").length)
+    .toBeGreaterThan(0);
+  expect(diagnosticsByRule(makeProject(folderSizeFiles(10, 1)), "no-large-folder").length)
+    .toBeGreaterThan(0);
+});
+
+it("Property: folders over the README threshold require configured boundary docs", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 6 }),
+      fc.integer({ min: 2, max: 6 }),
+      fc.boolean(),
+      fc.constantFrom("README.md", "ARCHITECTURE.md"),
+      (productionCount, minFolderReadmeChildren, hasReadme, readmeName) => {
+        const root = makeProject({
+          ...folderSizeFiles(productionCount, 0),
+          ...(hasReadme ? { [`src/rules/${readmeName}`]: "# Rules\n" } : {}),
+        });
+        const diagnostics = diagnosticsByRule(root, "folder-readme-required", {
+          minFolderReadmeChildren,
+          folderReadmeFileNames: [readmeName],
+        });
+
+        expect(diagnostics.length > 0)
+          .toBe(productionCount >= minFolderReadmeChildren && !hasReadme);
+      },
+    ),
+    { numRuns: 24 },
+  );
+});
+
+it("Property: distant folder imports follow folder-hop budget", () => {
+  fc.assert(
+    fc.property(
+      fc.array(segmentArb, { minLength: 1, maxLength: 4 }),
+      fc.array(segmentArb, { minLength: 1, maxLength: 4 }),
+      fc.integer({ min: 1, max: 6 }),
+      (fromSegments, toSegments, maxFolderImportDistance) => {
+        fc.pre(folderKey(fromSegments) !== folderKey(toSegments));
+        const root = makeProject(distantImportFiles(fromSegments, toSegments));
+        const diagnostics = diagnosticsByRule(root, "no-distant-folder-import", {
+          maxFolderImportDistance,
+        });
+        const expectedDistance = folderDistance(
+          folderKey(fromSegments),
+          folderKey(toSegments),
+        );
+        expect(diagnostics.length > 0).toBe(expectedDistance > maxFolderImportDistance);
+      },
+    ),
+    { numRuns: 16 },
+  );
+});
+
+function folderSizeFiles(
+  productionCount: number,
+  unpairedTestCount: number,
+): Record<string, string> {
+  return {
+    ...pairedProductionFiles(productionCount),
+    ...unpairedTestFiles("src/rules", unpairedTestCount),
+  };
+}
+
+function pairedProductionFiles(count: number): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, index) => [
+      [`src/rules/case-${index}.ts`, `export const case${index} = true;\n`],
+      [`src/rules/case-${index}.test.ts`, `export const case${index}Test = true;\n`],
+    ]).flat(),
+  );
+}
+
+function standaloneTestFiles(count: number): Record<string, string> {
+  return {
+    ...unpairedTestFiles("tests", count),
+  };
+}
+
+function unpairedTestFiles(directory: string, count: number): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: count }, (_, index) => [
+      `${directory}/orphan-${index}.test.ts`,
+      `export const orphan${index} = true;\n`,
+    ]),
+  );
+}
+
+function distantImportFiles(
+  fromSegments: readonly string[],
+  toSegments: readonly string[],
+): Record<string, string> {
+  return {
+    [`src/${folderKey(fromSegments)}/index.ts`]: [
+      `import { value } from "${relativeImport(fromSegments, toSegments)}";`,
+      "export const own = value;",
+    ].join("\n"),
+    [`src/${folderKey(toSegments)}/index.ts`]: "export const value = true;\n",
+  };
+}
+
+function relativeImport(
+  fromSegments: readonly string[],
+  toSegments: readonly string[],
+): string {
+  return `${"../".repeat(fromSegments.length)}${folderKey(toSegments)}/index`;
+}
+
+function folderKey(segments: readonly string[]): string {
+  return segments.join("/");
+}
+
+function fixtureTsconfig(
+  include: readonly string[],
+  exclude: readonly string[] = [],
+): string {
+  return JSON.stringify({
+    compilerOptions: {
+      target: "ES2022",
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      strict: true,
+      skipLibCheck: true,
+      rootDir: ".",
+    },
+    include,
+    exclude,
+  });
+}

--- a/lsp/architecture/analyzer/folder-shape/index.ts
+++ b/lsp/architecture/analyzer/folder-shape/index.ts
@@ -1,0 +1,87 @@
+/**
+ * @file Folder-shape analysis barrel. Composes the per-rule folder
+ * shape checks (child-count budget, README requirement, explicit-API
+ * requirement) into a single project-level diagnostic pass.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { uniqueDiagnostics } from "../project/api/index.js";
+import { explicitFolderApiDiagnostics } from "./explicit-api.js";
+import { folderChildLimitDiagnostics } from "./large-folder.js";
+import {
+  firstSorted,
+  folderChildren,
+  sourceFolderPath,
+  type FolderChildren,
+} from "./children/index.js";
+import type { ProjectArchitectureGraph } from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+/**
+ * Run every folder-shape architecture check (child-count budget, README
+ * requirement, explicit-API requirement) against the project graph and
+ * return a deduplicated diagnostic list.
+ * @param graph Project architecture graph (modules, folders, edges).
+ * @param options Resolved architecture rule options with policy lists.
+ * @returns Deduplicated diagnostics; empty array when the folder layer
+ * is healthy.
+ */
+export function checkFolderShape(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return uniqueDiagnostics([
+    ...folderChildLimitDiagnostics(graph, options),
+    ...folderReadmeRequiredDiagnostics(graph, options),
+    ...explicitFolderApiDiagnostics(graph, options),
+  ]);
+}
+
+function folderReadmeRequiredDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return folderChildren(graph, options).flatMap((children) =>
+    folderReadmeRequiredDiagnostic(children, graph, options)
+  );
+}
+
+function folderReadmeRequiredDiagnostic(
+  children: FolderChildren,
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  if (children.productionChildren.size < options.minFolderReadmeChildren) return [];
+  if (folderHasReadme(graph, children.folder, options)) return [];
+  return [missingReadmeDiagnostic(children, graph, options)];
+}
+
+function folderHasReadme(
+  graph: ProjectArchitectureGraph,
+  folder: string,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  const directory = path.join(graph.projectRoot, sourceFolderPath(folder));
+  return options.folderReadmeFileNames.some((fileName) =>
+    fs.existsSync(path.join(directory, fileName))
+  );
+}
+
+function missingReadmeDiagnostic(
+  children: FolderChildren,
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): ArchitectureDiagnostic {
+  const folderPath = sourceFolderPath(children.folder);
+  const readmeName = options.folderReadmeFileNames[0] ?? "README.md";
+  return {
+    ruleId: "folder-readme-required",
+    file: firstSorted(children.files) ?? graph.reportFile,
+    severity: "warn",
+    message:
+      `${folderPath} has ${children.productionChildren.size} direct semantic children ` +
+      `(threshold ${options.minFolderReadmeChildren}) but no configured README file. ` +
+      `Add ${folderPath}/${readmeName} describing the folder boundary, or split the folder.`,
+  };
+}

--- a/lsp/architecture/analyzer/folder-shape/large-folder.ts
+++ b/lsp/architecture/analyzer/folder-shape/large-folder.ts
@@ -1,0 +1,128 @@
+import {
+  firstSorted,
+  folderChildren,
+  sourceFolderPath,
+  type FolderChildren,
+} from "./children/index.js";
+import type { ProjectArchitectureGraph } from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+interface FolderSizeStats {
+  readonly productionChildren: readonly string[];
+  readonly testChildren: readonly string[];
+  readonly unpairedTestChildren: readonly string[];
+  readonly visibleChildren: readonly string[];
+  readonly totalChildrenIncludingTests: number;
+  readonly maxProductionChildren: number;
+  readonly maxChildrenIncludingTests: number;
+  readonly maxUnpairedTestChildren: number;
+}
+
+export function folderChildLimitDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return folderChildren(graph, options).flatMap((children) =>
+    folderChildLimitDiagnostic(children, graph, options)
+  );
+}
+
+function folderChildLimitDiagnostic(
+  children: FolderChildren,
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  const stats = folderSizeStats(children, options);
+  if (!largeFolder(stats)) return [];
+  return [largeFolderDiagnostic(children, graph, stats)];
+}
+
+function folderSizeStats(
+  children: FolderChildren,
+  options: ResolvedArchitectureOptions,
+): FolderSizeStats {
+  const unpairedTestChildren = setDifference(children.testChildren, children.productionChildren);
+  const productionChildren = [...children.productionChildren].sort();
+  const testChildren = [...children.testChildren].sort();
+  return {
+    productionChildren,
+    testChildren,
+    unpairedTestChildren,
+    visibleChildren: unionSorted(productionChildren, testChildren),
+    totalChildrenIncludingTests: productionChildren.length + testChildren.length,
+    maxProductionChildren: maxChildrenForFolder(children.folder, options),
+    maxChildrenIncludingTests: maxChildrenIncludingTestsForFolder(children.folder, options),
+    maxUnpairedTestChildren: maxUnpairedTestChildrenForFolder(children.folder, options),
+  };
+}
+
+function largeFolder(stats: FolderSizeStats): boolean {
+  return stats.productionChildren.length > stats.maxProductionChildren ||
+    stats.totalChildrenIncludingTests > stats.maxChildrenIncludingTests ||
+    stats.unpairedTestChildren.length > stats.maxUnpairedTestChildren;
+}
+
+function maxChildrenForFolder(
+  folder: string,
+  options: ResolvedArchitectureOptions,
+): number {
+  return folderChildLimitOverride(folder, options)?.maxChildren ?? options.maxFolderChildren;
+}
+
+function maxChildrenIncludingTestsForFolder(
+  folder: string,
+  options: ResolvedArchitectureOptions,
+): number {
+  return folderChildLimitOverride(folder, options)?.maxChildrenIncludingTests ??
+    options.maxFolderChildrenIncludingTests;
+}
+
+function maxUnpairedTestChildrenForFolder(
+  folder: string,
+  options: ResolvedArchitectureOptions,
+): number {
+  return folderChildLimitOverride(folder, options)?.maxUnpairedTestChildren ??
+    options.maxUnpairedTestChildren;
+}
+
+function folderChildLimitOverride(
+  folder: string,
+  options: ResolvedArchitectureOptions,
+): ResolvedArchitectureOptions["folderChildCountOverrides"][number] | undefined {
+  return options.folderChildCountOverrides.find((entry) => entry.folder === folder);
+}
+
+function largeFolderDiagnostic(
+  children: FolderChildren,
+  graph: ProjectArchitectureGraph,
+  stats: FolderSizeStats,
+): ArchitectureDiagnostic {
+  const file = firstSorted(children.files) ?? graph.reportFile;
+  return {
+    ruleId: "no-large-folder",
+    file,
+    severity: "warn",
+    message:
+      `${sourceFolderPath(children.folder)} has ${stats.productionChildren.length} ` +
+      `direct production children (max ${stats.maxProductionChildren}), ` +
+      `${stats.totalChildrenIncludingTests} children including tests (max ` +
+      `${stats.maxChildrenIncludingTests}), and ${stats.unpairedTestChildren.length} ` +
+      `unpaired test children (max ${stats.maxUnpairedTestChildren}): ` +
+      `${stats.visibleChildren.slice(0, 6).join(", ")}. ` +
+      "Split broad package-tree folders into semantic subfolders or pair tests with the code they exercise.",
+  };
+}
+
+function setDifference(
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>,
+): readonly string[] {
+  return [...left].filter((value) => !right.has(value)).sort();
+}
+
+function unionSorted(
+  leftValues: readonly string[],
+  rightValues: readonly string[],
+): readonly string[] {
+  return [...new Set([...leftValues, ...rightValues])].sort();
+}

--- a/lsp/architecture/analyzer/imports/README.md
+++ b/lsp/architecture/analyzer/imports/README.md
@@ -1,0 +1,14 @@
+# Import Graph
+
+This folder owns local import resolution and graph analysis for architecture
+diagnostics.
+
+- `project-graph/` builds the project graph facade from TypeScript source.
+- `specifier-resolution.ts` resolves local module specifiers.
+- `edges.ts`, `folder-edges.ts`, and `folder-graph.ts` derive module and folder
+  dependency graphs.
+- `folder-distance.ts` measures import reach across folder paths.
+- `module-symbols.ts` extracts exported symbol relationships from source files.
+
+Code outside this folder should prefer `index.ts` or the higher-level
+architecture/project facades instead of importing graph internals directly.

--- a/lsp/architecture/analyzer/imports/edges.ts
+++ b/lsp/architecture/analyzer/imports/edges.ts
@@ -1,0 +1,136 @@
+import path from "node:path";
+import ts from "typescript";
+import { resolveLocalSpecifier } from "./specifier-resolution.js";
+import type {
+  ExternalModuleEdge,
+  LocalModuleEdge,
+  ModuleEdgeKind,
+} from "../project/index.js";
+
+export interface ModuleEdges {
+  readonly localEdges: readonly LocalModuleEdge[];
+  readonly externalEdges: readonly ExternalModuleEdge[];
+}
+
+interface SpecifierEdgeContext {
+  readonly fromFile: string;
+  readonly moduleSpecifier: ts.Expression;
+  readonly typeOnly: boolean;
+  readonly kind: ModuleEdgeKind;
+  readonly sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>;
+}
+
+export function collectModuleEdges(
+  sourceFile: ts.SourceFile,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): ModuleEdges {
+  const localEdges: LocalModuleEdge[] = [];
+  const externalEdges: ExternalModuleEdge[] = [];
+
+  for (const statement of sourceFile.statements) {
+    const context = specifierEdgeContext(sourceFile, statement, sourceFilesByPath);
+    if (context !== null) collectSpecifierEdge(context, localEdges, externalEdges);
+  }
+
+  return { localEdges, externalEdges };
+}
+
+function specifierEdgeContext(
+  sourceFile: ts.SourceFile,
+  statement: ts.Statement,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): SpecifierEdgeContext | null {
+  if (ts.isImportDeclaration(statement)) {
+    return {
+      fromFile: sourceFile.fileName,
+      moduleSpecifier: statement.moduleSpecifier,
+      typeOnly: importDeclarationIsTypeOnly(statement),
+      kind: "import",
+      sourceFilesByPath,
+    };
+  }
+  if (!ts.isExportDeclaration(statement) || !statement.moduleSpecifier) return null;
+  return {
+    fromFile: sourceFile.fileName,
+    moduleSpecifier: statement.moduleSpecifier,
+    typeOnly: exportDeclarationIsTypeOnly(statement),
+    kind: "reexport",
+    sourceFilesByPath,
+  };
+}
+
+function collectSpecifierEdge(
+  context: SpecifierEdgeContext,
+  localEdges: LocalModuleEdge[],
+  externalEdges: ExternalModuleEdge[],
+): void {
+  if (!ts.isStringLiteral(context.moduleSpecifier)) return;
+  const specifier = context.moduleSpecifier.text;
+  const localTarget = resolveLocalSpecifier(
+    context.fromFile,
+    specifier,
+    context.sourceFilesByPath,
+  );
+  if (localTarget) {
+    localEdges.push(localModuleEdge(context, localTarget, specifier));
+    return;
+  }
+  const packageName = packageNameFromSpecifier(specifier);
+  if (packageName !== null) {
+    externalEdges.push(externalModuleEdge(context, packageName, specifier));
+  }
+}
+
+function localModuleEdge(
+  context: SpecifierEdgeContext,
+  localTarget: string,
+  specifier: string,
+): LocalModuleEdge {
+  return {
+    from: path.resolve(context.fromFile),
+    to: localTarget,
+    kind: context.kind,
+    typeOnly: context.typeOnly,
+    specifier,
+  };
+}
+
+function externalModuleEdge(
+  context: SpecifierEdgeContext,
+  packageName: string,
+  specifier: string,
+): ExternalModuleEdge {
+  return {
+    from: path.resolve(context.fromFile),
+    packageName,
+    kind: context.kind,
+    typeOnly: context.typeOnly,
+    specifier,
+  };
+}
+
+function importDeclarationIsTypeOnly(statement: ts.ImportDeclaration): boolean {
+  if (statement.importClause?.isTypeOnly) return true;
+  const namedBindings = statement.importClause?.namedBindings;
+  return Boolean(
+    namedBindings &&
+      ts.isNamedImports(namedBindings) &&
+      namedBindings.elements.length > 0 &&
+      namedBindings.elements.every((element) => element.isTypeOnly),
+  );
+}
+
+function exportDeclarationIsTypeOnly(statement: ts.ExportDeclaration): boolean {
+  if (statement.isTypeOnly) return true;
+  if (!statement.exportClause || !ts.isNamedExports(statement.exportClause)) return false;
+  return statement.exportClause.elements.every((specifier) => specifier.isTypeOnly);
+}
+
+function packageNameFromSpecifier(specifier: string): string | null {
+  if (specifier.startsWith(".") || specifier.startsWith("/")) return null;
+  if (specifier.startsWith("node:")) return "node";
+
+  const segments = specifier.split("/");
+  if (segments[0]?.startsWith("@")) return segments.slice(0, 2).join("/");
+  return segments[0] ?? null;
+}

--- a/lsp/architecture/analyzer/imports/folder-distance.ts
+++ b/lsp/architecture/analyzer/imports/folder-distance.ts
@@ -1,0 +1,97 @@
+import type {
+  LocalModuleEdge,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "./project-graph/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+export function distantFolderImportDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.localEdges.flatMap((edge) =>
+    distantFolderImportDiagnostic(graph, options, edge)
+  );
+}
+
+export function folderDistance(left: string, right: string): number {
+  const leftSegments = folderSegments(left);
+  const rightSegments = folderSegments(right);
+  const sharedPrefixLength = commonPrefixLength(leftSegments, rightSegments);
+  return leftSegments.length + rightSegments.length - (2 * sharedPrefixLength);
+}
+
+function distantFolderImportDiagnostic(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+  edge: LocalModuleEdge,
+): readonly ArchitectureDiagnostic[] {
+  if (edge.kind !== "import") return [];
+  const pair = modulePair(graph, edge);
+  if (pair === null || ignoredModulePair(pair.fromModule, pair.toModule)) return [];
+  const distance = folderDistance(pair.fromModule.folder, pair.toModule.folder);
+  if (distance <= options.maxFolderImportDistance) return [];
+  return [distantImportDiagnostic(pair.fromModule, pair.toModule, distance, options)];
+}
+
+function ignoredModulePair(fromModule: SourceModule, toModule: SourceModule): boolean {
+  return fromModule.isTestLike ||
+    toModule.isTestLike ||
+    generatedModule(fromModule) ||
+    generatedModule(toModule);
+}
+
+function distantImportDiagnostic(
+  fromModule: SourceModule,
+  toModule: SourceModule,
+  distance: number,
+  options: ResolvedArchitectureOptions,
+): ArchitectureDiagnostic {
+  return {
+    ruleId: "no-distant-folder-import",
+    file: fromModule.fileName,
+    severity: "warn",
+    message:
+      `${fromModule.relativePath} imports ${toModule.relativePath} across ` +
+      `${distance} folder hops (max ${options.maxFolderImportDistance}). ` +
+      `Use a nearer facade/port instead of reaching from ` +
+      `${sourceFolderPath(fromModule.folder)} into ${sourceFolderPath(toModule.folder)}.`,
+  };
+}
+
+function folderSegments(folder: string): readonly string[] {
+  return folder === "." ? [] : folder.split("/");
+}
+
+function commonPrefixLength(
+  leftSegments: readonly string[],
+  rightSegments: readonly string[],
+): number {
+  let index = 0;
+  while (
+    index < leftSegments.length &&
+    index < rightSegments.length &&
+    leftSegments[index] === rightSegments[index]
+  ) {
+    index += 1;
+  }
+  return index;
+}
+
+function modulePair(
+  graph: ProjectArchitectureGraph,
+  edge: LocalModuleEdge,
+): { readonly fromModule: SourceModule; readonly toModule: SourceModule } | null {
+  const fromModule = graph.modulesByFileName.get(edge.from);
+  const toModule = graph.modulesByFileName.get(edge.to);
+  return fromModule && toModule ? { fromModule, toModule } : null;
+}
+
+function generatedModule(module: SourceModule): boolean {
+  return /(^|\/)(__generated__|generated)(\/|$)/.test(module.relativePath) ||
+    /\.(generated|gen)\.[cm]?[tj]sx?$/.test(module.relativePath);
+}
+
+function sourceFolderPath(folder: string): string {
+  return folder === "." ? "src" : `src/${folder}`;
+}

--- a/lsp/architecture/analyzer/imports/folder-edges.ts
+++ b/lsp/architecture/analyzer/imports/folder-edges.ts
@@ -1,0 +1,81 @@
+import type {
+  FolderEdge,
+  LocalModuleEdge,
+  SourceModule,
+} from "../project/index.js";
+
+interface FolderEdgeRecord {
+  readonly key: string;
+  readonly fileName: string;
+  readonly metadata: Omit<FolderEdge, "files">;
+}
+
+export function collectFolderEdges(
+  localEdges: readonly LocalModuleEdge[],
+  modulesByFileName: ReadonlyMap<string, SourceModule>,
+): readonly FolderEdge[] {
+  const edgeFilesByKey = new Map<string, Set<string>>();
+  const edgeMetadataByKey = new Map<string, Omit<FolderEdge, "files">>();
+
+  for (const edge of localEdges) {
+    const record = folderEdgeRecord(edge, modulesByFileName);
+    if (record !== null) {
+      addFolderEdgeRecord(record, edgeFilesByKey, edgeMetadataByKey);
+    }
+  }
+
+  return [...edgeMetadataByKey.entries()]
+    .map(([key, edge]) => ({
+      ...edge,
+      files: [...(edgeFilesByKey.get(key) ?? [])].sort(),
+    }))
+    .sort(compareFolderEdges);
+}
+
+function folderEdgeRecord(
+  edge: LocalModuleEdge,
+  modulesByFileName: ReadonlyMap<string, SourceModule>,
+): FolderEdgeRecord | null {
+  const fromModule = modulesByFileName.get(edge.from);
+  const toModule = modulesByFileName.get(edge.to);
+  if (!fromModule || !toModule) return null;
+  if (fromModule.folder === toModule.folder) return null;
+  if (nestedNonRootFolderPair(fromModule.folder, toModule.folder)) return null;
+  return {
+    key: `${fromModule.folder}\0${toModule.folder}\0${edge.kind}`,
+    fileName: fromModule.fileName,
+    metadata: {
+      from: fromModule.folder,
+      to: toModule.folder,
+      kind: edge.kind,
+    },
+  };
+}
+
+function nestedNonRootFolderPair(left: string, right: string): boolean {
+  if (left === "." || right === ".") return false;
+  return folderContains(left, right) || folderContains(right, left);
+}
+
+function folderContains(parent: string, child: string): boolean {
+  return parent === child || child.startsWith(`${parent}/`);
+}
+
+function addFolderEdgeRecord(
+  record: FolderEdgeRecord,
+  edgeFilesByKey: Map<string, Set<string>>,
+  edgeMetadataByKey: Map<string, Omit<FolderEdge, "files">>,
+): void {
+  const files = edgeFilesByKey.get(record.key) ?? new Set<string>();
+  files.add(record.fileName);
+  edgeFilesByKey.set(record.key, files);
+  edgeMetadataByKey.set(record.key, record.metadata);
+}
+
+function compareFolderEdges(left: FolderEdge, right: FolderEdge): number {
+  return folderEdgeKey(left).localeCompare(folderEdgeKey(right));
+}
+
+function folderEdgeKey(edge: FolderEdge): string {
+  return `${edge.from}/${edge.to}/${edge.kind}`;
+}

--- a/lsp/architecture/analyzer/imports/folder-graph.analyzer.test.ts
+++ b/lsp/architecture/analyzer/imports/folder-graph.analyzer.test.ts
@@ -1,0 +1,225 @@
+import * as fc from "fast-check";
+import { afterEach, expect, it } from "vitest";
+import {
+  cleanupArchitectureFixtures,
+  diagnosticMessages,
+  diagnosticsByRule,
+  diagnosticsFor,
+  hasRule,
+  makeProject,
+  segmentArb,
+} from "../test-support/analyzer-fixtures.js";
+
+afterEach(cleanupArchitectureFixtures);
+
+it("flags folder cycles, root/internal cycles, and sibling domain imports", () => {
+  const root = makeProject({
+    "src/index.ts": [
+      'import { internalValue } from "./internal/value";',
+      "export const rootValue = internalValue;",
+    ].join("\n"),
+    "src/internal/value.ts": [
+      'import { rootValue } from "../index";',
+      "export const internalValue = rootValue;",
+    ].join("\n"),
+    "src/billing/charge.ts": [
+      'import { sendReceipt } from "../mail/send-receipt";',
+      "export const charge = sendReceipt;",
+    ].join("\n"),
+    "src/mail/send-receipt.ts": "export const sendReceipt = true;\n",
+  });
+
+  expect(diagnosticMessages(root)).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining("Folder dependency cycle"),
+      expect.stringContaining("Root files and internal files depend on each other"),
+      expect.stringContaining("imports src/mail/send-receipt.ts across sibling domains"),
+    ]),
+  );
+});
+
+it("flags upward layer imports when layers are declared", () => {
+  const root = makeProject({
+    "src/index.ts": "export const rootValue = true;\n",
+    "src/feature/use-root.ts": [
+      'import { rootValue } from "../index";',
+      "export const useRoot = rootValue;",
+    ].join("\n"),
+  });
+
+  const messages = diagnosticMessages(root, {
+    layers: [
+      { name: "entrypoint", folders: ["."], reason: "test: composition root" },
+      { name: "feature", folders: ["feature"], reason: "test: feature layer" },
+    ],
+  });
+  expect(messages).toEqual(
+    expect.arrayContaining([expect.stringContaining("imports upward into src/index.ts")]),
+  );
+  expect(messages.some((message) => message.includes("layer 'feature'"))).toBe(true);
+  expect(messages.some((message) => message.includes("layer 'entrypoint'"))).toBe(true);
+});
+
+it("no-upward-layer-import is dormant when no layers are declared", () => {
+  const root = makeProject({
+    "src/index.ts": "export const rootValue = true;\n",
+    "src/feature/use-root.ts": [
+      'import { rootValue } from "../index";',
+      "export const useRoot = rootValue;",
+    ].join("\n"),
+  });
+
+  expect(diagnosticMessages(root).some((message) => message.includes("imports upward")))
+    .toBe(false);
+});
+
+it("allows sibling domain imports through declared shared folders and test files", () => {
+  const root = makeProject({
+    "src/payments/charge.ts": [
+      'import { sendReceipt } from "../mail/send-receipt";',
+      'import { formatMoney } from "../shared/format-money";',
+      "export const charge = [sendReceipt, formatMoney];",
+    ].join("\n"),
+    "src/payments/charge.test.ts": [
+      'import { sendReceipt } from "../mail/send-receipt";',
+      "export const testOnly = sendReceipt;",
+    ].join("\n"),
+    "src/mail/send-receipt.ts": "export const sendReceipt = true;\n",
+    "src/shared/format-money.ts": "export const formatMoney = true;\n",
+  });
+
+  const diagnostics = diagnosticsByRule(root, "no-cross-domain-sibling-import", {
+    sharedFolderNames: [
+      { folder: "shared", reason: "test: package-wide formatting helpers" },
+    ],
+  });
+
+  expect(diagnostics.map((diagnostic) => diagnostic.message)).toEqual([
+    expect.stringContaining("src/payments/charge.ts imports src/mail/send-receipt.ts"),
+  ]);
+});
+
+it("does not treat re-exports or test files as upward layer imports", () => {
+  const root = makeProject({
+    "src/index.ts": "export const rootValue = true;\n",
+    "src/feature/reexport-root.ts": 'export { rootValue } from "../index";\n',
+    "src/feature/use-root.test.ts": [
+      'import { rootValue } from "../index";',
+      "export const useRoot = rootValue;",
+    ].join("\n"),
+  });
+
+  expect(
+    diagnosticsByRule(root, "no-upward-layer-import", {
+      layers: [
+        { name: "entrypoint", folders: ["."], reason: "test: composition root" },
+        { name: "feature", folders: ["feature"], reason: "test: feature layer" },
+      ],
+    }),
+  ).toEqual([]);
+});
+
+it("Property: folder cycles and package mesh follow generated dependency shape", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 2, maxLength: 7 }),
+      fc.boolean(),
+      (folders, closeCycle) => {
+        const root = makeProject(folderCycleFiles(folders, closeCycle));
+        const diagnostics = diagnosticsFor(root, {
+          minPackageMeshFolders: folders.length,
+          maxFolderEdgeDensity: 1,
+        });
+
+        expect(hasRule(diagnostics, "no-folder-cycle")).toBe(closeCycle);
+        expect(hasRule(diagnostics, "no-package-mesh")).toBe(closeCycle);
+      },
+    ),
+    { numRuns: 8 },
+  );
+});
+
+it("Property: upward edges flag and downward edges do not in layered configs", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 2 }),
+      fc.integer({ min: 0, max: 2 }),
+      (fromIndex, toIndex) => {
+        const folders = ["app", "domain", "kernel"] as const;
+        if (fromIndex === toIndex) return;
+        const messages = layeredImportDiagnostics(folders, fromIndex, toIndex);
+        if (fromIndex > toIndex) {
+          expect(messages.length).toBeGreaterThan(0);
+          expect(messages[0]?.message).toContain(`layer '${folders[fromIndex]}'`);
+          expect(messages[0]?.message).toContain(`layer '${folders[toIndex]}'`);
+        } else {
+          expect(messages).toEqual([]);
+        }
+      },
+    ),
+    { numRuns: 18 },
+  );
+});
+
+it("Property: skipping layers downward is allowed", () => {
+  fc.assert(
+    fc.property(fc.constant(null), () => {
+      const root = makeProject({
+        "src/app/index.ts": [
+          'import { value } from "../kernel/index";',
+          "export const reExport = value;",
+        ].join("\n"),
+        "src/kernel/index.ts": "export const value = true;\n",
+      });
+      const layers = [
+        { name: "app", folders: ["app"], reason: "test: layer 0" },
+        { name: "domain", folders: ["domain"], reason: "test: layer 1 (skipped)" },
+        { name: "kernel", folders: ["kernel"], reason: "test: layer 2" },
+      ];
+      expect(diagnosticsByRule(root, "no-upward-layer-import", { layers })).toEqual([]);
+    }),
+    { numRuns: 5 },
+  );
+});
+
+function folderCycleFiles(
+  folders: readonly string[],
+  closeCycle: boolean,
+): Record<string, string> {
+  return Object.fromEntries([
+    ["src/index.ts", "export const ok = true;\n"],
+    ...folders.map((folder, index) => [
+      `src/${folder}/index.ts`,
+      resolveFolderCycleSource(folders[index + 1] ?? (closeCycle ? folders[0] : null)),
+    ] as const),
+  ]);
+}
+
+function resolveFolderCycleSource(nextFolder: string | null): string {
+  return nextFolder
+    ? `import { value as next } from "../${nextFolder}/index"; export const value = next;\n`
+    : "export const value = true;\n";
+}
+
+function layeredImportDiagnostics(
+  folders: readonly ["app", "domain", "kernel"],
+  fromIndex: number,
+  toIndex: number,
+): ReturnType<typeof diagnosticsByRule> {
+  const fromFolder = folders[fromIndex] ?? "app";
+  const toFolder = folders[toIndex] ?? "kernel";
+  const root = makeProject({
+    [`src/${fromFolder}/index.ts`]: [
+      `import { value } from "../${toFolder}/index";`,
+      "export const reExport = value;",
+    ].join("\n"),
+    [`src/${toFolder}/index.ts`]: "export const value = true;\n",
+  });
+  return diagnosticsByRule(root, "no-upward-layer-import", {
+    layers: folders.map((folder, layerIndex) => ({
+      name: folder,
+      folders: [folder],
+      reason: `test: layer ${layerIndex}`,
+    })),
+  });
+}

--- a/lsp/architecture/analyzer/imports/folder-graph.test.ts
+++ b/lsp/architecture/analyzer/imports/folder-graph.test.ts
@@ -1,0 +1,183 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+it("resolves local TypeScript sources from extensionless and ESM .js specifiers", () => {
+  const root = path.resolve("/repo");
+  const sourceFiles = new Map(
+    [
+      path.resolve(root, "src/a.ts"),
+      path.resolve(root, "src/b/index.ts"),
+    ].map((fileName) => [
+      fileName,
+      ts.createSourceFile(fileName, "export const ok = true;", ts.ScriptTarget.Latest),
+    ]),
+  );
+
+  expect(resolveLocalSpecifier(path.resolve(root, "src/index.ts"), "./a", sourceFiles))
+    .toBe(path.resolve(root, "src/a.ts"));
+  expect(resolveLocalSpecifier(path.resolve(root, "src/index.ts"), "./a.js", sourceFiles))
+    .toBe(path.resolve(root, "src/a.ts"));
+  expect(resolveLocalSpecifier(path.resolve(root, "src/index.ts"), "./b", sourceFiles))
+    .toBe(path.resolve(root, "src/b/index.ts"));
+});
+
+it("Property: local specifier resolution follows every source/output extension pair", () => {
+  fc.assert(
+    fc.property(segmentArb, sourceExtensionArb, fc.constantFrom(...OUTPUT_EXTENSIONS), (
+      moduleName,
+      sourceExtension,
+      outputExtension,
+    ) => {
+      const root = path.resolve("/repo");
+      const target = path.resolve(root, "src", `${moduleName}${sourceExtension}`);
+      const sourceFiles = new Map([
+        [
+          target,
+          ts.createSourceFile(target, "export const ok = true;", ts.ScriptTarget.Latest),
+        ],
+      ]);
+
+      expect(
+        resolveLocalSpecifier(
+          path.resolve(root, "src/index.ts"),
+          `./${moduleName}`,
+          sourceFiles,
+        ),
+      ).toBe(target);
+      expect(
+        resolveLocalSpecifier(
+          path.resolve(root, "src/index.ts"),
+          `./${moduleName}${outputExtension}`,
+          sourceFiles,
+        ),
+      ).toBe(target);
+      expect(
+        resolveLocalSpecifier(
+          path.resolve(root, "src/index.ts"),
+          moduleName,
+          sourceFiles,
+        ),
+      ).toBeNull();
+    }),
+    { numRuns: 80 },
+  );
+});
+
+it("computes folder keys, top folders, test-like paths, and folder graph density", () => {
+  const root = path.resolve("/repo");
+  expect(folderKeyForFile(path.resolve(root, "src/index.ts"), root)).toBe(".");
+  expect(folderKeyForFile(path.resolve(root, "src/domain/model.ts"), root)).toBe(
+    "domain",
+  );
+  expect(folderKeyForFile(path.resolve(root, "scripts/release.ts"), root)).toBe(
+    "scripts",
+  );
+  expect(topFolder(".")).toBe(".");
+  expect(topFolder("domain/payments")).toBe("domain");
+  expect(isTestLikePath(path.resolve(root, "src/test-utils/index.ts"))).toBe(true);
+
+  const edges = [
+    { from: "a", to: "b", kind: "import" as const, files: ["/repo/src/a.ts"] },
+    { from: "b", to: "a", kind: "import" as const, files: ["/repo/src/b.ts"] },
+  ];
+  expect(stronglyConnectedFolderComponents(edges)).toEqual([["a", "b"]]);
+  expect(folderEdgeDensity(["a", "b"], edges)).toBe(1);
+  expect(folderEdgeDensity([], edges)).toBe(0);
+  expect(folderEdgeDensity(["a"], edges)).toBe(0);
+});
+
+it("Property: acyclic folder chains do not produce strongly connected components", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 2, maxLength: 8 }),
+      (segments) => {
+        const edges = segments.slice(0, -1).map((segment, index) => ({
+          from: segment,
+          to: segments[index + 1] ?? segment,
+          kind: "import" as const,
+          files: [`/repo/src/${segment}/index.ts`],
+        }));
+
+        expect(stronglyConnectedFolderComponents(edges)).toEqual([]);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: folder rings form one sorted strongly connected component", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 2, maxLength: 7 }),
+      (segments) => {
+        const edges = segments.map((segment, index) => ({
+          from: segment,
+          to: segments[(index + 1) % segments.length] ?? segment,
+          kind: "import" as const,
+          files: [`/repo/src/${segment}/index.ts`],
+        }));
+
+        expect(stronglyConnectedFolderComponents(edges)).toEqual([
+          [...segments].sort(),
+        ]);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: folder edge density counts unique folder directions only", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 2, maxLength: 7 }),
+      (folders) => {
+        const baseEdges = folders.slice(0, -1).map((folder, index) => ({
+          from: folder,
+          to: folders[index + 1] ?? folder,
+          kind: "import" as const,
+          files: [`/repo/src/${folder}/index.ts`],
+        }));
+        const duplicateEdges = baseEdges.flatMap((edge) => [
+          edge,
+          { ...edge, files: ["/repo/src/duplicate.ts"] },
+          { ...edge, kind: "reexport" as const, files: ["/repo/src/reexport.ts"] },
+        ]);
+        const expectedDensity = baseEdges.length / (folders.length * (folders.length - 1));
+
+        expect(folderEdgeDensity(folders, duplicateEdges)).toBeCloseTo(expectedDensity);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: canonical test-only paths are detected by segment or file suffix", () => {
+  fc.assert(
+    fc.property(
+      segmentArb,
+      testOnlySegmentArb,
+      fc.constantFrom(".test.ts", ".spec.tsx", ".test.mts", ".spec.cts"),
+      (moduleName, testOnlySegment, testSuffix) => {
+        const root = path.resolve("/repo");
+
+        expect(
+          isTestLikePath(path.resolve(root, "src", testOnlySegment, `${moduleName}.ts`)),
+        ).toBe(true);
+        expect(isTestLikePath(path.resolve(root, "src", testOnlySegment)))
+          .toBe(true);
+        expect(isTestLikePath(path.resolve(root, "src", "fixture", `${moduleName}.ts`)))
+          .toBe(true);
+        expect(
+          isTestLikePath(path.resolve(root, "src", `${testOnlySegment}-prod`, `${moduleName}.ts`)),
+        ).toBe(false);
+        expect(isTestLikePath(path.resolve(root, "src", `${moduleName}${testSuffix}`)))
+          .toBe(true);
+        expect(isTestLikePath(path.resolve(root, "src", `${moduleName}.prod.ts`)))
+          .toBe(false);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});

--- a/lsp/architecture/analyzer/imports/folder-graph/cross-folder.ts
+++ b/lsp/architecture/analyzer/imports/folder-graph/cross-folder.ts
@@ -1,0 +1,136 @@
+import type {
+  LocalModuleEdge,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "../project-graph/index.js";
+import type {
+  ArchitectureDiagnostic,
+  ResolvedArchitectureOptions,
+} from "../../project/api/index.js";
+
+interface ModulePair {
+  readonly fromModule: SourceModule;
+  readonly toModule: SourceModule;
+}
+
+export function crossDomainSiblingImportDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.localEdges.flatMap((edge) =>
+    crossDomainSiblingImportDiagnostic(graph, options, edge)
+  );
+}
+
+export function crossLayerImportDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  if (options.layers.length === 0) return [];
+
+  return graph.localEdges.flatMap((edge) =>
+    crossLayerImportDiagnostic(graph, options, edge)
+  );
+}
+
+function crossDomainSiblingImportDiagnostic(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+  edge: LocalModuleEdge,
+): readonly ArchitectureDiagnostic[] {
+  const pair = importModulePair(graph, edge);
+  if (pair === null) return [];
+  if (!isCrossDomainSiblingPair(pair, options)) return [];
+  if (bothModulesHaveLayers(graph, pair)) return [];
+  return [crossDomainSiblingDiagnostic(pair)];
+}
+
+function crossLayerImportDiagnostic(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+  edge: LocalModuleEdge,
+): readonly ArchitectureDiagnostic[] {
+  const pair = importModulePair(graph, edge);
+  if (pair === null || pair.fromModule.isTestLike) return [];
+  const fromLayer = moduleLayer(graph, pair.fromModule);
+  const toLayer = moduleLayer(graph, pair.toModule);
+  if (fromLayer === null || toLayer === null || fromLayer <= toLayer) return [];
+  return [crossLayerDiagnostic(pair, options, fromLayer, toLayer)];
+}
+
+function importModulePair(
+  graph: ProjectArchitectureGraph,
+  edge: LocalModuleEdge,
+): ModulePair | null {
+  if (edge.kind !== "import") return null;
+  const fromModule = graph.modulesByFileName.get(edge.from);
+  const toModule = graph.modulesByFileName.get(edge.to);
+  return fromModule && toModule ? { fromModule, toModule } : null;
+}
+
+function isCrossDomainSiblingPair(
+  pair: ModulePair,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  if (pair.fromModule.isTestLike || pair.toModule.isTestLike) return false;
+  if (pair.fromModule.topFolder === "." || pair.toModule.topFolder === ".") return false;
+  if (pair.fromModule.topFolder === pair.toModule.topFolder) return false;
+  return !sharedFolder(options, pair.fromModule.topFolder) &&
+    !sharedFolder(options, pair.toModule.topFolder);
+}
+
+function bothModulesHaveLayers(
+  graph: ProjectArchitectureGraph,
+  pair: ModulePair,
+): boolean {
+  return moduleLayer(graph, pair.fromModule) !== null &&
+    moduleLayer(graph, pair.toModule) !== null;
+}
+
+function moduleLayer(
+  graph: ProjectArchitectureGraph,
+  module: SourceModule,
+): number | null {
+  return graph.folderLayerIndex.get(module.folder) ?? null;
+}
+
+function crossDomainSiblingDiagnostic(
+  pair: ModulePair,
+): ArchitectureDiagnostic {
+  return {
+    ruleId: "no-cross-domain-sibling-import",
+    file: pair.fromModule.fileName,
+    severity: "warn",
+    message:
+      `${pair.fromModule.relativePath} imports ${pair.toModule.relativePath} across sibling ` +
+      `domains (${pair.fromModule.topFolder} -> ${pair.toModule.topFolder}). ` +
+      "Sibling features should meet through a facade, registry, or shared kernel.",
+  };
+}
+
+function crossLayerDiagnostic(
+  pair: ModulePair,
+  options: ResolvedArchitectureOptions,
+  fromLayer: number,
+  toLayer: number,
+): ArchitectureDiagnostic {
+  const fromLayerName = options.layers[fromLayer]?.name ?? `layer ${fromLayer}`;
+  const toLayerName = options.layers[toLayer]?.name ?? `layer ${toLayer}`;
+  return {
+    ruleId: "no-upward-layer-import",
+    file: pair.fromModule.fileName,
+    severity: "warn",
+    message:
+      `${pair.fromModule.relativePath} (layer '${fromLayerName}') imports upward into ` +
+      `${pair.toModule.relativePath} (layer '${toLayerName}'). ` +
+      "Lower-numbered layers must not depend on higher-numbered ones; move the shared " +
+      "contract into a deeper layer or invert the dependency.",
+  };
+}
+
+function sharedFolder(
+  options: ResolvedArchitectureOptions,
+  folderName: string,
+): boolean {
+  return options.sharedFolderNames.some((entry) => entry.folder === folderName);
+}

--- a/lsp/architecture/analyzer/imports/folder-graph/cycles.ts
+++ b/lsp/architecture/analyzer/imports/folder-graph/cycles.ts
@@ -1,0 +1,143 @@
+import type {
+  FolderEdge,
+  ProjectArchitectureGraph,
+} from "../project-graph/index.js";
+import type { ArchitectureDiagnostic } from "../../project/api/index.js";
+
+interface FolderGraphIndex {
+  readonly nodes: ReadonlySet<string>;
+  readonly adjacency: ReadonlyMap<string, ReadonlySet<string>>;
+}
+
+interface TarjanState {
+  index: number;
+  readonly adjacency: ReadonlyMap<string, ReadonlySet<string>>;
+  readonly stack: string[];
+  readonly onStack: Set<string>;
+  readonly indices: Map<string, number>;
+  readonly lowlinks: Map<string, number>;
+  readonly components: string[][];
+}
+
+export function stronglyConnectedFolderComponents(
+  folderEdges: readonly FolderEdge[],
+): readonly (readonly string[])[] {
+  const index = folderGraphIndex(folderEdges);
+  const state = createTarjanState(index.adjacency);
+  for (const node of [...index.nodes].sort()) {
+    if (!state.indices.has(node)) connectFolderComponent(state, node);
+  }
+  return state.components.filter((component) => component.length > 1);
+}
+
+export function folderCycleDiagnostics(
+  graph: ProjectArchitectureGraph,
+  components: readonly (readonly string[])[],
+): readonly ArchitectureDiagnostic[] {
+  return components.map((component) => ({
+    ruleId: "no-folder-cycle",
+    file: graph.reportFile,
+    severity: "warn",
+    message:
+      `Folder dependency cycle: ${component.join(" <-> ")}. ` +
+      "Folders should expose a stable direction of knowledge; cycles make every " +
+      "folder in the component part of the same abstraction.",
+  }));
+}
+
+export function rootInternalCycleDiagnostics(
+  graph: ProjectArchitectureGraph,
+  components: readonly (readonly string[])[],
+): readonly ArchitectureDiagnostic[] {
+  const hasCycle = components.some(
+    (component) => component.includes(".") && component.includes("internal"),
+  );
+  if (!hasCycle) return [];
+
+  return [
+    {
+      ruleId: "no-root-internal-cycle",
+      file: graph.reportFile,
+      severity: "error",
+      message:
+        "Root files and internal files depend on each other. The public/root layer " +
+        "should hide internal decisions; internal code should not import back through it.",
+    },
+  ];
+}
+
+function folderGraphIndex(folderEdges: readonly FolderEdge[]): FolderGraphIndex {
+  const nodes = new Set<string>();
+  const adjacency = new Map<string, Set<string>>();
+  for (const edge of folderEdges) {
+    nodes.add(edge.from);
+    nodes.add(edge.to);
+    const neighbors = adjacency.get(edge.from) ?? new Set<string>();
+    neighbors.add(edge.to);
+    adjacency.set(edge.from, neighbors);
+  }
+  return { adjacency, nodes };
+}
+
+function createTarjanState(
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+): TarjanState {
+  return {
+    index: 0,
+    adjacency,
+    stack: [],
+    onStack: new Set<string>(),
+    indices: new Map<string, number>(),
+    lowlinks: new Map<string, number>(),
+    components: [],
+  };
+}
+
+function connectFolderComponent(state: TarjanState, node: string): void {
+  state.indices.set(node, state.index);
+  state.lowlinks.set(node, state.index);
+  state.index += 1;
+  state.stack.push(node);
+  state.onStack.add(node);
+
+  for (const neighbor of state.adjacency.get(node) ?? []) {
+    visitFolderNeighbor(state, node, neighbor);
+  }
+  completeFolderComponent(state, node);
+}
+
+function visitFolderNeighbor(
+  state: TarjanState,
+  node: string,
+  neighbor: string,
+): void {
+  if (!state.indices.has(neighbor)) {
+    connectFolderComponent(state, neighbor);
+    updateLowlink(state, node, state.lowlinks.get(neighbor) ?? 0);
+    return;
+  }
+  if (state.onStack.has(neighbor)) {
+    updateLowlink(state, node, state.indices.get(neighbor) ?? 0);
+  }
+}
+
+function updateLowlink(state: TarjanState, node: string, candidate: number): void {
+  state.lowlinks.set(node, Math.min(state.lowlinks.get(node) ?? 0, candidate));
+}
+
+function completeFolderComponent(state: TarjanState, node: string): void {
+  if (state.lowlinks.get(node) !== state.indices.get(node)) return;
+  state.components.push(popFolderComponent(state, node).sort());
+}
+
+function popFolderComponent(state: TarjanState, root: string): string[] {
+  const component: string[] = [];
+  let next = state.stack.pop() ?? null;
+  while (next !== null) {
+    state.onStack.delete(next);
+    component.push(next);
+    if (next === root) return component;
+    next = state.stack.pop() ?? null;
+  }
+  return component;
+}

--- a/lsp/architecture/analyzer/imports/folder-graph/index.ts
+++ b/lsp/architecture/analyzer/imports/folder-graph/index.ts
@@ -1,0 +1,50 @@
+/**
+ * @file Folder-graph analysis barrel. Composes the four folder-graph
+ * checks (cycles, mesh, cross-domain-sibling, cross-layer, distance)
+ * into one diagnostic pass.
+ */
+
+import { distantFolderImportDiagnostics } from "../folder-distance.js";
+import {
+  folderCycleDiagnostics,
+  rootInternalCycleDiagnostics,
+  stronglyConnectedFolderComponents,
+} from "./cycles.js";
+import { packageMeshDiagnostics, productionFolderGraph } from "./mesh.js";
+import {
+  crossDomainSiblingImportDiagnostics,
+  crossLayerImportDiagnostics,
+} from "./cross-folder.js";
+import type { ProjectArchitectureGraph } from "../project-graph/index.js";
+import type {
+  ArchitectureDiagnostic,
+  ResolvedArchitectureOptions,
+} from "../../project/api/index.js";
+
+export { stronglyConnectedFolderComponents } from "./cycles.js";
+export { folderEdgeDensity } from "./mesh.js";
+
+/**
+ * Run every folder-graph architecture check against the project graph
+ * and return their combined diagnostic list. Composes the cycle,
+ * mesh-density, distant-import, cross-domain-sibling, and cross-layer
+ * checks into a single pass.
+ * @param graph Project architecture graph (modules, folders, edges).
+ * @param options Resolved architecture rule options with policy lists.
+ * @returns Combined diagnostics from every folder-graph check.
+ */
+export function checkFolderGraph(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  const productionGraph = productionFolderGraph(graph);
+  const components = stronglyConnectedFolderComponents(productionGraph.edges);
+  return [
+    ...folderCycleDiagnostics(graph, components),
+    ...rootInternalCycleDiagnostics(graph, components),
+    ...packageMeshDiagnostics(graph, productionGraph, components, options),
+    ...distantFolderImportDiagnostics(graph, options),
+    ...crossDomainSiblingImportDiagnostics(graph, options),
+    ...crossLayerImportDiagnostics(graph, options),
+  ];
+}

--- a/lsp/architecture/analyzer/imports/folder-graph/mesh.ts
+++ b/lsp/architecture/analyzer/imports/folder-graph/mesh.ts
@@ -1,0 +1,82 @@
+import type {
+  FolderEdge,
+  ProjectArchitectureGraph,
+} from "../project-graph/index.js";
+import type {
+  ArchitectureDiagnostic,
+  ResolvedArchitectureOptions,
+} from "../../project/api/index.js";
+
+export interface ProductionFolderGraph {
+  readonly folders: readonly string[];
+  readonly edges: readonly FolderEdge[];
+}
+
+export function productionFolderGraph(
+  graph: ProjectArchitectureGraph,
+): ProductionFolderGraph {
+  return {
+    folders: productionFolderNames(graph),
+    edges: productionFolderEdges(graph),
+  };
+}
+
+export function folderEdgeDensity(
+  folders: readonly string[],
+  folderEdges: readonly FolderEdge[],
+): number {
+  if (folders.length < 2) return 0;
+
+  const uniqueDirections = new Set(
+    folderEdges.map((edge) => `${edge.from}\0${edge.to}`),
+  );
+  return uniqueDirections.size / (folders.length * (folders.length - 1));
+}
+
+export function packageMeshDiagnostics(
+  graph: ProjectArchitectureGraph,
+  productionGraph: ProductionFolderGraph,
+  components: readonly (readonly string[])[],
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  if (productionGraph.folders.length < options.minPackageMeshFolders) return [];
+
+  const density = folderEdgeDensity(productionGraph.folders, productionGraph.edges);
+  const tooDense = density > options.maxFolderEdgeDensity;
+  const tooCyclic = components.length > options.maxFolderCycles;
+  if (!tooDense && !tooCyclic) return [];
+
+  return [
+    {
+      ruleId: "no-package-mesh",
+      file: graph.reportFile,
+      severity: "warn",
+      message:
+        `Package folder graph has ${productionGraph.folders.length} production folders, ` +
+        `${productionGraph.edges.length} production folder edges, ${components.length} cycle groups, ` +
+        `and density ${density.toFixed(2)}. This is a mesh, not a layered package shape.`,
+    },
+  ];
+}
+
+function productionFolderEdges(graph: ProjectArchitectureGraph): readonly FolderEdge[] {
+  return graph.folderEdges.filter((edge) =>
+    edge.files.some((file) => productionFileEdge(graph, file))
+  );
+}
+
+function productionFileEdge(
+  graph: ProjectArchitectureGraph,
+  fileName: string,
+): boolean {
+  const module = graph.modulesByFileName.get(fileName);
+  return module !== undefined && !module.isTestLike;
+}
+
+function productionFolderNames(graph: ProjectArchitectureGraph): readonly string[] {
+  return [...new Set(
+    graph.modules
+      .filter((module) => !module.isTestLike)
+      .map((module) => module.folder),
+  )].sort();
+}

--- a/lsp/architecture/analyzer/imports/index.ts
+++ b/lsp/architecture/analyzer/imports/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @file Imports analysis barrel. Public facade for the import-graph
+ * builder, folder-cycle/root-cycle/cross-domain/distance/upward-layer
+ * checks, and graph type re-exports.
+ */
+
+export {
+  buildProjectGraph,
+} from "./project-graph/index.js";
+export type {
+  ExportConsumer,
+  LocalModuleEdge,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "../project/index.js";
+export {
+  checkFolderGraph,
+} from "./folder-graph/index.js";

--- a/lsp/architecture/analyzer/imports/layers.test.ts
+++ b/lsp/architecture/analyzer/imports/layers.test.ts
@@ -1,0 +1,102 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+const loadProjectGraph = async () => import("./project-graph/index.js");
+
+it("Property: longest matching prefix wins when a folder matches multiple layer entries", async () => {
+  const { layerIndexFor } = await loadProjectGraph();
+  fc.assert(
+    fc.property(
+      fc
+        .tuple(
+          fc.stringMatching(/^[a-z]{3,8}$/),
+          fc.stringMatching(/^[a-z]{3,8}$/),
+          fc.stringMatching(/^[a-z]{3,8}$/),
+        )
+        .filter(([a, b, c]) => a !== b && b !== c && a !== c),
+      ([root, mid, leaf]) => {
+        const folder = `${root}/${mid}/${leaf}`;
+        const layers = [
+          { name: "broad", folders: [root], reason: "test: broad" },
+          { name: "narrow", folders: [`${root}/${mid}`], reason: "test: narrow" },
+          { name: "other", folders: ["unrelated"], reason: "test: other" },
+        ];
+        expect(layerIndexFor(folder, layers)).toBe(1);
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: when entries match with equal length, the lower layer index wins", async () => {
+  const { layerIndexFor } = await loadProjectGraph();
+  fc.assert(
+    fc.property(fc.stringMatching(/^[a-z]{3,8}$/), (folder) => {
+      const layers = [
+        { name: "first", folders: [folder], reason: "test: first" },
+        { name: "second", folders: [folder], reason: "test: second" },
+      ];
+      expect(layerIndexFor(folder, layers)).toBe(0);
+    }),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: a folder with no matching layer entry returns null", async () => {
+  const { layerIndexFor } = await loadProjectGraph();
+  fc.assert(
+    fc.property(
+      fc.stringMatching(/^[a-z]{3,8}$/),
+      fc.stringMatching(/^[a-z]{3,8}$/),
+      (folder, otherFolder) => {
+        if (folder === otherFolder) return;
+        const layers = [
+          { name: "only", folders: [otherFolder], reason: "test: only" },
+        ];
+        expect(layerIndexFor(folder, layers)).toBeNull();
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: with no layers configured, layerIndexFor returns null for every folder", async () => {
+  const { layerIndexFor } = await loadProjectGraph();
+  fc.assert(
+    fc.property(fc.stringMatching(/^[a-z][a-z0-9/-]{0,30}$/), (folder) => {
+      expect(layerIndexFor(folder, [])).toBeNull();
+    }),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: layer folder prefixes match only on path segment boundaries", () => {
+  fc.assert(
+    fc.property(
+      fc
+        .tuple(fc.stringMatching(/^[a-z]{3,8}$/), fc.stringMatching(/^[a-z]{1,4}$/))
+        .filter(([prefix, suffix]) => !`${prefix}${suffix}`.startsWith(`${prefix}/`)),
+      ([prefix, suffix]) => {
+        const layers = [
+          { name: "prefix", folders: [prefix], reason: "test: prefix layer" },
+        ];
+
+        expect(layerIndexFor(`${prefix}/${suffix}`, layers)).toBe(0);
+        expect(layerIndexFor(`${prefix}${suffix}`, layers)).toBeNull();
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("root layer entry matches the root folder only", () => {
+  const layers = [
+    { name: "root", folders: ["."], reason: "test: package root" },
+  ];
+
+  expect(layerIndexFor(".", layers)).toBe(0);
+  expect(layerIndexFor("feature", layers)).toBeNull();
+  expect(layerIndexFor("feature/deep", layers)).toBeNull();
+});

--- a/lsp/architecture/analyzer/imports/module-symbols.ts
+++ b/lsp/architecture/analyzer/imports/module-symbols.ts
@@ -1,0 +1,316 @@
+import path from "node:path";
+import ts from "typescript";
+import { resolveLocalSpecifier } from "./specifier-resolution.js";
+import type { ExportConsumer } from "../project/index.js";
+
+interface ImportTargetContext {
+  readonly fromFile: string;
+  readonly targetFile: string;
+  readonly typeOnly: boolean;
+}
+
+interface NamespaceImportBinding extends ImportTargetContext {
+  readonly localName: string;
+}
+
+export function collectExportedSymbolNames(sourceFile: ts.SourceFile): readonly string[] {
+  const symbols = new Set<string>();
+  for (const statement of sourceFile.statements) {
+    addExportedSymbolNames(symbols, statement);
+  }
+  return [...symbols].sort();
+}
+
+export function collectExportConsumers(
+  sourceFiles: readonly ts.SourceFile[],
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): readonly ExportConsumer[] {
+  return sourceFiles
+    .flatMap((sourceFile) => [
+      ...namedImportConsumers(sourceFile, sourceFilesByPath),
+      ...namedReexportConsumers(sourceFile, sourceFilesByPath),
+      ...namespaceImportConsumers(sourceFile, sourceFilesByPath),
+    ])
+    .sort(compareExportConsumers);
+}
+
+function addExportedSymbolNames(
+  symbols: Set<string>,
+  statement: ts.Statement,
+): void {
+  if (ts.isExportDeclaration(statement)) {
+    addExportDeclarationNames(symbols, statement);
+    return;
+  }
+  if (ts.isExportAssignment(statement)) {
+    symbols.add("default");
+    return;
+  }
+  if (!hasExportModifier(statement)) return;
+  addExportedDeclarationNames(symbols, statement);
+}
+
+function addExportDeclarationNames(
+  symbols: Set<string>,
+  statement: ts.ExportDeclaration,
+): void {
+  const exportClause = statement.exportClause;
+  if (!exportClause) return;
+  if (ts.isNamespaceExport(exportClause)) {
+    symbols.add(exportClause.name.text);
+    return;
+  }
+  for (const element of exportClause.elements) {
+    symbols.add(element.name.text);
+  }
+}
+
+function addExportedDeclarationNames(
+  symbols: Set<string>,
+  statement: ts.Statement,
+): void {
+  if (ts.isVariableStatement(statement)) {
+    for (const declaration of statement.declarationList.declarations) {
+      addBindingName(symbols, declaration.name);
+    }
+    return;
+  }
+  const name = exportedDeclarationName(statement);
+  symbols.add(name ?? "default");
+}
+
+function addBindingName(symbols: Set<string>, name: ts.BindingName): void {
+  if (ts.isIdentifier(name)) symbols.add(name.text);
+}
+
+function namedImportConsumers(
+  sourceFile: ts.SourceFile,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): readonly ExportConsumer[] {
+  return sourceFile.statements.flatMap((statement) =>
+    importDeclarationConsumers(sourceFile.fileName, statement, sourceFilesByPath)
+  );
+}
+
+function importDeclarationConsumers(
+  fromFile: string,
+  statement: ts.Statement,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): readonly ExportConsumer[] {
+  if (!ts.isImportDeclaration(statement)) return [];
+  const context = importTargetContext(fromFile, statement, sourceFilesByPath);
+  if (context === null || !statement.importClause) return [];
+  return importClauseConsumers(statement.importClause, context);
+}
+
+function importTargetContext(
+  fromFile: string,
+  statement: ts.ImportDeclaration,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): ImportTargetContext | null {
+  if (!ts.isStringLiteral(statement.moduleSpecifier)) return null;
+  const targetFile = resolveLocalSpecifier(
+    fromFile,
+    statement.moduleSpecifier.text,
+    sourceFilesByPath,
+  );
+  if (targetFile === null) return null;
+  return {
+    fromFile: path.resolve(fromFile),
+    targetFile,
+    typeOnly: statement.importClause?.isTypeOnly ?? false,
+  };
+}
+
+function importClauseConsumers(
+  importClause: ts.ImportClause,
+  context: ImportTargetContext,
+): readonly ExportConsumer[] {
+  const consumers: ExportConsumer[] = [];
+  if (importClause.name) {
+    consumers.push(exportConsumer(context, "default", "import"));
+  }
+  if (importClause.namedBindings && ts.isNamedImports(importClause.namedBindings)) {
+    consumers.push(...namedImportBindingConsumers(importClause.namedBindings, context));
+  }
+  return consumers;
+}
+
+function namedImportBindingConsumers(
+  namedImports: ts.NamedImports,
+  context: ImportTargetContext,
+): readonly ExportConsumer[] {
+  return namedImports.elements.map((element) =>
+    exportConsumer(
+      { ...context, typeOnly: context.typeOnly || element.isTypeOnly },
+      importedExportName(element),
+      "import",
+    )
+  );
+}
+
+function namedReexportConsumers(
+  sourceFile: ts.SourceFile,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): readonly ExportConsumer[] {
+  return sourceFile.statements.flatMap((statement) =>
+    exportDeclarationConsumers(sourceFile.fileName, statement, sourceFilesByPath)
+  );
+}
+
+function exportDeclarationConsumers(
+  fromFile: string,
+  statement: ts.Statement,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): readonly ExportConsumer[] {
+  if (!ts.isExportDeclaration(statement)) return [];
+  if (!statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) return [];
+  if (!statement.exportClause || !ts.isNamedExports(statement.exportClause)) return [];
+
+  const targetFile = resolveLocalSpecifier(
+    fromFile,
+    statement.moduleSpecifier.text,
+    sourceFilesByPath,
+  );
+  if (targetFile === null) return [];
+
+  return statement.exportClause.elements.map((element) =>
+    exportConsumer(
+      {
+        fromFile: path.resolve(fromFile),
+        targetFile,
+        typeOnly: statement.isTypeOnly || element.isTypeOnly,
+      },
+      importedExportName(element),
+      "reexport",
+    )
+  );
+}
+
+function namespaceImportConsumers(
+  sourceFile: ts.SourceFile,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): readonly ExportConsumer[] {
+  const bindings = namespaceImportBindings(sourceFile, sourceFilesByPath);
+  if (bindings.size === 0) return [];
+  return namespaceMemberUses(sourceFile, bindings);
+}
+
+function namespaceImportBindings(
+  sourceFile: ts.SourceFile,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): ReadonlyMap<string, NamespaceImportBinding> {
+  const bindings = new Map<string, NamespaceImportBinding>();
+  for (const statement of sourceFile.statements) {
+    addNamespaceImportBinding(bindings, sourceFile.fileName, statement, sourceFilesByPath);
+  }
+  return bindings;
+}
+
+function addNamespaceImportBinding(
+  bindings: Map<string, NamespaceImportBinding>,
+  fromFile: string,
+  statement: ts.Statement,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): void {
+  if (!ts.isImportDeclaration(statement)) return;
+  const context = importTargetContext(fromFile, statement, sourceFilesByPath);
+  const namespaceImport = resolveNamespaceImportFromClause(statement.importClause);
+  if (context === null || namespaceImport === null) return;
+  bindings.set(namespaceImport.name.text, {
+    ...context,
+    localName: namespaceImport.name.text,
+  });
+}
+
+function resolveNamespaceImportFromClause(
+  importClause: ts.ImportClause | undefined,
+): ts.NamespaceImport | null {
+  const namedBindings = importClause?.namedBindings;
+  return namedBindings && ts.isNamespaceImport(namedBindings) ? namedBindings : null;
+}
+
+function namespaceMemberUses(
+  sourceFile: ts.SourceFile,
+  bindings: ReadonlyMap<string, NamespaceImportBinding>,
+): readonly ExportConsumer[] {
+  const consumers: ExportConsumer[] = [];
+  const visit = (node: ts.Node): void => {
+    const consumer = namespaceMemberConsumer(node, bindings);
+    if (consumer !== null) consumers.push(consumer);
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+  return consumers;
+}
+
+function namespaceMemberConsumer(
+  node: ts.Node,
+  bindings: ReadonlyMap<string, NamespaceImportBinding>,
+): ExportConsumer | null {
+  if (!ts.isPropertyAccessExpression(node)) return null;
+  if (!ts.isIdentifier(node.expression)) return null;
+  const binding = bindings.get(node.expression.text);
+  return binding === undefined
+    ? null
+    : exportConsumer(binding, node.name.text, "import");
+}
+
+function exportConsumer(
+  context: ImportTargetContext,
+  exportName: string,
+  kind: ExportConsumer["kind"],
+): ExportConsumer {
+  return {
+    exportName,
+    consumerFile: context.fromFile,
+    targetFile: context.targetFile,
+    kind,
+    typeOnly: context.typeOnly,
+  };
+}
+
+function importedExportName(element: ts.ImportSpecifier | ts.ExportSpecifier): string {
+  return element.propertyName?.text ?? element.name.text;
+}
+
+function compareExportConsumers(
+  left: ExportConsumer,
+  right: ExportConsumer,
+): number {
+  return consumerSortKey(left).localeCompare(consumerSortKey(right));
+}
+
+function consumerSortKey(consumer: ExportConsumer): string {
+  return [
+    consumer.targetFile,
+    consumer.exportName,
+    consumer.consumerFile,
+    consumer.kind,
+  ].join("\0");
+}
+
+function hasExportModifier(statement: ts.Statement): boolean {
+  return Boolean(
+    ts.canHaveModifiers(statement) &&
+      ts.getModifiers(statement)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword),
+  );
+}
+
+function exportedDeclarationName(statement: ts.Statement): string | null {
+  for (const reader of DECLARATION_NAME_READERS) {
+    const name = reader(statement);
+    if (name !== undefined) return name;
+  }
+  return null;
+}
+
+type DeclarationNameReader = (statement: ts.Statement) => string | null | undefined;
+
+const DECLARATION_NAME_READERS: readonly DeclarationNameReader[] = [
+  (statement) => ts.isFunctionDeclaration(statement) ? statement.name?.text ?? null : undefined,
+  (statement) => ts.isClassDeclaration(statement) ? statement.name?.text ?? null : undefined,
+  (statement) => ts.isInterfaceDeclaration(statement) ? statement.name.text : undefined,
+  (statement) => ts.isTypeAliasDeclaration(statement) ? statement.name.text : undefined,
+  (statement) => ts.isEnumDeclaration(statement) ? statement.name.text : undefined,
+];

--- a/lsp/architecture/analyzer/imports/project-graph/index.test.ts
+++ b/lsp/architecture/analyzer/imports/project-graph/index.test.ts
@@ -1,0 +1,303 @@
+import { expect, it } from "vitest";
+import type { ProjectArchitectureGraph } from "./index.js";
+import * as h from "../../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+const EXPORT_CLASSIFICATION_SOURCE = [
+  "export function makeThing() {}",
+  "export class Thing {}",
+  "export interface Shape { readonly id: string; }",
+  "export type Alias = string;",
+  "export enum Mode { One }",
+  "export const first = 1, second = 2;",
+  "const local = 1;",
+  'export * from "./star";',
+  'export { value } from "./value";',
+  'export * as named from "./named";',
+  "export default class {}",
+  "export default first;",
+].join("\n");
+
+const EXPORTED_DECLARATION_NAMES = [
+  "makeThing",
+  "Thing",
+  "Shape",
+  "Alias",
+  "Mode",
+  "first",
+  "local",
+  null,
+  null,
+  null,
+  null,
+  null,
+];
+
+const EXPORT_MODIFIER_FLAGS = [
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  false,
+  false,
+  false,
+  false,
+  true,
+  false,
+];
+
+const STAR_EXPORT_FLAGS = [
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  false,
+  true,
+  false,
+  false,
+  false,
+  false,
+];
+
+const GRAPH_EXTERNAL_EDGES = [
+  { packageName: "vendor-lib", kind: "import", typeOnly: true, specifier: "vendor-lib" },
+  { packageName: "runtime-lib", kind: "import", typeOnly: false, specifier: "runtime-lib" },
+  { packageName: "types-lib", kind: "import", typeOnly: true, specifier: "types-lib" },
+  { packageName: "node", kind: "import", typeOnly: true, specifier: "node:stream" },
+  { packageName: "@scope/pkg", kind: "import", typeOnly: true, specifier: "@scope/pkg/subpath" },
+] as const;
+
+it("classifies exported declarations and export-star declarations from syntax shape", () => {
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    EXPORT_CLASSIFICATION_SOURCE,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  expect(sourceFile.statements.map(exportedDeclarationName)).toEqual(EXPORTED_DECLARATION_NAMES);
+  expect(sourceFile.statements.map(hasExportModifier)).toEqual(EXPORT_MODIFIER_FLAGS);
+  expect(sourceFile.statements.map(isStarExportDeclaration)).toEqual(STAR_EXPORT_FLAGS);
+});
+
+it("builds project graph metadata for public files, typed edges, and folder edges", () => {
+  const root = path.resolve("/repo");
+  const graph = buildGraphMetadataFixture(root);
+
+  expectGraphPublicMetadata(graph);
+  expectGraphLocalEdges(graph, root);
+  expectGraphExternalEdges(graph);
+  expectGraphExportConsumers(graph, root);
+  expectGraphFolderEdges(graph, root);
+});
+
+function buildGraphMetadataFixture(root: string): ProjectArchitectureGraph {
+  return buildProjectGraph(
+    sourceFilesByRelativePath(root, graphMetadataSources()),
+    packageJsonForExports({ ".": "./dist/index.js", "./direct": "./src/direct.ts" }),
+    resolveArchitectureOptions({
+      projectRoot: root,
+      layers: [
+        { name: "root", folders: ["."], reason: "test: public root" },
+        { name: "feature", folders: ["feature"], reason: "test: feature layer" },
+        { name: "internal", folders: ["internal"], reason: "test: internal layer" },
+      ],
+    }),
+    path.resolve(root, "package.json"),
+  );
+}
+
+function graphMetadataSources(): Record<string, string> {
+  return {
+    "src/index.ts": [
+      'import type { ExternalType } from "vendor-lib";',
+      'import { runtime } from "runtime-lib";',
+      'import { type NamedType } from "types-lib";',
+      'import type { Readable } from "node:stream";',
+      'import type { Scoped } from "@scope/pkg/subpath";',
+      'export type { LocalType } from "./types";',
+      'export { value } from "./feature/value";',
+      'export * from "./star";',
+      'export * as named from "./named";',
+      "export const own = runtime, second = 2;",
+      "export interface PublicShape { readonly field: ExternalType | NamedType | Readable | Scoped; }",
+      "export default own;",
+    ].join("\n"),
+    "src/types.ts": "export interface LocalType { readonly id: string; }\n",
+    "src/feature/value.ts": "export const value = true;\n",
+    "src/star.ts": "export const star = true;\n",
+    "src/named.ts": "export const named = true;\n",
+    "src/internal/worker.ts": 'import { value } from "../feature/value";\n',
+    "src/direct.ts": "export const direct = true;\n",
+  };
+}
+
+function expectGraphPublicMetadata(graph: ProjectArchitectureGraph): void {
+  expect(graph.publicModules.map((module) => module.relativePath)).toEqual([
+    "src/index.ts",
+    "src/direct.ts",
+  ]);
+  expect(graph.folders).toEqual([".", "feature", "internal"]);
+  expect([...graph.folderLayerIndex.entries()]).toEqual([
+    [".", 0],
+    ["feature", 1],
+    ["internal", 2],
+  ]);
+
+  const publicModule = graph.publicModules[0];
+  expect(publicModule?.exportedSymbolCount).toBe(8);
+  expect(publicModule?.exportedSymbols).toEqual([
+    "LocalType",
+    "PublicShape",
+    "default",
+    "named",
+    "own",
+    "second",
+    "value",
+  ]);
+  expect(publicModule?.localReexportCount).toBe(4);
+  expect(publicModule?.starExportCount).toBe(1);
+}
+
+function expectGraphLocalEdges(graph: ProjectArchitectureGraph, root: string): void {
+  expect(graph.localEdges.map((edge) => ({
+    from: relativeFixturePath(root, edge.from),
+    to: relativeFixturePath(root, edge.to),
+    kind: edge.kind,
+    typeOnly: edge.typeOnly,
+    specifier: edge.specifier,
+  }))).toEqual([
+    { from: "src/index.ts", to: "src/types.ts", kind: "reexport", typeOnly: true, specifier: "./types" },
+    {
+      from: "src/index.ts",
+      to: "src/feature/value.ts",
+      kind: "reexport",
+      typeOnly: false,
+      specifier: "./feature/value",
+    },
+    { from: "src/index.ts", to: "src/star.ts", kind: "reexport", typeOnly: false, specifier: "./star" },
+    { from: "src/index.ts", to: "src/named.ts", kind: "reexport", typeOnly: false, specifier: "./named" },
+    {
+      from: "src/internal/worker.ts",
+      to: "src/feature/value.ts",
+      kind: "import",
+      typeOnly: false,
+      specifier: "../feature/value",
+    },
+  ]);
+}
+
+function expectGraphExternalEdges(graph: ProjectArchitectureGraph): void {
+  expect(graph.externalEdges.map((edge) => ({
+    packageName: edge.packageName,
+    kind: edge.kind,
+    typeOnly: edge.typeOnly,
+    specifier: edge.specifier,
+  }))).toEqual(GRAPH_EXTERNAL_EDGES);
+}
+
+function expectGraphExportConsumers(graph: ProjectArchitectureGraph, root: string): void {
+  expect(graph.exportConsumers.map((consumer) => ({
+    target: relativeFixturePath(root, consumer.targetFile),
+    exportName: consumer.exportName,
+    consumer: relativeFixturePath(root, consumer.consumerFile),
+    kind: consumer.kind,
+    typeOnly: consumer.typeOnly,
+  }))).toEqual([
+    { target: "src/feature/value.ts", exportName: "value", consumer: "src/index.ts", kind: "reexport", typeOnly: false },
+    {
+      target: "src/feature/value.ts",
+      exportName: "value",
+      consumer: "src/internal/worker.ts",
+      kind: "import",
+      typeOnly: false,
+    },
+    { target: "src/types.ts", exportName: "LocalType", consumer: "src/index.ts", kind: "reexport", typeOnly: true },
+  ]);
+}
+
+function expectGraphFolderEdges(graph: ProjectArchitectureGraph, root: string): void {
+  expect(graph.folderEdges).toEqual([
+    {
+      from: ".",
+      to: "feature",
+      kind: "reexport",
+      files: [path.resolve(root, "src/index.ts")],
+    },
+    {
+      from: "internal",
+      to: "feature",
+      kind: "import",
+      files: [path.resolve(root, "src/internal/worker.ts")],
+    },
+  ]);
+}
+
+function relativeFixturePath(root: string, fileName: string): string {
+  return path.relative(root, fileName).replaceAll("\\", "/");
+}
+
+it("Property: graph public API fallback follows every conventional index candidate", () => {
+  fc.assert(
+    fc.property(
+      fc.constantFrom("src/index.ts", "src/index.tsx", "index.ts", "index.tsx"),
+      (relativePath) => {
+        const root = path.resolve("/repo");
+        const sourceFiles = sourceFilesByRelativePath(root, {
+          [relativePath]: "export const ok = true;\n",
+          "src/private.ts": "export const privateValue = true;\n",
+        });
+        const graph = buildProjectGraph(
+          sourceFiles,
+          packageJsonForExports(undefined),
+          resolveArchitectureOptions({ projectRoot: root }),
+          path.resolve(root, "package.json"),
+        );
+
+        expect(graph.publicModules.map((module) => module.relativePath)).toEqual([
+          relativePath,
+        ]);
+      },
+    ),
+    { numRuns: 20 },
+  );
+});
+
+it("does not treat dist-remap candidates as public unless they exist", () => {
+  const root = path.resolve("/repo");
+  const sourceFiles = sourceFilesByRelativePath(root, {
+    "src/index.ts": "export const root = true;\n",
+    "src/direct.ts": "export const direct = true;\n",
+    "src/src/direct.ts": "export const nestedDirect = true;\n",
+  });
+  const graph = buildProjectGraph(
+    sourceFiles,
+    packageJsonForExports({ "./direct": "./src/direct.ts" }),
+    resolveArchitectureOptions({ projectRoot: root }),
+    path.resolve(root, "package.json"),
+  );
+
+  expect(graph.publicModules.map((module) => module.relativePath)).toEqual(["src/direct.ts"]);
+});
+
+it("falls back to conventional public API files when package exports do not resolve", () => {
+  const root = path.resolve("/repo");
+  const sourceFiles = sourceFilesByRelativePath(root, {
+    "src/index.ts": "export const ok = true;\n",
+    "src/private.ts": "export const privateValue = true;\n",
+  });
+  const graph = buildProjectGraph(
+    sourceFiles,
+    packageJsonForExports({ "./missing": "./dist/missing.js" }),
+    resolveArchitectureOptions({ projectRoot: root }),
+    path.resolve(root, "package.json"),
+  );
+
+  expect(graph.publicModules.map((module) => module.relativePath)).toEqual(["src/index.ts"]);
+});

--- a/lsp/architecture/analyzer/imports/project-graph/index.ts
+++ b/lsp/architecture/analyzer/imports/project-graph/index.ts
@@ -1,0 +1,229 @@
+/**
+ * @file Project-graph construction. Walks source files, builds
+ * `SourceModule` records with local and external edges, collapses to
+ * folder-level edges, computes export consumers, and assigns layer
+ * indices. Every downstream architecture check consumes this graph.
+ */
+
+import path from "node:path";
+import ts from "typescript";
+import { collectModuleEdges } from "../edges.js";
+import {
+  collectExportConsumers,
+  collectExportedSymbolNames,
+} from "../module-symbols.js";
+import { collectFolderEdges } from "../folder-edges.js";
+import { publicApiFileNames } from "../../package-api/index.js";
+import {
+  hasExportModifier,
+  isStarExportDeclaration,
+  isTestLikePath,
+  normalizePath,
+  type ExportConsumer,
+  type ProjectArchitectureGraph,
+  type SourceModule,
+} from "../../project/index.js";
+import { withTrailingSeparator } from "../../project/source-paths.js";
+import type { LayerDefinition, PackageJson, ResolvedArchitectureOptions } from "../../project/api/index.js";
+
+export { resolveLocalSpecifier } from "../specifier-resolution.js";
+export type {
+  ExportConsumer,
+  ExternalModuleEdge,
+  FolderEdge,
+  LocalModuleEdge,
+  ModuleEdgeKind,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "../../project/index.js";
+
+/**
+ * Build the canonical architecture graph for a TypeScript project:
+ * one `SourceModule` per source file, their local and external import
+ * edges, the folder-level edge collapse, the export-consumer index,
+ * and a folder-to-layer index keyed by the configured `layers`. Every
+ * downstream architecture check consumes this graph.
+ * @param sourceFiles Project source files (post-tsconfig include
+ * resolution).
+ * @param packageJson Parsed `package.json` used to identify public
+ * API files.
+ * @param options Resolved architecture options.
+ * @param reportFile File path used as the diagnostic target when a
+ * finding has no natural single file.
+ * @returns The fully-populated project architecture graph.
+ */
+export function buildProjectGraph(
+  sourceFiles: readonly ts.SourceFile[],
+  packageJson: PackageJson,
+  options: ResolvedArchitectureOptions,
+  reportFile: string,
+): ProjectArchitectureGraph {
+  const sourceFilesByPath = new Map(
+    sourceFiles.map((sourceFile) => [path.resolve(sourceFile.fileName), sourceFile] as const),
+  );
+  const publicFileNames = new Set(
+    publicApiFileNames(sourceFilesByPath, packageJson, options),
+  );
+
+  const modules = sourceFiles.map((sourceFile) =>
+    sourceModuleFromSourceFile(sourceFile, sourceFilesByPath, publicFileNames, options),
+  );
+  const modulesByFileName = new Map(
+    modules.map((module) => [module.fileName, module] as const),
+  );
+  const localEdges = modules.flatMap((module) => [...module.localEdges]);
+  const externalEdges = modules.flatMap((module) => [...module.externalEdges]);
+  const exportConsumers = collectExportConsumers(sourceFiles, sourceFilesByPath);
+  const publicModules = modules.filter((module) => module.isPublic);
+  const folders = [...new Set(modules.map((module) => module.folder))].sort();
+
+  const folderLayerIndex = new Map<string, number | null>(
+    folders.map((folder) => [folder, layerIndexFor(folder, options.layers)] as const),
+  );
+
+  return {
+    projectRoot: options.projectRoot,
+    reportFile,
+    modules,
+    modulesByFileName,
+    publicModules,
+    localEdges,
+    externalEdges,
+    exportConsumers,
+    exportConsumersByFileName: consumersByTargetFile(exportConsumers),
+    folderEdges: collectFolderEdges(localEdges, modulesByFileName),
+    folders,
+    folderLayerIndex,
+  };
+}
+
+/**
+ * Resolve which configured layer a folder belongs to. A folder matches
+ * a layer if any of the layer's `folders` entries equals the folder or
+ * is a segment-aligned path prefix of it. The most-specific (longest)
+ * entry wins; length ties resolve to the lower (earlier) layer index.
+ * @param folder Folder key (relative to `src/`; root is `.`).
+ * @param layers Ordered layer definitions from architecture options.
+ * @returns Zero-based layer index, or `null` when no layer matches or
+ * no layers are configured.
+ */
+export function layerIndexFor(
+  folder: string,
+  layers: ReadonlyArray<LayerDefinition>,
+): number | null {
+  if (layers.length === 0) return null;
+  const normalized = folder === "." ? "" : normalizePath(folder);
+
+  let bestLayer: number | null = null;
+  let bestEntryLength = -1;
+
+  layers.forEach((layer, layerIndex) => {
+    for (const entry of layer.folders) {
+      const normalizedEntry = entry === "." ? "" : normalizePath(entry);
+      const matches =
+        normalizedEntry === normalized ||
+        (normalizedEntry !== "" && normalized.startsWith(`${normalizedEntry}/`));
+      if (!matches) continue;
+      if (normalizedEntry.length > bestEntryLength) {
+        bestEntryLength = normalizedEntry.length;
+        bestLayer = layerIndex;
+      }
+    }
+  });
+
+  return bestLayer;
+}
+
+/**
+ * Canonical folder key for a source file: directory path relative to
+ * `src/` (when the file lives under `src/`) or relative to the project
+ * root (otherwise). The root folder is encoded as `.`.
+ * @param fileName Absolute or relative path to the source file.
+ * @param projectRoot Absolute path to the project root.
+ * @returns Folder key with forward-slash separators; `.` for root.
+ */
+export function folderKeyForFile(fileName: string, projectRoot: string): string {
+  const sourceRoot = path.join(projectRoot, "src");
+  const sourceRootWithSlash = withTrailingSeparator(sourceRoot);
+  const resolved = path.resolve(fileName);
+  const base = resolved.startsWith(sourceRootWithSlash) ? sourceRoot : projectRoot;
+  const relativeDirectory = path.relative(base, path.dirname(resolved));
+  return relativeDirectory.length === 0 ? "." : normalizePath(relativeDirectory);
+}
+
+/**
+ * Top-level folder segment for a folder key — the first path
+ * component, used by layer-direction and shared-kernel checks.
+ * @param folder Folder key from `folderKeyForFile`.
+ * @returns The first segment of `folder`, or `.` for the root folder.
+ */
+export function topFolder(folder: string): string {
+  return folder.split("/")[0] ?? ".";
+}
+
+function sourceModuleFromSourceFile(
+  sourceFile: ts.SourceFile,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+  publicFileNames: ReadonlySet<string>,
+  options: ResolvedArchitectureOptions,
+): SourceModule {
+  const fileName = path.resolve(sourceFile.fileName);
+  const folder = folderKeyForFile(fileName, options.projectRoot);
+  const edges = collectModuleEdges(sourceFile, sourceFilesByPath);
+
+  return {
+    fileName,
+    relativePath: normalizePath(path.relative(options.projectRoot, fileName)),
+    folder,
+    topFolder: topFolder(folder),
+    isIndex: path.parse(fileName).name === "index",
+    isPublic: publicFileNames.has(fileName),
+    isTestLike: isTestLikePath(fileName),
+    localEdges: edges.localEdges,
+    externalEdges: edges.externalEdges,
+    exportedSymbols: collectExportedSymbolNames(sourceFile),
+    exportedSymbolCount: countExportedSymbols(sourceFile),
+    localReexportCount: edges.localEdges.filter((edge) => edge.kind === "reexport").length,
+    starExportCount: sourceFile.statements.filter(isStarExportDeclaration).length,
+    topLevelStatementCount: countNonImportTopLevelStatements(sourceFile),
+  };
+}
+
+function countNonImportTopLevelStatements(sourceFile: ts.SourceFile): number {
+  return sourceFile.statements.reduce((count, statement) => {
+    if (ts.isImportDeclaration(statement)) return count;
+    if (ts.isImportEqualsDeclaration(statement)) return count;
+    return count + 1;
+  }, 0);
+}
+
+function consumersByTargetFile(
+  exportConsumers: readonly ExportConsumer[],
+): ReadonlyMap<string, readonly ExportConsumer[]> {
+  const grouped = new Map<string, ExportConsumer[]>();
+  for (const consumer of exportConsumers) {
+    const consumers = grouped.get(consumer.targetFile) ?? [];
+    consumers.push(consumer);
+    grouped.set(consumer.targetFile, consumers);
+  }
+  return grouped;
+}
+
+function countExportedSymbols(sourceFile: ts.SourceFile): number {
+  return sourceFile.statements.reduce((count, statement) => {
+    if (ts.isExportDeclaration(statement)) {
+      if (!statement.exportClause) return count + 1;
+      if (ts.isNamedExports(statement.exportClause)) {
+        return count + statement.exportClause.elements.length;
+      }
+      return count + 1;
+    }
+
+    if (ts.isExportAssignment(statement)) return count + 1;
+    if (!hasExportModifier(statement)) return count;
+    if (ts.isVariableStatement(statement)) {
+      return count + statement.declarationList.declarations.length;
+    }
+    return count + 1;
+  }, 0);
+}

--- a/lsp/architecture/analyzer/imports/specifier-resolution.ts
+++ b/lsp/architecture/analyzer/imports/specifier-resolution.ts
@@ -1,0 +1,22 @@
+import path from "node:path";
+import ts from "typescript";
+import {
+  candidateFileNames,
+  SOURCE_EXTENSIONS,
+} from "../project/api/index.js";
+
+export function resolveLocalSpecifier(
+  fromFile: string,
+  specifier: string,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+): string | null {
+  if (!specifier.startsWith(".")) return null;
+
+  const absolute = path.resolve(path.dirname(fromFile), specifier);
+  const candidates = [
+    ...candidateFileNames(absolute),
+    ...SOURCE_EXTENSIONS.map((extension) => path.join(absolute, `index${extension}`)),
+  ];
+
+  return candidates.find((candidate) => sourceFilesByPath.has(candidate)) ?? null;
+}

--- a/lsp/architecture/analyzer/index.ts
+++ b/lsp/architecture/analyzer/index.ts
@@ -1,0 +1,197 @@
+/**
+ * @file Architecture analyzer entry point. Composes every analysis pass
+ * (package exports, inventory barrels, vendor type leaks, public
+ * surface, folder graph, folder/module shape) into the single project
+ * report consumed by the architecture LSP server and CI shim.
+ */
+
+import path from "node:path";
+import type ts from "typescript";
+import { checkFolderShape } from "./folder-shape/index.js";
+import { checkInventoryBarrels } from "./exports/inventory-barrels.js";
+import { buildProjectGraph, checkFolderGraph } from "./imports/index.js";
+import { checkModuleShape } from "./module-shape/index.js";
+import {
+  checkPackageExports,
+  checkPublicSurface,
+  emptyPackageJson,
+  readPackageJson,
+} from "./package-api/index.js";
+import {
+  createProgram,
+  findPackageReportFile,
+  projectSourceFiles,
+  resolveArchitectureOptions,
+  uniqueDiagnostics,
+} from "./project/api/index.js";
+import { checkPublicVendorTypeLeaks } from "./type-surface/index.js";
+import {
+  buildDirectiveIndex,
+  isDirectiveSuppressed,
+  parseDirectivesFromSourceFile,
+  type FileDirectives,
+} from "./architecture-exceptions.js";
+import { ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID } from "./rule-ids.js";
+import type {
+  ArchitectureDiagnostic,
+  ArchitectureDiagnosticRuleId,
+  ArchitectureReport,
+  ResolvedArchitectureOptions,
+} from "./project/api/index.js";
+
+interface DirectiveAnalysis {
+  readonly directiveErrorDiagnostics: readonly ArchitectureDiagnostic[];
+  readonly directiveIndex: ReadonlyMap<string, ReadonlySet<ArchitectureDiagnosticRuleId>>;
+  readonly attemptedSuppressions: ReadonlyMap<string, ReadonlySet<ArchitectureDiagnosticRuleId>>;
+}
+
+/**
+ * Run every architecture analysis pass (package exports, inventory
+ * barrels, public vendor type leaks, public surface, folder graph,
+ * folder shape, module shape) against pre-resolved options and return
+ * the merged report with directive-based suppressions applied. Used by
+ * the cache layer so options are not re-decoded on every rule.
+ * @param options Pre-resolved architecture options (already
+ * schema-decoded and path-resolved).
+ * @param programProvider Lazy provider for the `ts.Program`. The
+ * default builds one from the project tsconfig via `createProgram`.
+ * The rule path passes a provider that returns
+ * `parserServices.program` so the analyzer reuses the program
+ * typescript-eslint already maintains instead of parsing every project
+ * file a second time.
+ * @returns The combined architecture report with deduplicated
+ * diagnostics, after directive suppressions are applied.
+ */
+export function analyzeResolvedArchitecture(
+  options: ResolvedArchitectureOptions,
+  programProvider: () => ts.Program | null = () => createProgram(options),
+): ArchitectureReport {
+  const packageJson = readPackageJson(options.projectRoot) ?? emptyPackageJson();
+  const program = programProvider();
+  const sourceFiles = program ? projectSourceFiles(program, options.projectRoot) : [];
+  const packageReportFile = findPackageReportFile(sourceFiles, options.projectRoot);
+  const graph = buildProjectGraph(sourceFiles, packageJson, options, packageReportFile);
+  const directiveAnalysis = analyzeDirectiveComments(sourceFiles);
+
+  const allDiagnostics = uniqueDiagnostics([
+    ...checkPackageExports(packageJson, options, packageReportFile),
+    ...checkInventoryBarrels(sourceFiles, options),
+    ...resolvePublicVendorTypeLeaks(program, packageJson, options),
+    ...checkPublicSurface(graph, sourceFiles, options),
+    ...checkFolderGraph(graph, options),
+    ...checkFolderShape(graph, options),
+    ...checkModuleShape(graph, options),
+  ]);
+
+  const diagnostics = [
+    ...directiveAnalysis.directiveErrorDiagnostics,
+    ...filterSuppressedDiagnostics(allDiagnostics, directiveAnalysis),
+  ];
+  return { diagnostics, diagnosticsByFile: indexByFile(diagnostics) };
+}
+
+function indexByFile(
+  diagnostics: readonly ArchitectureDiagnostic[],
+): ReadonlyMap<string, readonly ArchitectureDiagnostic[]> {
+  const byFile = new Map<string, ArchitectureDiagnostic[]>();
+  for (const diagnostic of diagnostics) {
+    const bucket = byFile.get(diagnostic.file);
+    if (bucket === undefined) byFile.set(diagnostic.file, [diagnostic]);
+    else bucket.push(diagnostic);
+  }
+  return byFile;
+}
+
+function resolvePublicVendorTypeLeaks(
+  program: ReturnType<typeof createProgram>,
+  packageJson: ReturnType<typeof emptyPackageJson>,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return program === null ? [] : checkPublicVendorTypeLeaks(program, packageJson, options);
+}
+
+function analyzeDirectiveComments(
+  sourceFiles: readonly ReturnType<typeof projectSourceFiles>[number][],
+): DirectiveAnalysis {
+  const fileDirectives: FileDirectives[] = [];
+  const directiveErrorDiagnostics: ArchitectureDiagnostic[] = [];
+  const attemptedSuppressions = new Map<string, Set<ArchitectureDiagnosticRuleId>>();
+
+  for (const sourceFile of sourceFiles) {
+    const result = parseDirectivesFromSourceFile(sourceFile);
+    const resolvedFile = path.resolve(sourceFile.fileName);
+    if (result.directives.length > 0) {
+      fileDirectives.push({ file: resolvedFile, directives: result.directives });
+    }
+    for (const err of result.errors) {
+      directiveErrorDiagnostics.push(directiveParseDiagnostic(resolvedFile, err));
+      if (err.ruleId !== null) {
+        recordAttemptedSuppression(attemptedSuppressions, resolvedFile, err.ruleId);
+      }
+    }
+  }
+  return {
+    attemptedSuppressions,
+    directiveErrorDiagnostics,
+    directiveIndex: buildDirectiveIndex(fileDirectives),
+  };
+}
+
+function directiveParseDiagnostic(
+  resolvedFile: string,
+  error: { readonly line: number; readonly message: string },
+): ArchitectureDiagnostic {
+  return {
+    ruleId: ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID,
+    file: resolvedFile,
+    severity: "error",
+    message: `Architecture directive parse error (line ${error.line}): ${error.message}`,
+  };
+}
+
+function recordAttemptedSuppression(
+  attemptedSuppressions: Map<string, Set<ArchitectureDiagnosticRuleId>>,
+  resolvedFile: string,
+  ruleId: ArchitectureDiagnosticRuleId,
+): void {
+  const set = attemptedSuppressions.get(resolvedFile) ?? new Set();
+  set.add(ruleId);
+  attemptedSuppressions.set(resolvedFile, set);
+}
+
+function filterSuppressedDiagnostics(
+  diagnostics: readonly ArchitectureDiagnostic[],
+  directiveAnalysis: DirectiveAnalysis,
+): readonly ArchitectureDiagnostic[] {
+  return diagnostics.filter((diagnostic) =>
+    shouldKeepDiagnostic(diagnostic, directiveAnalysis)
+  );
+}
+
+function shouldKeepDiagnostic(
+  diagnostic: ArchitectureDiagnostic,
+  directiveAnalysis: DirectiveAnalysis,
+): boolean {
+  if (diagnostic.ruleId === ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID) return true;
+  const ruleId = diagnostic.ruleId as ArchitectureDiagnosticRuleId;
+  const resolvedFile = path.resolve(diagnostic.file);
+  if (isDirectiveSuppressed(directiveAnalysis.directiveIndex, resolvedFile, ruleId)) {
+    return false;
+  }
+  return !directiveAnalysis.attemptedSuppressions.get(resolvedFile)?.has(ruleId);
+}
+
+/**
+ * Public entry: decode raw user options, resolve paths, and run the
+ * full architecture analysis. The LSP server uses
+ * `cachedProjectArchitecture` instead so options are not re-resolved on
+ * every diagnostic publish; this entry is for tests, CI shims, and
+ * callers that have not pre-resolved options.
+ * @param options Raw architecture options object from user config
+ * (defaults to `{}`).
+ * @returns The combined architecture report with diagnostics and
+ * suppressions applied.
+ */
+export function analyzeWorkspace(options: unknown = {}): ArchitectureReport {
+  return analyzeResolvedArchitecture(resolveArchitectureOptions(options));
+}

--- a/lsp/architecture/analyzer/index.ts
+++ b/lsp/architecture/analyzer/index.ts
@@ -49,16 +49,16 @@ interface DirectiveAnalysis {
  * Run every architecture analysis pass (package exports, inventory
  * barrels, public vendor type leaks, public surface, folder graph,
  * folder shape, module shape) against pre-resolved options and return
- * the merged report with directive-based suppressions applied. Used by
- * the cache layer so options are not re-decoded on every rule.
+ * the merged report with directive-based suppressions applied. The
+ * cache layer calls this with pre-resolved options so options are not
+ * re-decoded on every analyzer hit.
  * @param options Pre-resolved architecture options (already
  * schema-decoded and path-resolved).
  * @param programProvider Lazy provider for the `ts.Program`. The
  * default builds one from the project tsconfig via `createProgram`.
- * The rule path passes a provider that returns
- * `parserServices.program` so the analyzer reuses the program
- * typescript-eslint already maintains instead of parsing every project
- * file a second time.
+ * The LSP workspace engine supplies a provider that returns its
+ * cached `ts.Program` so the analyzer does not parse every project
+ * file on each diagnostic refresh.
  * @returns The combined architecture report with deduplicated
  * diagnostics, after directive suppressions are applied.
  */

--- a/lsp/architecture/analyzer/module-shape/README.md
+++ b/lsp/architecture/analyzer/module-shape/README.md
@@ -1,0 +1,23 @@
+# module-shape
+
+Rules that score the *shape* of an individual module — how many things it
+exports, who imports it, and whether its surface coheres.
+
+| File | Rule | What it flags |
+|------|------|---------------|
+| `implicit-boundary.ts` | `file-implicit-boundary-module` | Non-facade files that act as implicit boundaries between caller and implementation regions. |
+| `shared-kernel-cohesion.ts` | `shared-kernel-cohesion` | Wide shared-kernel files whose exports are consumed by mostly disjoint modules. |
+| `no-trivial-sink-file.ts` | `no-trivial-sink-file` | Tiny files (≤2 exports, ≤5 statements) with exactly one consumer that uses (not re-exports) the symbols. Inline at the call site. |
+| `no-fat-orchestrator.ts` | `no-fat-orchestrator` | Non-entry files with high fan-out (≥15), low fan-in (≤1), and a substantive body (≥20 top-level statements). Either declare it an entry point or split. |
+
+## Boundary
+
+These rules read the project graph (`graph.modules`,
+`graph.exportConsumersByFileName`, `module.localEdges`,
+`module.externalEdges`, `module.topLevelStatementCount`,
+`module.exportedSymbolCount`) and emit `ArchitectureDiagnostic`s. They never
+walk file ASTs directly; the graph builder is the single source of truth for
+counting.
+
+The `index.ts` here composes these checks into `checkModuleShape`, which is
+called once per project from the architecture analyzer entry point.

--- a/lsp/architecture/analyzer/module-shape/boundary-shapes.test.ts
+++ b/lsp/architecture/analyzer/module-shape/boundary-shapes.test.ts
@@ -25,16 +25,6 @@ it("surfaces architecture diagnostics through the analyzer API", () => {
   expect(findings[0]?.message).toContain("This exports inventory");
 });
 
-it("infers the nearest package root when projectRoot is omitted", () => {
-  const root = makeInventoryProject();
-  const findings = analyzeWorkspace({ projectRoot: root }).diagnostics.filter(
-    (d) => d.ruleId === "no-inventory-barrel",
-  );
-
-  expect(findings).toHaveLength(1);
-  expect(findings[0]?.message).toContain("This exports inventory");
-});
-
 it("rule id registry covers every architecture diagnostic family", () => {
   // Spot-check that the registry exposes the rule ids the LSP server
   // wires into `code` and `codeDescription.href` per diagnostic.

--- a/lsp/architecture/analyzer/module-shape/boundary-shapes.test.ts
+++ b/lsp/architecture/analyzer/module-shape/boundary-shapes.test.ts
@@ -1,0 +1,143 @@
+import * as fc from "fast-check";
+import { afterEach, expect, it } from "vitest";
+import { analyzeWorkspace } from "../index.js";
+import { ARCHITECTURE_DIAGNOSTIC_RULE_IDS } from "../rule-ids.js";
+import {
+  cleanupArchitectureFixtures,
+  diagnosticsByRule,
+  folderApiFixture,
+  implicitBoundaryFixture,
+  makeProject,
+  segmentArb,
+  sharedKernelCohesionFixture,
+} from "../test-support/analyzer-fixtures.js";
+
+afterEach(cleanupArchitectureFixtures);
+
+it("surfaces architecture diagnostics through the analyzer API", () => {
+  const root = makeInventoryProject();
+  const findings = analyzeWorkspace({ projectRoot: root }).diagnostics.filter(
+    (d) => d.ruleId === "no-inventory-barrel",
+  );
+
+  expect(findings).toHaveLength(1);
+  expect(findings[0]?.ruleId).toBe("no-inventory-barrel");
+  expect(findings[0]?.message).toContain("This exports inventory");
+});
+
+it("infers the nearest package root when projectRoot is omitted", () => {
+  const root = makeInventoryProject();
+  const findings = analyzeWorkspace({ projectRoot: root }).diagnostics.filter(
+    (d) => d.ruleId === "no-inventory-barrel",
+  );
+
+  expect(findings).toHaveLength(1);
+  expect(findings[0]?.message).toContain("This exports inventory");
+});
+
+it("rule id registry covers every architecture diagnostic family", () => {
+  // Spot-check that the registry exposes the rule ids the LSP server
+  // wires into `code` and `codeDescription.href` per diagnostic.
+  const expected = [
+    "no-inventory-barrel",
+    "no-public-vendor-type-leak",
+    "no-folder-cycle",
+    "require-curated-public-facade",
+    "folder-explicit-api-required",
+    "file-implicit-boundary-module",
+    "shared-kernel-cohesion",
+    "no-large-folder",
+    "folder-readme-required",
+    "no-distant-folder-import",
+  ];
+  for (const ruleId of expected) {
+    expect(ARCHITECTURE_DIAGNOSTIC_RULE_IDS).toContain(ruleId);
+  }
+});
+
+it("Property: folder API diagnostics follow outside concrete imports", () => {
+  fc.assert(
+    fc.property(
+      fc.record({
+        apiFolder: segmentArb,
+        consumerFolder: segmentArb,
+        concreteCount: fc.integer({ min: 2, max: 5 }),
+        consumerCount: fc.integer({ min: 1, max: 3 }),
+        hasFacade: fc.boolean(),
+      }),
+      (input) => {
+        fc.pre(input.apiFolder !== "index" && input.apiFolder !== input.consumerFolder);
+        const root = makeProject(folderApiFixture(input));
+
+        expect(diagnosticsByRule(root, "folder-explicit-api-required").length > 0)
+          .toBe(!input.hasFacade);
+      },
+    ),
+    { numRuns: 20 },
+  );
+});
+
+it("Property: implicit boundary diagnostics follow caller/helper topology", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 2, max: 4 }),
+      fc.integer({ min: 2, max: 4 }),
+      fc.boolean(),
+      (callerCount, helperCount, explicitBoundaryName) => {
+        const boundaryName = explicitBoundaryName ? "boundary-api" : "boundary";
+        const root = makeProject(
+          implicitBoundaryFixture(boundaryName, callerCount, helperCount),
+        );
+        const options = explicitBoundaryName
+          ? {
+            facadeFiles: [
+              {
+                file: `${boundaryName}.ts`,
+                reason: "fixture intentionally declares this non-index boundary",
+              },
+            ],
+          }
+          : {};
+
+        expect(diagnosticsByRule(root, "file-implicit-boundary-module", options).length > 0)
+          .toBe(!explicitBoundaryName);
+      },
+    ),
+    { numRuns: 16 },
+  );
+});
+
+it("Property: shared-kernel cohesion follows export consumer overlap", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 6, max: 10 }),
+      fc.integer({ min: 4, max: 6 }),
+      fc.boolean(),
+      (exportCount, consumerCount, cohesive) => {
+        const root = makeProject(
+          sharedKernelCohesionFixture(exportCount, consumerCount, cohesive),
+        );
+
+        expect(diagnosticsByRule(root, "shared-kernel-cohesion").length > 0)
+          .toBe(!cohesive);
+      },
+    ),
+    { numRuns: 16 },
+  );
+});
+
+function makeInventoryProject(): string {
+  return makeProject({
+    "src/widgets/index.ts": [
+      'export { A } from "./a";',
+      'export { B } from "./b";',
+      'export { C } from "./c";',
+      'export { D } from "./d";',
+    ].join("\n"),
+    "src/widgets/a.ts": "export const A = 1;\n",
+    "src/widgets/b.ts": "export const B = 1;\n",
+    "src/widgets/c.ts": "export const C = 1;\n",
+    "src/widgets/d.ts": "export const D = 1;\n",
+    "src/widgets/e.ts": "export const E = 1;\n",
+  });
+}

--- a/lsp/architecture/analyzer/module-shape/implicit-boundary.ts
+++ b/lsp/architecture/analyzer/module-shape/implicit-boundary.ts
@@ -1,0 +1,91 @@
+import {
+  explicitFacadeModule,
+  generatedModule,
+  resolveImplementationModule,
+  resolveProductionModule,
+} from "../project/index.js";
+import type { ProjectArchitectureGraph, SourceModule } from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+export function implicitBoundaryModuleDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.modules.flatMap((module) =>
+    implicitBoundaryModuleDiagnostic(graph, options, module)
+  );
+}
+
+function implicitBoundaryModuleDiagnostic(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+  module: SourceModule,
+): readonly ArchitectureDiagnostic[] {
+  if (!implicitBoundaryCandidate(module, options)) return [];
+  const incomingFiles = incomingProductionFiles(graph, module);
+  const outgoingFiles = outgoingImplementationFiles(graph, module);
+  if (!implicitBoundaryShape(incomingFiles, outgoingFiles, options)) return [];
+  return [boundaryModuleDiagnostic(module, incomingFiles, outgoingFiles)];
+}
+
+function implicitBoundaryCandidate(
+  module: SourceModule,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  if (module.isTestLike || generatedModule(module) || explicitFacadeModule(module, options)) {
+    return false;
+  }
+  return module.exportedSymbolCount >= options.minImplicitBoundaryExports;
+}
+
+function implicitBoundaryShape(
+  incomingFiles: ReadonlySet<string>,
+  outgoingFiles: ReadonlySet<string>,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  return incomingFiles.size >= options.minImplicitBoundaryIncomingFiles &&
+    outgoingFiles.size >= options.minImplicitBoundaryOutgoingFiles;
+}
+
+function incomingProductionFiles(
+  graph: ProjectArchitectureGraph,
+  module: SourceModule,
+): ReadonlySet<string> {
+  return new Set(
+    graph.localEdges
+      .filter((edge) => edge.to === module.fileName)
+      .map((edge) => graph.modulesByFileName.get(edge.from))
+      .filter(resolveProductionModule)
+      .map((consumer) => consumer.fileName),
+  );
+}
+
+function outgoingImplementationFiles(
+  graph: ProjectArchitectureGraph,
+  module: SourceModule,
+): ReadonlySet<string> {
+  return new Set(
+    module.localEdges
+      .map((edge) => graph.modulesByFileName.get(edge.to))
+      .filter(resolveImplementationModule)
+      .map((target) => target.fileName),
+  );
+}
+
+function boundaryModuleDiagnostic(
+  module: SourceModule,
+  incomingFiles: ReadonlySet<string>,
+  outgoingFiles: ReadonlySet<string>,
+): ArchitectureDiagnostic {
+  return {
+    ruleId: "file-implicit-boundary-module",
+    file: module.fileName,
+    severity: "warn",
+    message:
+      `${module.relativePath} acts like a boundary module: ` +
+      `${incomingFiles.size} production files depend on it, it depends on ` +
+      `${outgoingFiles.size} implementation files, and it exports ` +
+      `${module.exportedSymbolCount} names. Move the stable API to index.ts, ` +
+      "or list a deliberate non-index facade in architecture facadeFiles.",
+  };
+}

--- a/lsp/architecture/analyzer/module-shape/index.ts
+++ b/lsp/architecture/analyzer/module-shape/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @file Module-shape analysis barrel. Composes the per-rule module
+ * checks (implicit boundary, shared-kernel cohesion, trivial sink
+ * file, fat orchestrator) into a single project-level diagnostic pass.
+ */
+
+import { fatOrchestratorDiagnostics } from "./no-fat-orchestrator.js";
+import { implicitBoundaryModuleDiagnostics } from "./implicit-boundary.js";
+import { sharedKernelCohesionDiagnostics } from "./shared-kernel-cohesion.js";
+import { trivialSinkFileDiagnostics } from "./no-trivial-sink-file.js";
+import { uniqueDiagnostics } from "../project/api/index.js";
+import type { ProjectArchitectureGraph } from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+/**
+ * Run every module-shape architecture check (implicit boundary,
+ * shared-kernel cohesion, trivial sink file, fat orchestrator) against
+ * the project graph and return a deduplicated diagnostic list.
+ * @param graph Project architecture graph (modules, folders, edges).
+ * @param options Resolved architecture rule options with policy lists.
+ * @returns Deduplicated diagnostics; empty array when the module layer
+ * is healthy.
+ */
+export function checkModuleShape(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return uniqueDiagnostics([
+    ...implicitBoundaryModuleDiagnostics(graph, options),
+    ...sharedKernelCohesionDiagnostics(graph, options),
+    ...trivialSinkFileDiagnostics(graph, options),
+    ...fatOrchestratorDiagnostics(graph, options),
+  ]);
+}

--- a/lsp/architecture/analyzer/module-shape/no-fat-orchestrator.test.ts
+++ b/lsp/architecture/analyzer/module-shape/no-fat-orchestrator.test.ts
@@ -1,0 +1,113 @@
+import * as fc from "fast-check";
+import { afterEach, expect, it } from "vitest";
+import {
+  cleanupArchitectureFixtures,
+  diagnosticsByRule,
+  makeProject,
+} from "../test-support/analyzer-fixtures.js";
+
+afterEach(cleanupArchitectureFixtures);
+
+it("Property: a file with fan-out below threshold never fires no-fat-orchestrator", () => {
+  fc.assert(
+    fc.property(fc.integer({ min: 1, max: 14 }), (importCount) => {
+      const root = makeProject({
+        ...makeImportSiblings(importCount),
+        "src/feature/below-threshold.ts": makeOrchestratorBody(importCount, 25),
+      });
+      const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+      expect(diagnostics).toHaveLength(0);
+    }),
+    { numRuns: 5 },
+  );
+});
+
+function makeImportSiblings(count: number): Record<string, string> {
+  const files: Record<string, string> = {};
+  for (let i = 0; i < count; i += 1) {
+    files[`src/feature/dep-${i}.ts`] = `export const D${i} = ${i};\n`;
+  }
+  return files;
+}
+
+function makeOrchestratorBody(importCount: number, statementCount: number): string {
+  const imports = Array.from(
+    { length: importCount },
+    (_, i) => `import { D${i} } from "./dep-${i}.js";`,
+  ).join("\n");
+  const statements = Array.from(
+    { length: statementCount },
+    (_, i) => `const local${i} = ${i};`,
+  ).join("\n");
+  const usage = Array.from({ length: importCount }, (_, i) => `D${i}`).join(" + ");
+  return `${imports}\nexport const total = ${usage};\n${statements}\n`;
+}
+
+it("flags a non-entry file with high fan-out, low fan-in, and substantive body", () => {
+  const root = makeProject({
+    ...makeImportSiblings(16),
+    "src/feature/orchestrator.ts": makeOrchestratorBody(16, 20),
+  });
+  const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.message).toContain("orchestrator.ts");
+  expect(diagnostics[0]?.message).toContain("imports");
+});
+
+it("does not fire when fan-out is below threshold", () => {
+  const root = makeProject({
+    ...makeImportSiblings(10),
+    "src/feature/small.ts": makeOrchestratorBody(10, 25),
+  });
+  const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire when top-level statement count is low", () => {
+  const root = makeProject({
+    ...makeImportSiblings(20),
+    "src/feature/wiring.ts": makeOrchestratorBody(20, 2),
+  });
+  const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire when fan-in is high (it's a hub, not an orphan orchestrator)", () => {
+  const root = makeProject({
+    ...makeImportSiblings(16),
+    "src/feature/hub.ts": makeOrchestratorBody(16, 25),
+    "src/feature/use-a.ts":
+      'import { total } from "./hub.js";\nexport const a = total;\n',
+    "src/feature/use-b.ts":
+      'import { total } from "./hub.js";\nexport const b = total;\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire on index files", () => {
+  const root = makeProject({
+    ...makeImportSiblings(16),
+    "src/feature/index.ts": makeOrchestratorBody(16, 20),
+  });
+  const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire on files under cli/ or bin/", () => {
+  const root = makeProject({
+    ...makeImportSiblings(16),
+    "src/cli/run.ts": makeOrchestratorBody(16, 20),
+  });
+  const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire on test-like files", () => {
+  const root = makeProject({
+    ...makeImportSiblings(16),
+    "src/feature/big.test.ts": makeOrchestratorBody(16, 20),
+  });
+  const diagnostics = diagnosticsByRule(root, "no-fat-orchestrator");
+  expect(diagnostics).toHaveLength(0);
+});

--- a/lsp/architecture/analyzer/module-shape/no-fat-orchestrator.ts
+++ b/lsp/architecture/analyzer/module-shape/no-fat-orchestrator.ts
@@ -1,0 +1,77 @@
+import {
+  generatedModule,
+} from "../project/index.js";
+import type {
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+const MIN_FAN_OUT = 15;
+const MIN_TOP_LEVEL_STATEMENTS = 20;
+const MAX_FAN_IN = 1;
+
+const ENTRY_PATH_PATTERNS = [
+  /(^|[\\/])bin[\\/]/,
+  /(^|[\\/])cli[\\/]/,
+  /(^|[\\/])(main|cli|index)\.[cm]?[jt]sx?$/,
+  /\.config\.[cm]?[jt]sx?$/,
+];
+
+export function fatOrchestratorDiagnostics(
+  graph: ProjectArchitectureGraph,
+  _options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.modules.flatMap((module) => fatOrchestratorDiagnostic(graph, module));
+}
+
+function fatOrchestratorDiagnostic(
+  graph: ProjectArchitectureGraph,
+  module: SourceModule,
+): readonly ArchitectureDiagnostic[] {
+  if (!orchestratorCandidate(module)) return [];
+  const fanOut = module.localEdges.length + module.externalEdges.length;
+  if (fanOut < MIN_FAN_OUT) return [];
+  if (module.topLevelStatementCount < MIN_TOP_LEVEL_STATEMENTS) return [];
+  const fanIn = uniqueConsumerCount(graph, module);
+  if (fanIn > MAX_FAN_IN) return [];
+  return [fatOrchestratorReport(module, fanOut, fanIn)];
+}
+
+function orchestratorCandidate(module: SourceModule): boolean {
+  if (module.isTestLike) return false;
+  if (module.isIndex) return false;
+  if (module.isPublic) return false;
+  if (generatedModule(module)) return false;
+  if (isEntryPath(module.relativePath)) return false;
+  return true;
+}
+
+function isEntryPath(relativePath: string): boolean {
+  return ENTRY_PATH_PATTERNS.some((pattern) => pattern.test(relativePath));
+}
+
+function uniqueConsumerCount(
+  graph: ProjectArchitectureGraph,
+  module: SourceModule,
+): number {
+  const consumers = graph.exportConsumersByFileName.get(module.fileName) ?? [];
+  return new Set(consumers.map((consumer) => consumer.consumerFile)).size;
+}
+
+function fatOrchestratorReport(
+  module: SourceModule,
+  fanOut: number,
+  fanIn: number,
+): ArchitectureDiagnostic {
+  return {
+    ruleId: "no-fat-orchestrator",
+    file: module.fileName,
+    severity: "warn",
+    message:
+      `${module.relativePath} is shaped like an orchestrator (${fanOut} imports, ` +
+      `${module.topLevelStatementCount} top-level statements, ${fanIn} consumer${fanIn === 1 ? "" : "s"}) ` +
+      `but is not an entry point. Either declare it as an entry point (index/main/cli, public surface, ` +
+      `or move under bin/cli/) or split the wiring into focused submodules.`,
+  };
+}

--- a/lsp/architecture/analyzer/module-shape/no-trivial-sink-file.test.ts
+++ b/lsp/architecture/analyzer/module-shape/no-trivial-sink-file.test.ts
@@ -1,0 +1,104 @@
+import * as fc from "fast-check";
+import { afterEach, expect, it } from "vitest";
+import {
+  cleanupArchitectureFixtures,
+  diagnosticsByRule,
+  makeProject,
+} from "../test-support/analyzer-fixtures.js";
+
+afterEach(cleanupArchitectureFixtures);
+
+it("Property: a leaf with multiple consumers never fires no-trivial-sink-file", () => {
+  fc.assert(
+    fc.property(fc.integer({ min: 2, max: 6 }), (consumerCount) => {
+      const files: Record<string, string> = {
+        "src/feature/leaf.ts": "export const VALUE = 1;\n",
+      };
+      for (let i = 0; i < consumerCount; i += 1) {
+        files[`src/feature/consumer-${i}.ts`] =
+          `import { VALUE } from "./leaf.js";\nexport const c${i} = VALUE;\n`;
+      }
+      const root = makeProject(files);
+      const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+      expect(diagnostics).toHaveLength(0);
+    }),
+    { numRuns: 5 },
+  );
+});
+
+it("flags a small single-export file with exactly one consumer", () => {
+  const root = makeProject({
+    "src/feature/sink.ts": "export const VALUE = 42;\n",
+    "src/feature/use.ts":
+      'import { VALUE } from "./sink.js";\nexport const result = VALUE + 1;\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.message).toContain("sink.ts");
+  expect(diagnostics[0]?.message).toContain("1 consumer");
+  expect(diagnostics[0]?.message).toContain("Inline its contents");
+});
+
+it("does not fire when surface is large", () => {
+  const root = makeProject({
+    "src/feature/large.ts":
+      "export const A = 1;\nexport const B = 2;\nexport const C = 3;\nexport const D = 4;\n",
+    "src/feature/use.ts":
+      'import { A, B, C, D } from "./large.js";\nexport const r = A + B + C + D;\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire when there are multiple consumers", () => {
+  const root = makeProject({
+    "src/feature/leaf.ts": "export const VALUE = 42;\n",
+    "src/feature/a.ts":
+      'import { VALUE } from "./leaf.js";\nexport const a = VALUE;\n',
+    "src/feature/b.ts":
+      'import { VALUE } from "./leaf.js";\nexport const b = VALUE;\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire when the file is a pure barrel", () => {
+  const root = makeProject({
+    "src/feature/inner.ts": "export const X = 1;\n",
+    "src/feature/barrel.ts": 'export { X } from "./inner.js";\n',
+    "src/feature/use.ts":
+      'import { X } from "./barrel.js";\nexport const r = X;\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire when the sole consumer pure-re-exports the symbol (barrel exception)", () => {
+  const root = makeProject({
+    "src/types/user.ts": "export interface User { readonly id: string; }\n",
+    "src/types/index.ts": 'export type { User } from "./user.js";\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire on index files", () => {
+  const root = makeProject({
+    "src/feature/index.ts": "export const VALUE = 42;\n",
+    "src/use.ts":
+      'import { VALUE } from "./feature/index.js";\nexport const r = VALUE;\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+  expect(diagnostics).toHaveLength(0);
+});
+
+it("does not fire on test-like files", () => {
+  const root = makeProject({
+    "src/feature/sink.test.ts":
+      'export const FIXTURE = 1;\nimport { FIXTURE as X } from "./sink.test.js";\n',
+    "src/feature/use.test.ts":
+      'import { FIXTURE } from "./sink.test.js";\nconst _u = FIXTURE;\n',
+  });
+  const diagnostics = diagnosticsByRule(root, "no-trivial-sink-file");
+  expect(diagnostics).toHaveLength(0);
+});

--- a/lsp/architecture/analyzer/module-shape/no-trivial-sink-file.ts
+++ b/lsp/architecture/analyzer/module-shape/no-trivial-sink-file.ts
@@ -1,0 +1,94 @@
+import {
+  explicitFacadeModule,
+  generatedModule,
+} from "../project/index.js";
+import type {
+  ExportConsumer,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+const MAX_EXPORTED_SYMBOLS = 2;
+const MAX_TOP_LEVEL_STATEMENTS = 5;
+
+export function trivialSinkFileDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.modules.flatMap((module) =>
+    trivialSinkFileDiagnostic(graph, options, module)
+  );
+}
+
+function trivialSinkFileDiagnostic(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+  module: SourceModule,
+): readonly ArchitectureDiagnostic[] {
+  if (!sinkCandidate(module, options)) return [];
+  if (!moduleHasTrivialSurface(module)) return [];
+  const consumers = graph.exportConsumersByFileName.get(module.fileName) ?? [];
+  const uniqueConsumerFile = soleConsumerFile(consumers);
+  if (uniqueConsumerFile === null) return [];
+  if (consumersOnlyReexport(consumers)) return [];
+  return [singleConsumerDiagnostic(module, uniqueConsumerFile, graph)];
+}
+
+function sinkCandidate(
+  module: SourceModule,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  if (module.isTestLike) return false;
+  if (module.isIndex) return false;
+  if (module.isPublic) return false;
+  if (generatedModule(module)) return false;
+  if (explicitFacadeModule(module, options)) return false;
+  return true;
+}
+
+function moduleHasTrivialSurface(module: SourceModule): boolean {
+  if (module.exportedSymbolCount === 0) return false;
+  if (module.exportedSymbolCount > MAX_EXPORTED_SYMBOLS) return false;
+  if (module.topLevelStatementCount > MAX_TOP_LEVEL_STATEMENTS) return false;
+  return !isPureBarrel(module);
+}
+
+function isPureBarrel(module: SourceModule): boolean {
+  if (module.exportedSymbolCount === 0) return false;
+  return (
+    module.localReexportCount + module.starExportCount === module.exportedSymbolCount
+  );
+}
+
+function soleConsumerFile(consumers: readonly ExportConsumer[]): string | null {
+  if (consumers.length === 0) return null;
+  const unique = new Set(consumers.map((consumer) => consumer.consumerFile));
+  if (unique.size !== 1) return null;
+  const [first] = unique;
+  return first ?? null;
+}
+
+function consumersOnlyReexport(consumers: readonly ExportConsumer[]): boolean {
+  if (consumers.length === 0) return false;
+  return consumers.every((consumer) => consumer.kind === "reexport");
+}
+
+function singleConsumerDiagnostic(
+  module: SourceModule,
+  consumerFile: string,
+  graph: ProjectArchitectureGraph,
+): ArchitectureDiagnostic {
+  const consumerModule = graph.modulesByFileName.get(consumerFile);
+  const consumerLabel = consumerModule?.relativePath ?? consumerFile;
+  return {
+    ruleId: "no-trivial-sink-file",
+    file: module.fileName,
+    severity: "warn",
+    message:
+      `${module.relativePath} has 1 consumer (${consumerLabel}) and a trivial surface ` +
+      `(${module.exportedSymbolCount} export${module.exportedSymbolCount === 1 ? "" : "s"}, ` +
+      `${module.topLevelStatementCount} top-level statement${module.topLevelStatementCount === 1 ? "" : "s"}). ` +
+      `Inline its contents at the call site to remove the indirection, or expose it via a barrel if it is meant to be public.`,
+  };
+}

--- a/lsp/architecture/analyzer/module-shape/shared-kernel-cohesion.ts
+++ b/lsp/architecture/analyzer/module-shape/shared-kernel-cohesion.ts
@@ -1,0 +1,172 @@
+import {
+  explicitFacadeModule,
+  generatedModule,
+  jaccardOverlap,
+  resolveProductionModule,
+  unionSets,
+} from "../project/index.js";
+import type {
+  ExportConsumer,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "../imports/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+interface ExportConsumerSets {
+  readonly consumedExports: readonly string[];
+  readonly consumersByExport: ReadonlyMap<string, ReadonlySet<string>>;
+  readonly totalConsumers: ReadonlySet<string>;
+}
+
+interface ExportOverlap {
+  readonly primaryExport: string;
+  readonly secondaryExport: string;
+  readonly score: number;
+}
+
+interface OverlapStats {
+  readonly medianScore: number;
+  readonly comparisonCount: number;
+  readonly samples: readonly string[];
+}
+
+export function sharedKernelCohesionDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.modules.flatMap((module) =>
+    sharedKernelCohesionDiagnostic(graph, options, module)
+  );
+}
+
+function sharedKernelCohesionDiagnostic(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+  module: SourceModule,
+): readonly ArchitectureDiagnostic[] {
+  if (!sharedKernelCandidate(module, options)) return [];
+  const consumerSets = productionConsumerSets(graph, module);
+  if (!enoughSharedKernelEvidence(consumerSets, options)) return [];
+  const overlap = summarizeExportOverlap(consumerSets);
+  if (overlap === null || overlap.medianScore >= options.maxSharedKernelMedianOverlap) {
+    return [];
+  }
+  return [lowCohesionDiagnostic(module, consumerSets, overlap)];
+}
+
+function sharedKernelCandidate(
+  module: SourceModule,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  return !explicitFacadeModule(module, options) && !module.isTestLike && !generatedModule(module);
+}
+
+function enoughSharedKernelEvidence(
+  consumerSets: ExportConsumerSets,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  return consumerSets.consumedExports.length >= options.minSharedKernelExports &&
+    consumerSets.totalConsumers.size >= options.minSharedKernelConsumers;
+}
+
+function productionConsumerSets(
+  graph: ProjectArchitectureGraph,
+  module: SourceModule,
+): ExportConsumerSets {
+  const consumersByExport = new Map<string, Set<string>>();
+  for (const consumer of graph.exportConsumersByFileName.get(module.fileName) ?? []) {
+    addProductionExportConsumer(consumersByExport, graph, consumer);
+  }
+  const consumedExports = [...consumersByExport.keys()].sort();
+  return {
+    consumedExports,
+    consumersByExport,
+    totalConsumers: unionSets([...consumersByExport.values()]),
+  };
+}
+
+function addProductionExportConsumer(
+  consumersByExport: Map<string, Set<string>>,
+  graph: ProjectArchitectureGraph,
+  consumer: ExportConsumer,
+): void {
+  const consumerModule = graph.modulesByFileName.get(consumer.consumerFile);
+  if (!resolveProductionModule(consumerModule)) return;
+  const consumers = consumersByExport.get(consumer.exportName) ?? new Set<string>();
+  consumers.add(consumer.consumerFile);
+  consumersByExport.set(consumer.exportName, consumers);
+}
+
+function summarizeExportOverlap(
+  consumerSets: ExportConsumerSets,
+): OverlapStats | null {
+  const overlaps = exportPairOverlaps(consumerSets);
+  if (overlaps.length === 0) return null;
+  const sorted = [...overlaps].sort((first, second) => first.score - second.score);
+  return {
+    medianScore: sorted[Math.floor(sorted.length / 2)]?.score ?? 0,
+    comparisonCount: sorted.length,
+    samples: sorted.slice(0, 3).map(overlapSample),
+  };
+}
+
+function exportPairOverlaps(consumerSets: ExportConsumerSets): readonly ExportOverlap[] {
+  const pairs: ExportOverlap[] = [];
+  const names = consumerSets.consumedExports;
+  for (let firstIndex = 0; firstIndex < names.length; firstIndex += 1) {
+    addExportPairOverlaps(pairs, consumerSets, names, firstIndex);
+  }
+  return pairs;
+}
+
+function addExportPairOverlaps(
+  pairs: ExportOverlap[],
+  consumerSets: ExportConsumerSets,
+  names: readonly string[],
+  firstIndex: number,
+): void {
+  for (let secondIndex = firstIndex + 1; secondIndex < names.length; secondIndex += 1) {
+    const primaryExport = names[firstIndex];
+    const secondaryExport = names[secondIndex];
+    if (primaryExport !== undefined && secondaryExport !== undefined) {
+      pairs.push(exportPairOverlap(consumerSets, primaryExport, secondaryExport));
+    }
+  }
+}
+
+function exportPairOverlap(
+  consumerSets: ExportConsumerSets,
+  primaryExport: string,
+  secondaryExport: string,
+): ExportOverlap {
+  return {
+    primaryExport,
+    secondaryExport,
+    score: jaccardOverlap(
+      consumerSets.consumersByExport.get(primaryExport) ?? new Set(),
+      consumerSets.consumersByExport.get(secondaryExport) ?? new Set(),
+    ),
+  };
+}
+
+function overlapSample(overlap: ExportOverlap): string {
+  return `${overlap.primaryExport}/${overlap.secondaryExport}`;
+}
+
+function lowCohesionDiagnostic(
+  module: SourceModule,
+  consumerSets: ExportConsumerSets,
+  overlap: OverlapStats,
+): ArchitectureDiagnostic {
+  return {
+    ruleId: "shared-kernel-cohesion",
+    file: module.fileName,
+    severity: "warn",
+    message:
+      `${module.relativePath} has ${consumerSets.consumedExports.length} production ` +
+      `exports but low consumer overlap across export families ` +
+      `(median ${overlap.medianScore.toFixed(2)} across ` +
+      `${overlap.comparisonCount} pairs). ${overlap.samples.join(", ")} are ` +
+      "used by mostly different modules. Split cohesive helper modules or expose a small facade.",
+  };
+}

--- a/lsp/architecture/analyzer/package-api/index.ts
+++ b/lsp/architecture/analyzer/package-api/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @file Package-API analysis barrel. Re-exports the package-exports
+ * checks, public-surface analysis, public entrypoint resolution, and
+ * package.json reading helpers consumed by the architecture rules.
+ */
+
+export {
+  checkPackageExports,
+  packagePathSegments,
+  packageReportPath,
+  pathHasForbiddenSegment,
+} from "./package-exports.js";
+export { checkPublicSurface } from "./public-surface.js";
+export { publicApiFileNames } from "./public-entrypoints.js";
+export {
+  collectExportsValue,
+  collectPackageExportEntries,
+  emptyPackageJson,
+  readPackageJson,
+} from "../project/api/index.js";

--- a/lsp/architecture/analyzer/package-api/package-exports.core.test.ts
+++ b/lsp/architecture/analyzer/package-api/package-exports.core.test.ts
@@ -1,0 +1,243 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+import type { PackageJson } from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+it("normalizes package exports including conditions, subpaths, arrays, and main/types fallback", () => {
+  expect(
+    collectExportsValue(
+      {
+        ".": { import: "./dist/index.js", types: "./dist/index.d.ts" },
+        "./cli": ["./dist/cli.js", null],
+        "./internal/*": { default: "./dist/internal/*.js" },
+      },
+      ".",
+    ),
+  ).toEqual([
+    { publicPath: ".", targetPath: "./dist/index.js" },
+    { publicPath: ".", targetPath: "./dist/index.d.ts" },
+    { publicPath: "./cli", targetPath: "./dist/cli.js" },
+    { publicPath: "./internal/*", targetPath: "./dist/internal/*.js" },
+  ]);
+
+  const packageJson: PackageJson = {
+    name: "pkg",
+    main: "./dist/index.js",
+    types: "./dist/index.d.ts",
+    dependencies: new Map(),
+    devDependencies: new Map(),
+    peerDependencies: new Map(),
+  };
+
+  expect(collectPackageExportEntries(packageJson)).toEqual([
+    { publicPath: ".", targetPath: "./dist/index.js" },
+    { publicPath: ".", targetPath: "./dist/index.d.ts" },
+  ]);
+});
+
+it("Property: package export flattening preserves every explicit public subpath target", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 1, maxLength: 8 }),
+      (segments) => {
+        const exportsObject = Object.fromEntries(
+          segments.map((segment) => [
+            `./${segment}`,
+            {
+              import: `./dist/${segment}.js`,
+              types: `./dist/${segment}.d.ts`,
+            },
+          ]),
+        );
+
+        expect(collectExportsValue(exportsObject, ".")).toEqual(
+          segments.flatMap((segment) => [
+            { publicPath: `./${segment}`, targetPath: `./dist/${segment}.js` },
+            { publicPath: `./${segment}`, targetPath: `./dist/${segment}.d.ts` },
+          ]),
+        );
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: package export flattening ignores condition keys next to subpath keys", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 1, maxLength: 6 }),
+      fc.constantFrom("import", "require", "types", "default"),
+      (segments, conditionKey) => {
+        const exportsObject = {
+          [conditionKey]: "./dist/ignored-condition.js",
+          ...Object.fromEntries(
+            segments.map((segment) => [`./${segment}`, `./dist/${segment}.js`]),
+          ),
+        };
+
+        expect(collectExportsValue(exportsObject, ".")).toEqual(
+          segments.map((segment) => ({
+            publicPath: `./${segment}`,
+            targetPath: `./dist/${segment}.js`,
+          })),
+        );
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("uses the package root as the public path for string exports", () => {
+  expect(
+    collectExportsValue(
+      {
+        ".": "./dist/index.js",
+        import: "./dist/ignored-condition.js",
+      },
+      ".",
+    ),
+  ).toEqual([{ publicPath: ".", targetPath: "./dist/index.js" }]);
+
+  expect(
+    collectPackageExportEntries(
+      packageJsonForExports({
+        ".": {
+          import: "./dist/index.js",
+          types: "./dist/index.d.ts",
+        },
+      }),
+    ),
+  ).toEqual([
+    { publicPath: ".", targetPath: "./dist/index.js" },
+    { publicPath: ".", targetPath: "./dist/index.d.ts" },
+  ]);
+
+  expect(collectPackageExportEntries(packageJsonForExports("./dist/index.js"))).toEqual([
+    { publicPath: ".", targetPath: "./dist/index.js" },
+  ]);
+});
+
+it("reads package.json into typed dependency maps without unsafe record casts", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-package-json-"));
+  try {
+    expect(readPackageJson(root)).toBeNull();
+
+    fs.writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "pkg",
+        dependencies: { openai: "1.0.0", ignored: false },
+        devDependencies: { vitest: "2.0.0" },
+        peerDependencies: { react: "18.0.0" },
+      }),
+    );
+
+    const packageJson = readPackageJson(root);
+    expect(packageJson?.name).toBe("pkg");
+    expect(packageJson?.dependencies.get("openai")).toBe("1.0.0");
+    expect(packageJson?.dependencies.has("ignored")).toBe(false);
+    expect(packageJson?.devDependencies.get("vitest")).toBe("2.0.0");
+    expect(packageJson?.peerDependencies.get("react")).toBe("18.0.0");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+it("normalizes package export path segments before checking forbidden segments", () => {
+  expect(packagePathSegments("./internal/*.js")).toEqual(["internal"]);
+  expect(packagePathSegments("./...internal/**.js")).toEqual(["internal"]);
+  expect(packagePathSegments("./dist\\utils\\index.js")).toEqual([
+    "dist",
+    "utils",
+    "index",
+  ]);
+  expect(pathHasForbiddenSegment("./dist/helpers/index.js", ["helpers"])).toBe(true);
+  expect(pathHasForbiddenSegment("./dist/public/index.js", ["helpers"])).toBe(false);
+});
+
+it("Property: forbidden path detection is segment-based after slash, wildcard, and extension normalization", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 1, maxLength: 5 }),
+      segmentArb,
+      (segments, forbidden) => {
+        const cleanSegments = segments.filter((segment) => segment !== forbidden);
+        const absentPath = `./${cleanSegments.join("/")}/index.js`;
+        expect(pathHasForbiddenSegment(absentPath, [forbidden])).toBe(false);
+
+      const forbiddenGlob = `${forbidden}*.js`;
+      const presentPath = `./${[...cleanSegments, forbiddenGlob].join("\\")}`;
+        expect(pathHasForbiddenSegment(presentPath, [forbidden])).toBe(true);
+
+        const dottedPresentPath = `./${cleanSegments.join("/")}/...${forbidden}/**.js`;
+        expect(pathHasForbiddenSegment(dottedPresentPath, [forbidden])).toBe(true);
+      },
+    ),
+    { numRuns: 100 },
+  );
+});
+
+it("Property: internal package export diagnostics fire for forbidden public or target path segments", () => {
+  fc.assert(
+    fc.property(
+      segmentArb,
+      segmentArb,
+      fc.boolean(),
+      (publicSegment, targetSegment, forbiddenOnPublicPath) => {
+        const forbidden = "internal";
+        const publicPath = forbiddenOnPublicPath
+          ? `./${forbidden}/${publicSegment}`
+          : `./${publicSegment}`;
+        const targetPath = forbiddenOnPublicPath
+          ? `./dist/${targetSegment}.js`
+          : `./dist/${forbidden}/${targetSegment}.js`;
+        const diagnostics = diagnosticsForRule(
+          packageExportDiagnostics(
+            { ".": "./dist/index.js", [publicPath]: targetPath },
+            { forbiddenSubpathSegments: [forbidden] },
+          ),
+          "no-internal-subpath-export",
+        );
+
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]?.message).toContain(publicPath);
+        expect(diagnostics[0]?.message).toContain(targetPath);
+        expect(diagnostics[0]?.message).toContain("curated entrypoints");
+        expect(diagnostics[0]?.message).toContain("src/internal/utils/helpers");
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("documents why internal and test-only package exports are bad", () => {
+  const internalDiagnostic = diagnosticsForRule(
+    packageExportDiagnostics(
+      { ".": "./dist/index.js", "./internal/client": "./dist/internal/client.js" },
+      { forbiddenSubpathSegments: ["internal"] },
+    ),
+    "no-internal-subpath-export",
+  )[0];
+  expect(internalDiagnostic?.message).toBe(
+    'package.json export "./internal/client" exposes implementation path ' +
+      '"./dist/internal/client.js". Public exports should be curated entrypoints, ' +
+      "not src/internal/utils/helpers.",
+  );
+
+  const testDiagnostic = diagnosticsForRule(
+    packageExportDiagnostics(
+      { ".": "./dist/index.js", "./fixture": "./dist/__fixtures__/fixture.js" },
+      {
+        forbiddenSubpathSegments: [],
+        implementationPathSegments: [],
+        maxSubpathExports: 100,
+      },
+    ),
+    "no-public-test-helper-leak",
+  )[0];
+  expect(testDiagnostic?.message).toBe(
+    'package.json export "./fixture" exposes test-only path ' +
+      '"./dist/__fixtures__/fixture.js". Test helpers need an explicitly allowed testing ' +
+      "subpath so consumers do not treat them as production API.",
+  );
+});

--- a/lsp/architecture/analyzer/package-api/package-exports.policy.test.ts
+++ b/lsp/architecture/analyzer/package-api/package-exports.policy.test.ts
@@ -1,0 +1,197 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+it("Property: explicitly allowed public subpaths suppress internal export diagnostics", () => {
+  fc.assert(
+    fc.property(segmentArb, segmentArb, fc.boolean(), (publicSegment, targetSegment, onPublicPath) => {
+      const forbidden = "internal";
+      const publicPath = onPublicPath
+        ? `./${forbidden}/${publicSegment}`
+        : `./${publicSegment}`;
+      const targetPath = onPublicPath
+        ? `./dist/${targetSegment}.js`
+        : `./dist/${forbidden}/${targetSegment}.js`;
+
+      expect(
+        diagnosticsForRule(
+          packageExportDiagnostics(
+            { ".": "./dist/index.js", [publicPath]: targetPath },
+            {
+              allowedPublicSubpaths: [{ subpath: publicPath, reason: "test fixture" }],
+              forbiddenSubpathSegments: [forbidden],
+            },
+          ),
+          "no-internal-subpath-export",
+        ),
+      ).toEqual([]);
+    }),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: public subpath budget is inclusive up to the configured max", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 10 }),
+      fc.integer({ min: 0, max: 10 }),
+      (subpathCount, maxSubpathExports) => {
+        const exportsValue = Object.fromEntries([
+          [".", "./dist/index.js"],
+          ...Array.from({ length: subpathCount }, (_, index) => [
+            `./p${index}`,
+            `./dist/p${index}.js`,
+          ] as const),
+        ]);
+
+        const budgetDiagnostics = diagnosticsForRule(
+          packageExportDiagnostics(exportsValue, { maxSubpathExports }),
+          "no-internal-subpath-export",
+        ).filter((diagnostic) => diagnostic.message.includes("public subpaths"));
+
+        if (subpathCount > maxSubpathExports) {
+          expect(budgetDiagnostics).toHaveLength(1);
+          expect(budgetDiagnostics[0]?.message).toContain(String(subpathCount));
+          expect(budgetDiagnostics[0]?.message).toContain(String(maxSubpathExports));
+          expect(budgetDiagnostics[0]?.message).toContain("filesystem");
+        } else {
+          expect(budgetDiagnostics).toEqual([]);
+        }
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: wildcard package export diagnostics follow the configured max", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 6 }),
+      fc.integer({ min: 0, max: 6 }),
+      (wildcardCount, maxWildcardExports) => {
+        const exportsValue = Object.fromEntries([
+          [".", "./dist/index.js"],
+          ...Array.from({ length: wildcardCount }, (_, index) => [
+            `./feature-${index}/*`,
+            `./dist/feature-${index}/*.js`,
+          ] as const),
+        ]);
+
+        const wildcardDiagnostics = packageExportDiagnostics(exportsValue, {
+          maxSubpathExports: 100,
+          maxWildcardExports,
+          forbiddenSubpathSegments: [],
+        }).filter((diagnostic) => diagnostic.message.includes("wildcard public surface"));
+
+        expect(wildcardDiagnostics.length).toBe(
+          wildcardCount > maxWildcardExports ? wildcardCount : 0,
+        );
+        for (const diagnostic of wildcardDiagnostics) {
+          expect(diagnostic.message).toContain("*");
+          expect(diagnostic.message).toContain("implementation files");
+        }
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: test helper public exports require explicit test subpath allowances", () => {
+  fc.assert(
+    fc.property(
+      segmentArb,
+      segmentArb,
+      testOnlySegmentArb,
+      fc.boolean(),
+      (publicSegment, targetSegment, testSegment, onPublicPath) => {
+        const publicPath = onPublicPath
+          ? `./${testSegment}/${publicSegment}`
+          : `./${publicSegment}`;
+        const targetPath = onPublicPath
+          ? `./dist/${targetSegment}.js`
+          : `./dist/${testSegment}/${targetSegment}.js`;
+
+        const diagnostics = diagnosticsForRule(
+          packageExportDiagnostics(
+            { ".": "./dist/index.js", [publicPath]: targetPath },
+            {
+              forbiddenSubpathSegments: [],
+              implementationPathSegments: [],
+              maxSubpathExports: 100,
+            },
+          ),
+          "no-public-test-helper-leak",
+        );
+
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]?.message).toContain(publicPath);
+        expect(diagnostics[0]?.message).toContain(targetPath);
+        expect(diagnostics[0]?.message).toContain("test-only path");
+        expect(diagnostics[0]?.message).toContain("production API");
+
+        expect(
+          diagnosticsForRule(
+            packageExportDiagnostics(
+              { ".": "./dist/index.js", [publicPath]: targetPath },
+              {
+                allowedTestPublicSubpaths: [{ subpath: publicPath, reason: "test fixture" }],
+                forbiddenSubpathSegments: [],
+                implementationPathSegments: [],
+                maxSubpathExports: 100,
+              },
+            ),
+            "no-public-test-helper-leak",
+          ),
+        ).toEqual([]);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("Property: implementation-shaped public entries flag public or target path leaks", () => {
+  fc.assert(
+    fc.property(
+      segmentArb,
+      segmentArb,
+      fc.boolean(),
+      (publicSegment, targetSegment, onPublicPath) => {
+        const implementationSegment = "driver";
+        const publicPath = onPublicPath
+          ? `./${implementationSegment}/${publicSegment}`
+          : `./${publicSegment}`;
+        const targetPath = onPublicPath
+          ? `./dist/${targetSegment}.js`
+          : `./dist/${implementationSegment}/${targetSegment}.js`;
+        const options = {
+          forbiddenSubpathSegments: [],
+          implementationPathSegments: [implementationSegment],
+          maxSubpathExports: 100,
+        };
+        const diagnostics = diagnosticsForRule(
+          packageExportDiagnostics(
+            { ".": "./dist/index.js", [publicPath]: targetPath },
+            options,
+          ),
+          "no-implementation-file-public-entry",
+        );
+
+        expect(diagnostics).toHaveLength(1);
+        expect(diagnostics[0]?.message).toContain(publicPath);
+        expect(diagnostics[0]?.message).toContain(targetPath);
+        expect(diagnostics[0]?.message).toContain("contract");
+
+        expect(
+          diagnosticsForRule(
+            packageExportDiagnostics(
+              { ".": "./dist/index.js", [publicPath]: targetPath },
+              { ...options, allowedPublicSubpaths: [{ subpath: publicPath, reason: "test fixture" }] },
+            ),
+            "no-implementation-file-public-entry",
+          ),
+        ).toEqual([]);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});

--- a/lsp/architecture/analyzer/package-api/package-exports.ts
+++ b/lsp/architecture/analyzer/package-api/package-exports.ts
@@ -1,0 +1,178 @@
+import path from "node:path";
+import { collectPackageExportEntries, stripKnownExtension } from "../project/api/index.js";
+import type {
+  ResolvedArchitectureOptions,
+  PackageExportEntry,
+  PackageJson,
+  ArchitectureDiagnostic,
+} from "../project/api/index.js";
+
+export function checkPackageExports(
+  packageJson: PackageJson,
+  options: ResolvedArchitectureOptions,
+  reportFile: string,
+): readonly ArchitectureDiagnostic[] {
+  const entries = collectPackageExportEntries(packageJson);
+  return [
+    ...internalSubpathDiagnostics(entries, options, reportFile),
+    ...subpathBudgetDiagnostics(entries, options, reportFile),
+    ...wildcardExportDiagnostics(entries, options, reportFile),
+    ...testHelperExportDiagnostics(entries, options, reportFile),
+    ...implementationFilePublicEntryDiagnostics(entries, options, reportFile),
+  ];
+}
+
+export function pathHasForbiddenSegment(
+  pathLike: string,
+  forbiddenSegments: readonly string[],
+): boolean {
+  const forbidden = new Set(forbiddenSegments);
+  return packagePathSegments(pathLike).some((segment) =>
+    forbidden.has(segment),
+  );
+}
+
+export function packagePathSegments(pathLike: string): readonly string[] {
+  return pathLike
+    .replaceAll("\\", "/")
+    .split("/")
+    .map((segment) => stripKnownExtension(segment.replace(/^\.+/, "").replaceAll("*", "")))
+    .filter((segment) => segment.length > 0);
+}
+
+function internalSubpathDiagnostics(
+  entries: readonly PackageExportEntry[],
+  options: ResolvedArchitectureOptions,
+  reportFile: string,
+): readonly ArchitectureDiagnostic[] {
+  return entries.flatMap((entry) => {
+    if (options.allowedPublicSubpaths.some((s) => s.subpath === entry.publicPath)) return [];
+
+    const exposesInternalPath =
+      pathHasForbiddenSegment(entry.publicPath, options.forbiddenSubpathSegments) ||
+      pathHasForbiddenSegment(entry.targetPath, options.forbiddenSubpathSegments);
+    if (!exposesInternalPath) return [];
+
+    return [
+      {
+        ruleId: "no-internal-subpath-export",
+        file: reportFile,
+        severity: "error",
+        message:
+          `package.json export "${entry.publicPath}" exposes implementation path ` +
+          `"${entry.targetPath}". Public exports should be curated entrypoints, ` +
+          "not src/internal/utils/helpers.",
+      },
+    ];
+  });
+}
+
+function subpathBudgetDiagnostics(
+  entries: readonly PackageExportEntry[],
+  options: ResolvedArchitectureOptions,
+  reportFile: string,
+): readonly ArchitectureDiagnostic[] {
+  const uniqueSubpaths = new Set(
+    entries.map((entry) => entry.publicPath).filter((key) => key !== "."),
+  );
+  if (uniqueSubpaths.size <= options.maxSubpathExports) return [];
+
+  return [
+    {
+      ruleId: "no-internal-subpath-export",
+      file: reportFile,
+      severity: "warn",
+      message:
+        `package.json exposes ${uniqueSubpaths.size} public subpaths. ` +
+        `The default budget is ${options.maxSubpathExports}; a growing subpath list ` +
+        "turns the filesystem into public API.",
+    },
+  ];
+}
+
+function wildcardExportDiagnostics(
+  entries: readonly PackageExportEntry[],
+  options: ResolvedArchitectureOptions,
+  reportFile: string,
+): readonly ArchitectureDiagnostic[] {
+  const wildcardEntries = entries.filter((entry) => entry.publicPath.includes("*"));
+  if (wildcardEntries.length <= options.maxWildcardExports) return [];
+
+  return wildcardEntries.map((entry) => ({
+    ruleId: "no-internal-subpath-export",
+    file: reportFile,
+    severity: "error",
+    message:
+      `package.json export "${entry.publicPath}" is a wildcard public surface. ` +
+      "Wildcard exports make implementation files importable by consumers.",
+  }));
+}
+
+function testHelperExportDiagnostics(
+  entries: readonly PackageExportEntry[],
+  options: ResolvedArchitectureOptions,
+  reportFile: string,
+): readonly ArchitectureDiagnostic[] {
+  return entries.flatMap((entry) => {
+    if (options.allowedTestPublicSubpaths.some((s) => s.subpath === entry.publicPath)) return [];
+
+    const exposesTestShape =
+      pathHasForbiddenSegment(entry.publicPath, testOnlySegments) ||
+      pathHasForbiddenSegment(entry.targetPath, testOnlySegments);
+    if (!exposesTestShape) return [];
+
+    return [
+      {
+        ruleId: "no-public-test-helper-leak",
+        file: reportFile,
+        severity: "warn",
+        message:
+          `package.json export "${entry.publicPath}" exposes test-only path ` +
+          `"${entry.targetPath}". Test helpers need an explicitly allowed testing ` +
+          "subpath so consumers do not treat them as production API.",
+      },
+    ];
+  });
+}
+
+function implementationFilePublicEntryDiagnostics(
+  entries: readonly PackageExportEntry[],
+  options: ResolvedArchitectureOptions,
+  reportFile: string,
+): readonly ArchitectureDiagnostic[] {
+  return entries.flatMap((entry) => {
+    if (options.allowedPublicSubpaths.some((s) => s.subpath === entry.publicPath)) return [];
+
+    const exposesImplementation =
+      pathHasForbiddenSegment(entry.publicPath, options.implementationPathSegments) ||
+      pathHasForbiddenSegment(entry.targetPath, options.implementationPathSegments);
+    if (!exposesImplementation) return [];
+
+    return [
+      {
+        ruleId: "no-implementation-file-public-entry",
+        file: reportFile,
+        severity: "warn",
+        message:
+          `package.json export "${entry.publicPath}" points at implementation-shaped ` +
+          `path "${entry.targetPath}". Public entrypoints should be named for the ` +
+          "contract they provide, not the concrete file or pattern behind it.",
+      },
+    ];
+  });
+}
+
+export function packageReportPath(projectRoot: string): string {
+  return path.join(projectRoot, "package.json");
+}
+
+const testOnlySegments = [
+  "test",
+  "tests",
+  "testing",
+  "test-utils",
+  "test-support",
+  "fixtures",
+  "__fixtures__",
+  "__tests__",
+];

--- a/lsp/architecture/analyzer/package-api/public-entrypoints.ts
+++ b/lsp/architecture/analyzer/package-api/public-entrypoints.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+import ts from "typescript";
+import { candidateFileNames, collectPackageExportEntries } from "../project/api/index.js";
+import type { PackageJson, ResolvedArchitectureOptions } from "../project/api/index.js";
+
+const DEFAULT_PUBLIC_ENTRYPOINTS = [
+  "src/index.ts",
+  "src/index.tsx",
+  "index.ts",
+  "index.tsx",
+] as const;
+
+export function publicApiFileNames(
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+  packageJson: PackageJson,
+  options: ResolvedArchitectureOptions,
+): ReadonlySet<string> {
+  const publicFiles = new Set<string>();
+  addPackagePublicFiles(publicFiles, packageJson, sourceFilesByPath, options);
+  if (publicFiles.size === 0) addDefaultPublicFiles(publicFiles, options.projectRoot);
+  return publicFiles;
+}
+
+function addPackagePublicFiles(
+  publicFiles: Set<string>,
+  packageJson: PackageJson,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+  options: ResolvedArchitectureOptions,
+): void {
+  for (const entry of collectPackageExportEntries(packageJson)) {
+    addPackageExportPublicFiles(publicFiles, entry.targetPath, sourceFilesByPath, options);
+  }
+}
+
+function addPackageExportPublicFiles(
+  publicFiles: Set<string>,
+  targetPath: string,
+  sourceFilesByPath: ReadonlyMap<string, ts.SourceFile>,
+  options: ResolvedArchitectureOptions,
+): void {
+  const candidates = sourceCandidatesForPackageTarget(targetPath, options.projectRoot);
+  for (const candidate of candidates) {
+    if (sourceFilesByPath.has(candidate)) publicFiles.add(candidate);
+  }
+}
+
+function addDefaultPublicFiles(
+  publicFiles: Set<string>,
+  projectRoot: string,
+): void {
+  for (const candidate of DEFAULT_PUBLIC_ENTRYPOINTS) {
+    publicFiles.add(path.resolve(projectRoot, candidate));
+  }
+}
+
+function sourceCandidatesForPackageTarget(
+  targetPath: string,
+  projectRoot: string,
+): readonly string[] {
+  const targetWithoutPrefix = targetPath.replaceAll("\\", "/").replace(/^\.\//, "");
+  const relativePaths = targetWithoutPrefix.startsWith("dist/")
+    ? [targetWithoutPrefix, `src/${targetWithoutPrefix.slice("dist/".length)}`]
+    : [targetWithoutPrefix];
+
+  return relativePaths.flatMap((relativePath) =>
+    candidateFileNames(path.resolve(projectRoot, relativePath)),
+  );
+}

--- a/lsp/architecture/analyzer/package-api/public-surface.analyzer.test.ts
+++ b/lsp/architecture/analyzer/package-api/public-surface.analyzer.test.ts
@@ -1,0 +1,257 @@
+import * as fc from "fast-check";
+import { afterEach, expect, it } from "vitest";
+import {
+  barrelExports,
+  cleanupArchitectureFixtures,
+  diagnosticMessages,
+  diagnosticsByRule,
+  diagnosticsFor,
+  hasRule,
+  makeProject,
+  nodeModuleTypePackage,
+  packageJsonWithDependency,
+  packageJsonWithExports,
+  ratioArb,
+  segmentArb,
+  sourceModuleFiles,
+} from "../test-support/analyzer-fixtures.js";
+
+afterEach(cleanupArchitectureFixtures);
+
+it("Property: inventory barrels follow count and ratio thresholds", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 1, max: 9 }),
+      fc.integer({ min: 0, max: 9 }),
+      fc.integer({ min: 1, max: 9 }),
+      ratioArb,
+      (eligibleCount, rawExportCount, minExportedSiblingModules, maxExportedSiblingRatio) => {
+        const exportedCount = Math.min(rawExportCount, eligibleCount);
+        const root = makeProject({
+          "src/widgets/index.ts": barrelExports("src/widgets", exportedCount),
+          ...sourceModuleFiles("src/widgets", eligibleCount),
+          "src/widgets/ignored.test.ts": "export const ignored = true;\n",
+        });
+        const shouldFlag =
+          exportedCount >= minExportedSiblingModules &&
+          exportedCount / eligibleCount >= maxExportedSiblingRatio;
+
+        expect(
+          hasRule(
+            diagnosticsFor(root, { minExportedSiblingModules, maxExportedSiblingRatio }),
+            "no-inventory-barrel",
+          ),
+        ).toBe(shouldFlag);
+      },
+    ),
+    { numRuns: 4 },
+  );
+});
+
+it("flags internal and wildcard package exports", () => {
+  const root = makeProject({
+    "package.json": packageJsonWithExports({
+      ".": "./dist/index.js",
+      "./internal/*": "./dist/internal/*.js",
+      "./utils": "./dist/utils/index.js",
+    }),
+  });
+
+  expect(
+    diagnosticMessages(root, {
+      forbiddenSubpathSegments: ["internal", "utils"],
+      allowedPublicSubpaths: [{ subpath: ".", reason: "test: primary entrypoint" }],
+    }),
+  ).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('export "./internal/*" exposes implementation path'),
+      expect.stringContaining('export "./utils" exposes implementation path'),
+      expect.stringContaining('export "./internal/*" is a wildcard public surface'),
+    ]),
+  );
+});
+
+it("flags public test helper and implementation-shaped package exports", () => {
+  const root = makeProject({
+    "package.json": packageJsonWithExports({
+      ".": "./dist/index.js",
+      "./test-utils": "./dist/test-utils/index.js",
+      "./driver": "./dist/db/driver.js",
+    }),
+    "src/test-utils/index.ts": "export const testHelper = true;\n",
+    "src/db/driver.ts": "export const driver = true;\n",
+  });
+
+  expect(
+    diagnosticMessages(root, {
+      implementationPathSegments: ["driver"],
+      allowedPublicSubpaths: [{ subpath: ".", reason: "test: primary entrypoint" }],
+      allowedTestPublicSubpaths: [
+        { subpath: "./testing", reason: "test: dedicated testing subpath" },
+      ],
+    }),
+  ).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('export "./test-utils" exposes test-only path'),
+      expect.stringContaining('export "./driver" points at implementation-shaped path'),
+    ]),
+  );
+});
+
+it("allows explicitly public subpaths", () => {
+  const root = makeProject({
+    "package.json": packageJsonWithExports({
+      ".": "./dist/index.js",
+      "./cli": "./dist/cli.js",
+      "./testing": "./dist/testing/index.js",
+    }),
+    "src/cli.ts": "export const cli = true;\n",
+    "src/testing/index.ts": "export const testing = true;\n",
+  });
+
+  expect(
+    diagnosticMessages(root, {
+      forbiddenSubpathSegments: ["internal", "utils", "helpers", "private"],
+      allowedPublicSubpaths: [
+        { subpath: ".", reason: "test: primary entrypoint" },
+        { subpath: "./cli", reason: "test: CLI invocation contract" },
+        { subpath: "./testing", reason: "test: consumer test helpers" },
+      ],
+      allowedTestPublicSubpaths: [
+        { subpath: "./testing", reason: "test: consumer test helpers" },
+      ],
+    }),
+  ).not.toContainEqual(expect.stringContaining("package.json export"));
+});
+
+it("flags export-star public boundaries and uncurated public facades", () => {
+  const root = makeProject({
+    "src/index.ts": ['export * from "./a";', 'export { B } from "./b";'].join("\n"),
+    "src/a.ts": "export const A = true;\n",
+    "src/b.ts": "export const B = true;\n",
+  });
+
+  expect(diagnosticMessages(root)).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining("uses 1 export-star boundary declaration"),
+      expect.stringContaining("is a public facade"),
+    ]),
+  );
+});
+
+it("Property: public reexport fanout follows the configured budget", () => {
+  fc.assert(
+    fc.property(
+      fc.integer({ min: 0, max: 18 }),
+      fc.integer({ min: 0, max: 18 }),
+      (reexportCount, maxPublicReexports) => {
+        const root = makeProject({
+          "src/index.ts": barrelExports("src", reexportCount),
+          ...sourceModuleFiles("src", reexportCount),
+        });
+
+        expect(
+          diagnosticsByRule(root, "no-large-public-surface", {
+            maxPublicExports: 100,
+            maxPublicReexports,
+          }).some((diagnostic) => diagnostic.message.includes("re-exports")),
+        ).toBe(reexportCount > maxPublicReexports);
+      },
+    ),
+    { numRuns: 8 },
+  );
+});
+
+it("Property: public vendor type leaks follow the allowlist", () => {
+  fc.assert(
+    fc.property(segmentArb, fc.boolean(), (packageName, allowed) => {
+      const typeName = "VendorShape";
+      const root = makeProject({
+        "package.json": packageJsonWithDependency(packageName),
+        ...nodeModuleTypePackage(packageName, typeName),
+        "src/index.ts": [
+          `import type { ${typeName} } from "${packageName}";`,
+          "export interface PublicShape {",
+          `  readonly raw: ${typeName};`,
+          "}",
+        ].join("\n"),
+      });
+
+      expect(
+        hasRule(
+          diagnosticsFor(root, {
+            publicTypePackages: allowed
+              ? [{ package: packageName, reason: "test: explicitly allowed" }]
+              : [],
+          }),
+          "no-public-vendor-type-leak",
+        ),
+      ).toBe(!allowed);
+    }),
+    { numRuns: 8 },
+  );
+});
+
+it("flags infrastructure type leaks and non-owned public boundary types", () => {
+  const root = makeProject({
+    "package.json": packageJsonWithDependency("kysely"),
+    ...nodeModuleTypePackage("kysely", "Kysely"),
+    "src/index.ts": [
+      'import type { Kysely } from "kysely";',
+      "export interface PublicDb {",
+      "  readonly raw: Kysely<{ readonly id: string }>;",
+      "}",
+    ].join("\n"),
+  });
+
+  expect(
+    diagnosticMessages(root, {
+      infrastructureTypePackages: [
+        { package: "kysely", reason: "test: query builder is implementation choice" },
+      ],
+    }),
+  ).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('export "PublicDb" references "kysely" types'),
+      expect.stringContaining('references infrastructure package "kysely"'),
+      expect.stringContaining('export "PublicDb" mentions "kysely" directly'),
+    ]),
+  );
+});
+
+it("allows public vendor types when the package is declared as public API", () => {
+  const root = makeProject({
+    "package.json": packageJsonWithDependency("openai"),
+    ...nodeModuleTypePackage("openai", "ChatCompletion"),
+    "src/index.ts": [
+      'import type { ChatCompletion } from "openai";',
+      "export interface ChatResult {",
+      "  readonly raw: ChatCompletion;",
+      "}",
+    ].join("\n"),
+  });
+
+  expect(
+    diagnosticsFor(root, {
+      publicTypePackages: [{ package: "openai", reason: "test: explicitly allowed" }],
+    }),
+  ).not.toContainEqual(expect.objectContaining({ ruleId: "no-public-vendor-type-leak" }));
+});
+
+it("warns for Node built-in public types unless the package is Node-facing", () => {
+  const root = makeProject({
+    "src/index.ts": [
+      'import type { Readable } from "node:stream";',
+      "export interface StreamResult {",
+      "  readonly body: Readable;",
+      "}",
+    ].join("\n"),
+  });
+
+  expect(diagnosticsFor(root)).toContainEqual(
+    expect.objectContaining({ ruleId: "no-public-vendor-type-leak", severity: "warn" }),
+  );
+  expect(diagnosticsFor(root, { packageRuntime: "node" })).not.toContainEqual(
+    expect.objectContaining({ ruleId: "no-public-vendor-type-leak" }),
+  );
+});

--- a/lsp/architecture/analyzer/package-api/public-surface.ts
+++ b/lsp/architecture/analyzer/package-api/public-surface.ts
@@ -1,0 +1,279 @@
+import path from "node:path";
+import ts from "typescript";
+import { uniqueDiagnostics } from "../project/api/index.js";
+import {
+  exportedDeclarationName,
+  hasExportModifier,
+} from "../project/index.js";
+import { packageAllowedInPublicTypes, packageNameFromSpecifier } from "../type-surface/index.js";
+import type { ArchitectureDiagnostic, ResolvedArchitectureOptions } from "../project/api/index.js";
+import type { ProjectArchitectureGraph, SourceModule } from "../project/index.js";
+
+export function checkPublicSurface(
+  graph: ProjectArchitectureGraph,
+  sourceFiles: readonly ts.SourceFile[],
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  const sourceFileByName = new Map(
+    sourceFiles.map((sourceFile) => [path.resolve(sourceFile.fileName), sourceFile] as const),
+  );
+
+  return uniqueDiagnostics([
+    ...exportStarBoundaryDiagnostics(graph),
+    ...largePublicSurfaceDiagnostics(graph, options),
+    ...curatedPublicFacadeDiagnostics(graph, options),
+    ...publicTestHelperLeakDiagnostics(graph),
+    ...boundaryOwnedTypeDiagnostics(graph, sourceFileByName, options),
+  ]);
+}
+
+function exportStarBoundaryDiagnostics(
+  graph: ProjectArchitectureGraph,
+): readonly ArchitectureDiagnostic[] {
+  return graph.modules.flatMap((module) => {
+    if (module.starExportCount === 0) return [];
+    if (!module.isPublic && !module.isIndex) return [];
+
+    return [
+      {
+        ruleId: "no-export-star-boundary",
+        file: module.fileName,
+        severity: "warn",
+        message:
+          `${module.relativePath} uses ${module.starExportCount} export-star boundary ` +
+          "declaration(s). export * makes the boundary inherit every future export " +
+          "from the target module.",
+      },
+    ];
+  });
+}
+
+function largePublicSurfaceDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.publicModules.flatMap((module) => {
+    const diagnostics: ArchitectureDiagnostic[] = [];
+
+    if (module.exportedSymbolCount > options.maxPublicExports) {
+      diagnostics.push({
+        ruleId: "no-large-public-surface",
+        file: module.fileName,
+        severity: "warn",
+        message:
+          `${module.relativePath} exports ${module.exportedSymbolCount} public symbols. ` +
+          `The default budget is ${options.maxPublicExports}; split concrete surfaces ` +
+          "behind narrower, named entrypoints.",
+      });
+    }
+
+    if (module.localReexportCount > options.maxPublicReexports) {
+      diagnostics.push({
+        ruleId: "no-large-public-surface",
+        file: module.fileName,
+        severity: "warn",
+        message:
+          `${module.relativePath} re-exports ${module.localReexportCount} local modules. ` +
+          `The default budget is ${options.maxPublicReexports}; a root entrypoint ` +
+          "should curate a contract, not load the package graph.",
+      });
+    }
+
+    return diagnostics;
+  });
+}
+
+function curatedPublicFacadeDiagnostics(
+  graph: ProjectArchitectureGraph,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.publicModules.flatMap((module) => {
+    if (!module.isIndex) return [];
+    if (
+      module.starExportCount === 0 &&
+      module.localReexportCount < options.minPublicFacadeModules
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        ruleId: "require-curated-public-facade",
+        file: module.fileName,
+        severity: "warn",
+        message:
+          `${module.relativePath} is a public facade but exposes ` +
+          `${module.localReexportCount} local re-export(s) and ` +
+          `${module.starExportCount} export-star declaration(s). Public facades should ` +
+          "name a small semantic contract: ports, factories, stable types, and registries.",
+      },
+    ];
+  });
+}
+
+function publicTestHelperLeakDiagnostics(
+  graph: ProjectArchitectureGraph,
+): readonly ArchitectureDiagnostic[] {
+  return graph.publicModules.flatMap((module) => {
+    const leakedEdges = module.localEdges.filter((edge) => {
+      const target = graph.modulesByFileName.get(edge.to);
+      return target ? edge.kind === "reexport" && target.isTestLike : false;
+    });
+    if (leakedEdges.length === 0) return [];
+
+    return [
+      {
+        ruleId: "no-public-test-helper-leak",
+        file: module.fileName,
+        severity: "warn",
+        message:
+          `${module.relativePath} is part of the public package API and exposes test-only ` +
+          "shape. Test helpers should live behind an explicitly allowed testing subpath.",
+      },
+    ];
+  });
+}
+
+function boundaryOwnedTypeDiagnostics(
+  graph: ProjectArchitectureGraph,
+  sourceFileByName: ReadonlyMap<string, ts.SourceFile>,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return graph.publicModules.flatMap((module) => {
+    const sourceFile = sourceFileByName.get(module.fileName);
+    if (!sourceFile) return [];
+
+    const importedTypes = externalImportedIdentifiers(sourceFile, options);
+    if (importedTypes.size === 0) {
+      return externalReexportBoundaryOwnedDiagnostics(sourceFile, module, options);
+    }
+
+    return [
+      ...externalReexportBoundaryOwnedDiagnostics(sourceFile, module, options),
+      ...exportedDeclarationTypeDiagnostics(sourceFile, module, importedTypes),
+    ];
+  });
+}
+
+function externalReexportBoundaryOwnedDiagnostics(
+  sourceFile: ts.SourceFile,
+  module: SourceModule,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return sourceFile.statements.flatMap((statement) => {
+    if (!ts.isExportDeclaration(statement)) return [];
+    if (!statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) return [];
+
+    const packageName = packageNameFromSpecifier(statement.moduleSpecifier.text);
+    if (packageName === null || packageAllowedInPublicTypes(packageName, options)) return [];
+
+    return [
+      {
+        ruleId: "require-boundary-owned-types",
+        file: sourceFile.fileName,
+        severity: "error",
+        message:
+          `${module.relativePath} re-exports "${packageName}" directly. Public boundaries ` +
+          "should expose package-owned names and wrap vendor or infrastructure types.",
+      },
+    ];
+  });
+}
+
+function exportedDeclarationTypeDiagnostics(
+  sourceFile: ts.SourceFile,
+  module: SourceModule,
+  importedTypes: ReadonlyMap<string, string>,
+): readonly ArchitectureDiagnostic[] {
+  return sourceFile.statements.flatMap((statement) => {
+    if (!hasExportModifier(statement)) return [];
+
+    const exportedName = exportedDeclarationName(statement);
+    if (!exportedName) return [];
+
+    const packages = importedPackagesReferencedByNode(statement, importedTypes);
+    return [...packages].map((packageName) => ({
+      ruleId: "require-boundary-owned-types",
+      file: sourceFile.fileName,
+      severity: "error",
+      message:
+        `${module.relativePath} export "${exportedName}" mentions "${packageName}" ` +
+        "directly. Define a boundary-owned type and translate at the adapter edge.",
+    }));
+  });
+}
+
+function externalImportedIdentifiers(
+  sourceFile: ts.SourceFile,
+  options: ResolvedArchitectureOptions,
+): ReadonlyMap<string, string> {
+  const identifiers = new Map<string, string>();
+  for (const statement of sourceFile.statements) {
+    addExternalImportedIdentifiers(identifiers, statement, options);
+  }
+  return identifiers;
+}
+
+function addExternalImportedIdentifiers(
+  identifiers: Map<string, string>,
+  statement: ts.Statement,
+  options: ResolvedArchitectureOptions,
+): void {
+  if (!ts.isImportDeclaration(statement)) return;
+  const packageName = externalPackageNameFromImport(statement, options);
+  if (packageName === null || !statement.importClause) return;
+  addImportClauseIdentifiers(identifiers, statement.importClause, packageName);
+}
+
+function externalPackageNameFromImport(
+  statement: ts.ImportDeclaration,
+  options: ResolvedArchitectureOptions,
+): string | null {
+  if (!ts.isStringLiteral(statement.moduleSpecifier)) return null;
+  const packageName = packageNameFromSpecifier(statement.moduleSpecifier.text);
+  if (packageName === null) return null;
+  return packageAllowedInPublicTypes(packageName, options) ? null : packageName;
+}
+
+function addImportClauseIdentifiers(
+  identifiers: Map<string, string>,
+  importClause: ts.ImportClause,
+  packageName: string,
+): void {
+  if (importClause.name) identifiers.set(importClause.name.text, packageName);
+  if (importClause.namedBindings) {
+    addNamedBindingIdentifiers(identifiers, importClause.namedBindings, packageName);
+  }
+}
+
+function addNamedBindingIdentifiers(
+  identifiers: Map<string, string>,
+  namedBindings: ts.NamedImportBindings,
+  packageName: string,
+): void {
+  if (ts.isNamespaceImport(namedBindings)) {
+    identifiers.set(namedBindings.name.text, packageName);
+    return;
+  }
+  for (const element of namedBindings.elements) {
+    identifiers.set(element.name.text, packageName);
+  }
+}
+
+function importedPackagesReferencedByNode(
+  node: ts.Node,
+  importedTypes: ReadonlyMap<string, string>,
+): ReadonlySet<string> {
+  const packages = new Set<string>();
+
+  const visit = (current: ts.Node): void => {
+    if (ts.isIdentifier(current)) {
+      const packageName = importedTypes.get(current.text);
+      if (packageName) packages.add(packageName);
+    }
+    ts.forEachChild(current, visit);
+  };
+
+  ts.forEachChild(node, visit);
+  return packages;
+}

--- a/lsp/architecture/analyzer/project/README.md
+++ b/lsp/architecture/analyzer/project/README.md
@@ -1,0 +1,15 @@
+# Architecture Project Model
+
+This folder owns the shared project model used by architecture diagnostics.
+
+- `api/` is the public implementation facade for architecture config,
+  diagnostics, cache, source files, package metadata, and source paths.
+- `source-model/` owns graph data structures and module classification.
+- `config.ts` and `config-schema.ts` parse and validate rule options.
+- `cache.ts` memoizes whole-project reports for the ESLint run.
+- `diagnostics/` owns diagnostic types and de-duplication.
+- `package-exports/`, `package-json.ts`, `source-files.ts`, and
+  `source-paths.ts` provide focused project facts.
+
+Diagnostics should depend on this model rather than re-reading files or
+re-deriving source classification locally.

--- a/lsp/architecture/analyzer/project/api/index.ts
+++ b/lsp/architecture/analyzer/project/api/index.ts
@@ -1,0 +1,37 @@
+/**
+ * @file Project-API barrel. Re-exports the architecture options
+ * schema, diagnostic types, project source-file collection, and rule
+ * helpers used by every architecture analysis pass.
+ */
+
+export {
+  ArchitectureOptionsError,
+  architectureOptionsJsonSchema,
+  resolveArchitectureOptions,
+  type ArchitectureOptionsInput,
+} from "../config.js";
+export { cachedProjectArchitecture, clearArchitectureCache } from "../cache/index.js";
+export {
+  SOURCE_EXTENSIONS,
+  candidateFileNames,
+  stripKnownExtension,
+} from "../source-paths.js";
+export {
+  createProgram,
+  findPackageReportFile,
+  projectSourceFiles,
+  publicApiSourceFiles,
+} from "../source-files.js";
+export { collectExportsValue, collectPackageExportEntries } from "../package-exports/index.js";
+export { emptyPackageJson, readPackageJson } from "../package-json.js";
+export { uniqueDiagnostics } from "../diagnostics/index.js";
+export type {
+  ArchitectureDiagnostic,
+  ArchitectureDiagnosticRuleId,
+  ArchitectureReport,
+  ArchitectureSeverity,
+  LayerDefinition,
+  PackageExportEntry,
+  PackageJson,
+  ResolvedArchitectureOptions,
+} from "../diagnostics/index.js";

--- a/lsp/architecture/analyzer/project/cache/cache.test.ts
+++ b/lsp/architecture/analyzer/project/cache/cache.test.ts
@@ -1,0 +1,272 @@
+import { expect, it } from "vitest";
+import * as h from "../../test-support/helper-fixtures.js";
+import type { ArchitectureDiagnostic } from "../../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+it("deduplicates diagnostics by rule, file, and message", () => {
+  const diagnostic: ArchitectureDiagnostic = {
+    ruleId: "no-inventory-barrel",
+    file: "/repo/src/index.ts",
+    severity: "warn",
+    message: "same",
+  };
+
+  expect(uniqueDiagnostics([diagnostic, diagnostic])).toEqual([diagnostic]);
+});
+
+it("Property: diagnostic dedupe key is rule plus file plus message", () => {
+  fc.assert(
+    fc.property(
+      fc.uniqueArray(segmentArb, { minLength: 1, maxLength: 6 }),
+      (messages) => {
+        const diagnostics: ArchitectureDiagnostic[] = messages.flatMap((message) => [
+          {
+            ruleId: "no-inventory-barrel",
+            file: "/repo/src/index.ts",
+            severity: "warn",
+            message,
+          },
+          {
+            ruleId: "no-inventory-barrel",
+            file: "/repo/src/index.ts",
+            severity: "error",
+            message,
+          },
+        ]);
+
+        expect(uniqueDiagnostics(diagnostics)).toHaveLength(messages.length);
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+it("normalizes options and clears the architecture cache without retaining stale reports", () => {
+  const root = path.resolve("/repo");
+  expect(resolveArchitectureOptions({ projectRoot: root, tsconfigPath: "tsconfig.eslint.json" }))
+    .toMatchObject({
+      projectRoot: root,
+      tsconfigPath: path.resolve(root, "tsconfig.eslint.json"),
+      minExportedSiblingModules: 4,
+      maxExportedSiblingRatio: 0.6,
+    });
+
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acg-architecture-cache-"));
+  try {
+    writeArchitectureCacheFixtureProject(projectRoot);
+    const options = resolveArchitectureOptions({
+      projectRoot,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+      // Disable TTL — this test asserts cache holds until clear() is
+      // called, independent of wall-clock. Under parallel test load
+      // the 5s default can expire mid-test.
+      cacheTtlMs: Infinity,
+    });
+    const staleReport = cachedProjectArchitecture(options);
+    expect(diagnosticsForRule(staleReport.diagnostics, "no-inventory-barrel")).toHaveLength(1);
+
+    fs.writeFileSync(path.join(projectRoot, "src", "index.ts"), "export const ok = true;\n");
+    expect(cachedProjectArchitecture(options)).toBe(staleReport);
+
+    clearArchitectureCache();
+    expect(
+      diagnosticsForRule(cachedProjectArchitecture(options).diagnostics, "no-inventory-barrel"),
+    ).toEqual([]);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+function writeArchitectureCacheFixtureProject(projectRoot: string): void {
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+    }),
+  );
+  fs.writeFileSync(path.join(projectRoot, "tsconfig.json"), architectureCacheTsconfig());
+  fs.mkdirSync(path.join(projectRoot, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "src", "index.ts"),
+    [
+      'export { M0 } from "./m0.js";',
+      'export { M1 } from "./m1.js";',
+      'export { M2 } from "./m2.js";',
+      'export { M3 } from "./m3.js";',
+    ].join("\n"),
+  );
+
+  for (let index = 0; index < 4; index += 1) {
+    fs.writeFileSync(
+      path.join(projectRoot, "src", `m${index}.ts`),
+      `export const M${index} = ${index};\n`,
+    );
+  }
+}
+
+function architectureCacheTsconfig(): string {
+  return JSON.stringify({
+    compilerOptions: {
+      target: "ES2022",
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      strict: true,
+      skipLibCheck: true,
+      declaration: true,
+      outDir: "./dist",
+      rootDir: "./src",
+    },
+    include: ["src/**/*"],
+  });
+}
+
+it("Property: schema rejects bare-string allowance entries on every reason-bearing option", () => {
+  const reasonBearingOptions = [
+    "publicTypePackages",
+    "infrastructureTypePackages",
+    "allowedPublicSubpaths",
+    "allowedTestPublicSubpaths",
+    "sharedFolderNames",
+  ] as const;
+  fc.assert(
+    fc.property(
+      fc.constantFrom(...reasonBearingOptions),
+      fc.array(fc.string({ minLength: 1, maxLength: 12 }), { minLength: 1, maxLength: 4 }),
+      (optionName, bareStrings) => {
+        expect(() =>
+          resolveArchitectureOptions({ [optionName]: bareStrings }),
+        ).toThrowError(new RegExp(optionName));
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: schema rejects allowance entries missing a reason on every reason-bearing option", () => {
+  const valueKey = {
+    publicTypePackages: "package",
+    infrastructureTypePackages: "package",
+    allowedPublicSubpaths: "subpath",
+    allowedTestPublicSubpaths: "subpath",
+    sharedFolderNames: "folder",
+  } as const;
+  fc.assert(
+    fc.property(
+      fc.constantFrom(...(Object.keys(valueKey) as Array<keyof typeof valueKey>)),
+      fc.string({ minLength: 1, maxLength: 12 }),
+      (optionName, value) => {
+        const entry = { [valueKey[optionName]]: value };
+        expect(() =>
+          resolveArchitectureOptions({ [optionName]: [entry] }),
+        ).toThrowError(/reason/i);
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: schema rejects packageRuntime values outside the allowed enum", () => {
+  fc.assert(
+    fc.property(
+      fc
+        .string({ minLength: 1, maxLength: 16 })
+        .filter((s) => !["browser", "node", "universal"].includes(s)),
+      (badRuntime) => {
+        expect(() =>
+          resolveArchitectureOptions({ packageRuntime: badRuntime }),
+        ).toThrowError(/packageRuntime/);
+      },
+    ),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: schema enforces ratio option bounds inclusively", () => {
+  const ratioOptions = [
+    "maxExportedSiblingRatio",
+    "maxFolderEdgeDensity",
+    "maxSharedKernelMedianOverlap",
+  ] as const;
+
+  fc.assert(
+    fc.property(
+      fc.constantFrom(...ratioOptions),
+      fc.oneof(
+        fc.double({ min: 0.000001, max: 100, noNaN: true }).map((n) => 1 + n),
+        fc.double({ min: 0.000001, max: 100, noNaN: true }).map((n) => -n),
+      ),
+      (optionName, invalidRatio) => {
+        expect(() =>
+          resolveArchitectureOptions({ [optionName]: invalidRatio }),
+        ).toThrowError(new RegExp(optionName));
+      },
+    ),
+    { numRuns: 40 },
+  );
+
+  expect(resolveArchitectureOptions({ maxExportedSiblingRatio: 0 }).maxExportedSiblingRatio)
+    .toBe(0);
+  expect(resolveArchitectureOptions({ maxFolderEdgeDensity: 1 }).maxFolderEdgeDensity)
+    .toBe(1);
+});
+
+it("defaults cacheTtlMs to 5000 and accepts Infinity for unlimited caching", () => {
+  expect(resolveArchitectureOptions({}).cacheTtlMs).toBe(5000);
+  expect(resolveArchitectureOptions({ cacheTtlMs: 0 }).cacheTtlMs).toBe(0);
+  expect(resolveArchitectureOptions({ cacheTtlMs: 60_000 }).cacheTtlMs).toBe(60_000);
+  expect(resolveArchitectureOptions({ cacheTtlMs: Infinity }).cacheTtlMs).toBe(Infinity);
+  expect(() => resolveArchitectureOptions({ cacheTtlMs: -1 })).toThrowError(
+    /cacheTtlMs/,
+  );
+});
+
+it("Property: schema rejects non-positive and non-integer count options", () => {
+  const positiveIntOptions = [
+    "minExportedSiblingModules",
+    "maxPublicExports",
+    "minPublicFacadeModules",
+    "minPackageMeshFolders",
+    "minExplicitApiConcreteFiles",
+    "minImplicitBoundaryIncomingFiles",
+    "minImplicitBoundaryOutgoingFiles",
+    "minImplicitBoundaryExports",
+    "minSharedKernelExports",
+    "minSharedKernelConsumers",
+  ] as const;
+  const nonNegativeIntOptions = [
+    "maxSubpathExports",
+    "maxWildcardExports",
+    "maxPublicReexports",
+    "maxFolderCycles",
+  ] as const;
+
+  fc.assert(
+    fc.property(fc.constantFrom(...positiveIntOptions), (optionName) => {
+      expect(() =>
+        resolveArchitectureOptions({ [optionName]: 0 }),
+      ).toThrowError(new RegExp(optionName));
+      expect(() =>
+        resolveArchitectureOptions({ [optionName]: 1.5 }),
+      ).toThrowError(new RegExp(optionName));
+    }),
+    { numRuns: 40 },
+  );
+
+  fc.assert(
+    fc.property(fc.constantFrom(...nonNegativeIntOptions), (optionName) => {
+      expect(() =>
+        resolveArchitectureOptions({ [optionName]: -1 }),
+      ).toThrowError(new RegExp(optionName));
+      expect(() =>
+        resolveArchitectureOptions({ [optionName]: 1.5 }),
+      ).toThrowError(new RegExp(optionName));
+    }),
+    { numRuns: 40 },
+  );
+});

--- a/lsp/architecture/analyzer/project/cache/dependency-watermark.ts
+++ b/lsp/architecture/analyzer/project/cache/dependency-watermark.ts
@@ -1,0 +1,81 @@
+/**
+ * @file Dependency watermark inputs for the architecture cache. Source
+ * files are watermarked in disk-cache.ts directly; this module covers
+ * the non-source inputs the analyzer reads (consumer's package.json,
+ * tsconfig content, and the analyzer's own version), so edits to any
+ * of them invalidate the persisted report.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { ResolvedArchitectureOptions } from "../diagnostics/index.js";
+
+const ANALYZER_VERSION_PSEUDO_PATH = "__analyzer_version__";
+const PACKAGE_JSON_PSEUDO_PATH_SUFFIX = "/__package_json__";
+const TSCONFIG_PSEUDO_PATH_SUFFIX = "/__tsconfig__";
+
+export interface DependencyWatermark {
+  readonly path: string;
+  readonly hash: string;
+}
+
+/**
+ * Watermark entries for analyzer inputs that aren't TypeScript source
+ * files. Edits to any of these change the report even when no `.ts`
+ * file changed, so they must participate in the cache watermark.
+ * @param options Resolved architecture options (used for projectRoot
+ * + tsconfig path).
+ * @param findTsconfig Optional override for tsconfig lookup; defaults
+ * to a tsconfig.json sibling of the project root.
+ * @returns Pseudo-watermark entries for package.json, tsconfig, and
+ * analyzer version.
+ */
+export function dependencyWatermarks(
+  options: ResolvedArchitectureOptions,
+  findTsconfig: (root: string) => string | undefined = (root) =>
+    path.join(root, "tsconfig.json"),
+): readonly DependencyWatermark[] {
+  const root = path.resolve(options.projectRoot);
+  const tsconfigPath = options.tsconfigPath ?? findTsconfig(root) ?? path.join(root, "tsconfig.json");
+  return [
+    { path: ANALYZER_VERSION_PSEUDO_PATH, hash: getAnalyzerVersion() },
+    {
+      path: `${root}${PACKAGE_JSON_PSEUDO_PATH_SUFFIX}`,
+      hash: hashFileOrAbsent(path.join(root, "package.json")),
+    },
+    {
+      path: `${root}${TSCONFIG_PSEUDO_PATH_SUFFIX}`,
+      hash: hashFileOrAbsent(tsconfigPath),
+    },
+  ];
+}
+
+function hashFileOrAbsent(filePath: string): string {
+  try {
+    const buf = fs.readFileSync(filePath);
+    return createHash("sha256").update(buf).digest("hex").slice(0, 32);
+  } catch (error) {
+    discardError(error);
+    return "absent";
+  }
+}
+
+let cachedAnalyzerVersion: string | null = null;
+function getAnalyzerVersion(): string {
+  if (cachedAnalyzerVersion !== null) return cachedAnalyzerVersion;
+  try {
+    const here = path.dirname(new URL(import.meta.url).pathname);
+    const pkgPath = path.resolve(here, "..", "..", "..", "..", "..", "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as { version?: string };
+    cachedAnalyzerVersion = pkg.version ?? "unknown";
+  } catch (error) {
+    discardError(error);
+    cachedAnalyzerVersion = "unknown";
+  }
+  return cachedAnalyzerVersion;
+}
+
+function discardError(_captured: unknown): null {
+  return null;
+}

--- a/lsp/architecture/analyzer/project/cache/disk-cache.ts
+++ b/lsp/architecture/analyzer/project/cache/disk-cache.ts
@@ -1,0 +1,201 @@
+/**
+ * @file Persistent on-disk cache for the architecture report. Loads
+ * the cached report when a content-hash watermark over project source
+ * files matches the previous run, so a fresh ESLint process can skip
+ * the full analyzer cold-build (~3 s on a 1500-file project).
+ *
+ * Cache location: `node_modules/.cache/agent-code-guard/report.json`
+ * under the project root. Auto-gitignored under `node_modules/` and
+ * auto-cleaned by package managers that prune the `.cache` directory.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import type {
+  ArchitectureDiagnostic,
+  ArchitectureReport,
+  ResolvedArchitectureOptions,
+} from "../diagnostics/index.js";
+import { dependencyWatermarks } from "./dependency-watermark.js";
+
+// v2 bumped 2026-05-12: watermark now includes package.json, tsconfig
+// content, and analyzer version so dependency / config edits invalidate.
+// v1 caches read as null on next call.
+const CACHE_VERSION = 2;
+const CACHE_DIR_SEGMENTS = ["node_modules", ".cache", "agent-code-guard"];
+const CACHE_FILE = "report.json";
+
+function discardCacheError(_captured: unknown): null {
+  // Disk cache is best-effort. A malformed file, permission error, or
+  // race against another lint must never block the linter; we fall back
+  // to a fresh analyzer build. The error is captured for future
+  // debugging via Node inspector if needed.
+  return null;
+}
+
+interface FileWatermark {
+  readonly path: string;
+  readonly hash: string;
+}
+
+interface PersistedReport {
+  readonly version: number;
+  readonly capturedAt: string;
+  readonly optionsHash: string;
+  readonly files: readonly FileWatermark[];
+  readonly diagnostics: readonly ArchitectureDiagnostic[];
+  readonly diagnosticsByFile: Record<string, readonly ArchitectureDiagnostic[]>;
+}
+
+function cacheFilePathFor(projectRoot: string): string {
+  return path.join(projectRoot, ...CACHE_DIR_SEGMENTS, CACHE_FILE);
+}
+
+/**
+ * Read and validate a persisted report. Returns `null` when the file
+ * is absent, malformed, or built against an older schema version.
+ * @param projectRoot Absolute project root.
+ * @returns The deserialized report and watermark, or `null`.
+ */
+export function readDiskCache(projectRoot: string): PersistedReport | null {
+  const filePath = cacheFilePathFor(projectRoot);
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as PersistedReport;
+    if (parsed.version !== CACHE_VERSION) return null;
+    return parsed;
+  } catch (error) {
+    return discardCacheError(error);
+  }
+}
+
+/**
+ * Persist a report along with its source-file watermark and the
+ * options hash it was built against.
+ * @param projectRoot Absolute project root.
+ * @param report The freshly built architecture report to persist.
+ * @param files Per-file watermark covering every project source file.
+ * @param optionsHash Stable hash of the resolved options that produced
+ * the report.
+ */
+export function writeDiskCache(
+  projectRoot: string,
+  report: ArchitectureReport,
+  files: readonly FileWatermark[],
+  optionsHash: string,
+): void {
+  const filePath = cacheFilePathFor(projectRoot);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  const diagnosticsByFile: Record<string, readonly ArchitectureDiagnostic[]> = {};
+  for (const [k, v] of report.diagnosticsByFile.entries()) diagnosticsByFile[k] = v;
+
+  const payload: PersistedReport = {
+    version: CACHE_VERSION,
+    capturedAt: new Date().toISOString(),
+    optionsHash,
+    files,
+    diagnostics: report.diagnostics,
+    diagnosticsByFile,
+  };
+  fs.writeFileSync(filePath, JSON.stringify(payload));
+}
+
+/**
+ * Rehydrate a persisted report into the in-memory shape (Map for the
+ * `diagnosticsByFile` field) the rest of the analyzer expects.
+ * @param persisted Loaded persisted-report payload.
+ * @returns The in-memory `ArchitectureReport` shape.
+ */
+export function hydrateReport(persisted: PersistedReport): ArchitectureReport {
+  const byFile = new Map<string, readonly ArchitectureDiagnostic[]>();
+  for (const [k, v] of Object.entries(persisted.diagnosticsByFile)) byFile.set(k, v);
+  return { diagnostics: persisted.diagnostics, diagnosticsByFile: byFile };
+}
+
+/**
+ * Compute a content-hash watermark over every source file the analyzer
+ * would see. Reads each file from disk and digests sha256-128; total
+ * cost is the I/O.
+ * @param options Resolved architecture options (used to locate the
+ * tsconfig that enumerates source files).
+ * @returns Per-file watermark sorted by path for stable comparison.
+ */
+export function computeFileWatermark(
+  options: ResolvedArchitectureOptions,
+): readonly FileWatermark[] {
+  const fileNames = enumerateProjectFiles(options);
+  const watermarks: FileWatermark[] = [];
+  for (const filePath of fileNames) {
+    try {
+      const buf = fs.readFileSync(filePath);
+      const hash = createHash("sha256").update(buf).digest("hex").slice(0, 32);
+      watermarks.push({ path: filePath, hash });
+    } catch (error) {
+      discardCacheError(error);
+      // File enumerated by tsconfig but unreadable now (race or stale
+      // tsconfig). Treat as cache-busting by inventing a unique hash.
+      watermarks.push({ path: filePath, hash: `missing-${Date.now()}` });
+    }
+  }
+  // Pseudo-watermarks for analyzer behavior inputs that aren't source
+  // files: edits to any of these change the report even when no .ts
+  // file changed, so the watermark must capture them.
+  const tsconfigFinder = (root: string): string | undefined =>
+    ts.findConfigFile(root, ts.sys.fileExists, "tsconfig.json") ?? undefined;
+  for (const extra of dependencyWatermarks(options, tsconfigFinder)) {
+    watermarks.push(extra);
+  }
+  watermarks.sort((left, right) => left.path.localeCompare(right.path));
+  return watermarks;
+}
+
+function enumerateProjectFiles(options: ResolvedArchitectureOptions): readonly string[] {
+  const configPath =
+    options.tsconfigPath ?? ts.findConfigFile(options.projectRoot, ts.sys.fileExists, "tsconfig.json");
+  if (!configPath) return [];
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(configPath),
+  );
+  if (parsed.errors.length > 0) return [];
+  const root = path.resolve(options.projectRoot);
+  return parsed.fileNames.filter((file) =>
+    path.resolve(file).startsWith(root + path.sep) &&
+    !file.includes(`${path.sep}node_modules${path.sep}`),
+  );
+}
+
+/**
+ * Stable hash of resolved options. Used to invalidate the disk cache
+ * when consumer config changes (different thresholds, different
+ * allowance lists) even though source files are unchanged.
+ * @param options Resolved architecture options.
+ * @returns Hex-truncated sha256 over the canonicalized options JSON.
+ */
+export function hashOptions(options: ResolvedArchitectureOptions): string {
+  return createHash("sha256").update(JSON.stringify(options)).digest("hex").slice(0, 32);
+}
+
+/**
+ * Compare two file watermarks for equality. Lengths must match and
+ * every (path, hash) tuple must align — the canonicalized sort order
+ * makes this O(n).
+ * @param before Watermark from a prior run.
+ * @param after Freshly computed watermark.
+ * @returns `true` iff every entry matches.
+ */
+export function watermarksMatch(
+  before: readonly FileWatermark[],
+  after: readonly FileWatermark[],
+): boolean {
+  if (before.length !== after.length) return false;
+  for (let i = 0; i < before.length; i++) {
+    if (before[i].path !== after[i].path || before[i].hash !== after[i].hash) return false;
+  }
+  return true;
+}

--- a/lsp/architecture/analyzer/project/cache/index.ts
+++ b/lsp/architecture/analyzer/project/cache/index.ts
@@ -1,0 +1,185 @@
+/**
+ * @file Architecture report cache. Layered: a per-workspace in-memory
+ * cache with the configurable `cacheTtlMs` TTL, backed by a persistent
+ * on-disk report under `node_modules/.cache/agent-code-guard/` that
+ * survives across linter processes.
+ *
+ * Workspace scoping: state is owned by a `WorkspaceCache` instance per
+ * `projectRoot`. The legacy `cachedProjectArchitecture` / `clearArchitectureCache`
+ * functions delegate to a process-level registry of those instances so
+ * ESLint plugin call sites keep working. Long-lived hosts (the LSP
+ * server) hold instances directly and call `clear()` on the relevant
+ * workspace only, so workspace A's edits do not blow workspace B's
+ * cache.
+ */
+
+import type ts from "typescript";
+import { analyzeResolvedArchitecture } from "../../index.js";
+import type { ArchitectureReport, ResolvedArchitectureOptions } from "../diagnostics/index.js";
+import { createProgram } from "../source-files.js";
+import {
+  computeFileWatermark,
+  hashOptions,
+  hydrateReport,
+  readDiskCache,
+  watermarksMatch,
+  writeDiskCache,
+} from "./disk-cache.js";
+
+interface CachedReport {
+  readonly report: ArchitectureReport;
+  readonly expiresAt: number;
+}
+
+/**
+ * Per-workspace cache for the architecture report. Owns its own
+ * in-memory map plus the option-key memoization. The disk-cache layer
+ * is shared across workspaces but partitioned on `projectRoot`, so two
+ * instances over different roots never collide on the same file.
+ */
+export class WorkspaceCache {
+  readonly #reportCache = new Map<string, CachedReport>();
+  readonly #keyCache = new WeakMap<ResolvedArchitectureOptions, string>();
+
+  /**
+   * Read or build the architecture report for this workspace. Hits the
+   * in-memory entry first, then the disk cache, then the analyzer. The
+   * disk-cache path is skipped when `programFingerprint` is supplied
+   * (long-lived hosts with in-memory `ts.Program` overlays), so unsaved
+   * LSP buffers never collide with the persisted disk report.
+   * @param options Resolved architecture options for this workspace.
+   * @param programProvider Lazy `ts.Program` source on cache miss.
+   * @param programFingerprint Stable identifier of the program supplied
+   * by `programProvider` (e.g., LSP `LanguageService` version). When
+   * omitted, the cache treats the program as the canonical disk-backed
+   * one.
+   * @returns The architecture report.
+   */
+  get(
+    options: ResolvedArchitectureOptions,
+    programProvider: () => ts.Program | null = () => createProgram(options),
+    programFingerprint?: string,
+  ): ArchitectureReport {
+    const optionsKey = this.#optionsKey(options);
+    const cacheKey =
+      programFingerprint === undefined ? optionsKey : `${optionsKey}|${programFingerprint}`;
+    const now = Date.now();
+    const cached = this.#reportCache.get(cacheKey);
+    if (cached !== undefined && cached.expiresAt > now) return cached.report;
+
+    const fromDisk =
+      programFingerprint === undefined ? this.#loadFromDiskCache(options) : null;
+    if (fromDisk !== null) {
+      this.#reportCache.set(cacheKey, {
+        report: fromDisk,
+        expiresAt: now + options.cacheTtlMs,
+      });
+      return fromDisk;
+    }
+
+    const report = analyzeResolvedArchitecture(options, programProvider);
+    this.#reportCache.set(cacheKey, { report, expiresAt: now + options.cacheTtlMs });
+    if (programFingerprint === undefined) this.#persistToDiskCache(options, report);
+    return report;
+  }
+
+  /**
+   * Drop every entry from this workspace's in-memory cache. Does not
+   * touch the on-disk report — that stays valid as long as its
+   * watermark matches.
+   */
+  clear(): void {
+    this.#reportCache.clear();
+  }
+
+  #optionsKey(options: ResolvedArchitectureOptions): string {
+    const cached = this.#keyCache.get(options);
+    if (cached !== undefined) return cached;
+    const key = JSON.stringify(options);
+    this.#keyCache.set(options, key);
+    return key;
+  }
+
+  #loadFromDiskCache(options: ResolvedArchitectureOptions): ArchitectureReport | null {
+    const persisted = readDiskCache(options.projectRoot);
+    if (persisted === null) return null;
+    if (persisted.optionsHash !== hashOptions(options)) return null;
+    const currentWatermark = computeFileWatermark(options);
+    if (!watermarksMatch(persisted.files, currentWatermark)) return null;
+    return hydrateReport(persisted);
+  }
+
+  #persistToDiskCache(options: ResolvedArchitectureOptions, report: ArchitectureReport): void {
+    try {
+      const files = computeFileWatermark(options);
+      writeDiskCache(options.projectRoot, report, files, hashOptions(options));
+    } catch (error) {
+      discardCacheWriteError(error);
+    }
+  }
+}
+
+function discardCacheWriteError(_captured: unknown): void {
+  // Best-effort: a write failure (read-only filesystem, missing
+  // node_modules) must not break the lint. The in-memory cache still
+  // covers the rest of this process.
+}
+
+const workspaceCaches = new Map<string, WorkspaceCache>();
+
+/**
+ * Get or create the cache instance for a given project root. Long-lived
+ * hosts (LSP server, etc.) call this to obtain a stable per-workspace
+ * cache they can `clear()` independently from other workspaces in the
+ * same process.
+ * @param projectRoot Absolute project root.
+ * @returns The cache instance for this workspace.
+ */
+export function getOrCreateWorkspaceCache(projectRoot: string): WorkspaceCache {
+  let cache = workspaceCaches.get(projectRoot);
+  if (cache === undefined) {
+    cache = new WorkspaceCache();
+    workspaceCaches.set(projectRoot, cache);
+  }
+  return cache;
+}
+
+/**
+ * Drop the in-memory cache for a specific workspace, leaving other
+ * workspaces' caches intact. Long-lived hosts call this on watcher
+ * events scoped to that workspace.
+ * @param projectRoot Absolute project root.
+ */
+export function clearWorkspaceCache(projectRoot: string): void {
+  workspaceCaches.get(projectRoot)?.clear();
+}
+
+/**
+ * Back-compat shim for the ESLint plugin call path: resolves the
+ * workspace cache for `options.projectRoot` and delegates. Existing
+ * callers keep the same signature; new code should prefer
+ * `getOrCreateWorkspaceCache(root).get(...)` so the workspace
+ * boundary is explicit.
+ * @param options Resolved architecture options (project root +
+ * thresholds + allowance lists).
+ * @param programProvider Lazy `ts.Program` provider used on cache
+ * miss.
+ * @returns The architecture report.
+ */
+export function cachedProjectArchitecture(
+  options: ResolvedArchitectureOptions,
+  programProvider: () => ts.Program | null = () => createProgram(options),
+): ArchitectureReport {
+  return getOrCreateWorkspaceCache(options.projectRoot).get(options, programProvider);
+}
+
+/**
+ * Drop every workspace's in-memory cache. Used by tests between
+ * fixtures and by hosts that want a hard reset; does not touch the
+ * on-disk cache. Long-lived hosts wanting to clear only one workspace
+ * should call `clearWorkspaceCache(projectRoot)` instead.
+ */
+export function clearArchitectureCache(): void {
+  for (const cache of workspaceCaches.values()) cache.clear();
+  workspaceCaches.clear();
+}

--- a/lsp/architecture/analyzer/project/cache/workspace-cache.test.ts
+++ b/lsp/architecture/analyzer/project/cache/workspace-cache.test.ts
@@ -1,0 +1,158 @@
+import { expect, it } from "vitest";
+import * as h from "../../test-support/helper-fixtures.js";
+
+const {
+  fs,
+  os,
+  path,
+  cachedProjectArchitecture,
+  clearArchitectureCache,
+  resolveArchitectureOptions,
+} = h;
+
+function writeFixtureProject(projectRoot: string): void {
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(projectRoot, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        skipLibCheck: true,
+        declaration: true,
+        outDir: "./dist",
+        rootDir: "./src",
+      },
+      include: ["src/**/*"],
+    }),
+  );
+  fs.mkdirSync(path.join(projectRoot, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "src", "index.ts"),
+    [
+      'export { M0 } from "./m0.js";',
+      'export { M1 } from "./m1.js";',
+      'export { M2 } from "./m2.js";',
+      'export { M3 } from "./m3.js";',
+    ].join("\n"),
+  );
+  for (let i = 0; i < 4; i += 1) {
+    fs.writeFileSync(
+      path.join(projectRoot, "src", `m${i}.ts`),
+      `export const M${i} = ${i};\n`,
+    );
+  }
+}
+
+it("WorkspaceCache: clearing one workspace leaves other workspaces intact", () => {
+  const rootA = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-wsA-"));
+  const rootB = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-wsB-"));
+  try {
+    writeFixtureProject(rootA);
+    writeFixtureProject(rootB);
+    const optionsA = resolveArchitectureOptions({
+      projectRoot: rootA,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const optionsB = resolveArchitectureOptions({
+      projectRoot: rootB,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+
+    const reportA = cachedProjectArchitecture(optionsA);
+    const reportB = cachedProjectArchitecture(optionsB);
+
+    h.clearWorkspaceCache(rootA);
+
+    expect(cachedProjectArchitecture(optionsB)).toBe(reportB);
+    expect(cachedProjectArchitecture(optionsA).diagnostics).toEqual(reportA.diagnostics);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(rootA, { recursive: true, force: true });
+    fs.rmSync(rootB, { recursive: true, force: true });
+  }
+});
+
+it("watermark: editing package.json invalidates the disk cache", () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-pkg-"));
+  try {
+    writeFixtureProject(projectRoot);
+    const options = resolveArchitectureOptions({
+      projectRoot,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const before = cachedProjectArchitecture(options);
+    expect(before.diagnostics.length).toBeGreaterThan(0);
+
+    clearArchitectureCache();
+    fs.writeFileSync(
+      path.join(projectRoot, "package.json"),
+      JSON.stringify({ name: "fixture", version: "2.0.0", type: "module", exports: {} }),
+    );
+    const after = cachedProjectArchitecture(options);
+    expect(after).not.toBe(before);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+it("watermark: editing tsconfig.json invalidates the disk cache", () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-tscfg-"));
+  try {
+    writeFixtureProject(projectRoot);
+    const options = resolveArchitectureOptions({
+      projectRoot,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const before = cachedProjectArchitecture(options);
+    expect(before.diagnostics.length).toBeGreaterThan(0);
+
+    clearArchitectureCache();
+    const tsconfig = JSON.parse(
+      fs.readFileSync(path.join(projectRoot, "tsconfig.json"), "utf8"),
+    ) as { compilerOptions: Record<string, unknown> };
+    tsconfig.compilerOptions.allowJs = true;
+    fs.writeFileSync(path.join(projectRoot, "tsconfig.json"), JSON.stringify(tsconfig));
+
+    const after = cachedProjectArchitecture(options);
+    expect(after).not.toBe(before);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+it("WorkspaceCache.get: programFingerprint keeps in-memory entries independent and skips disk persist", () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "acg-cache-fp-"));
+  try {
+    writeFixtureProject(projectRoot);
+    const options = resolveArchitectureOptions({
+      projectRoot,
+      minExportedSiblingModules: 1,
+      maxExportedSiblingRatio: 0,
+    });
+    const cache = h.getOrCreateWorkspaceCache(projectRoot);
+    const r1 = cache.get(options, undefined, "language-service-v1");
+    const r2 = cache.get(options, undefined, "language-service-v2");
+    expect(r1).not.toBe(r2);
+    expect(r1.diagnostics).toEqual(r2.diagnostics);
+  } finally {
+    clearArchitectureCache();
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+});

--- a/lsp/architecture/analyzer/project/config-schema.ts
+++ b/lsp/architecture/analyzer/project/config-schema.ts
@@ -1,0 +1,249 @@
+import { JSONSchema, Schema } from "effect";
+
+const NonEmptyString = Schema.String.pipe(Schema.minLength(1));
+
+// Allowance entries: every architectural exception MUST carry a written
+// reason. The act of writing the reason is the architectural decision —
+// the schema enforces it at validation time so reviewers see intent in
+// the config, not just a bare list.
+
+const PublicTypeAllowance = Schema.Struct({
+  package: NonEmptyString.annotations({
+    description: "External package whose types are intentionally part of this package's public contract.",
+  }),
+  reason: NonEmptyString.annotations({
+    description: "Why this package is part of the public contract. Goes into config review and CHANGELOG context.",
+  }),
+});
+type PublicTypeAllowance = typeof PublicTypeAllowance.Type;
+
+const InfrastructureAllowance = Schema.Struct({
+  package: NonEmptyString.annotations({
+    description: "Infrastructure package (database client, logger, transport, etc.) whose types should be flagged in public surfaces.",
+  }),
+  reason: NonEmptyString.annotations({
+    description: "Why this package is on the infrastructure list (not the public contract list).",
+  }),
+});
+type InfrastructureAllowance = typeof InfrastructureAllowance.Type;
+
+const SubpathAllowance = Schema.Struct({
+  subpath: NonEmptyString.annotations({
+    description: "package.json subpath that is intentionally part of the public contract (e.g., '.', './cli', './testing').",
+  }),
+  reason: NonEmptyString.annotations({
+    description: "Why this subpath is public. Documents intent for future maintainers.",
+  }),
+});
+type SubpathAllowance = typeof SubpathAllowance.Type;
+
+const SharedFolderAllowance = Schema.Struct({
+  folder: NonEmptyString.annotations({
+    description: "Folder name treated as a shared kernel; sibling/lower-level folders may import from it without crossing a boundary.",
+  }),
+  reason: NonEmptyString.annotations({
+    description: "Why this folder is a shared kernel rather than a domain.",
+  }),
+});
+type SharedFolderAllowance = typeof SharedFolderAllowance.Type;
+
+const FacadeFileAllowance = Schema.Struct({
+  file: NonEmptyString.annotations({
+    description: "Non-index facade file path relative to src (for example, 'rules/registry.ts'). index.ts files are already treated as facades.",
+  }),
+  reason: NonEmptyString.annotations({
+    description: "Why this non-index file is an intentional facade. Documents the boundary for reviewers.",
+  }),
+});
+type FacadeFileAllowance = typeof FacadeFileAllowance.Type;
+
+const PackageRuntime = Schema.Literal("browser", "node", "universal");
+type PackageRuntime = typeof PackageRuntime.Type;
+
+const Ratio = Schema.Number.pipe(Schema.between(0, 1));
+const NonNegativeInt = Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(0));
+const PositiveInt = Schema.Number.pipe(Schema.int(), Schema.greaterThanOrEqualTo(1));
+
+// Defaults — these populate when the option is omitted entirely. Note that
+// allowance arrays default to []; consumers MUST add explicit entries with
+// reasons. There is no default allowlist.
+// Strictness lists (forbiddenSubpathSegments, implementationPathSegments)
+// stay as bare strings because adding entries makes the rule STRICTER, not
+// more permissive. There is no architectural exception to acknowledge.
+
+const LayerDefinition = Schema.Struct({
+  name: NonEmptyString.annotations({
+    description: "Layer name (entrypoint, app, domain, adapters, shared, etc.).",
+  }),
+  folders: Schema.Array(NonEmptyString).annotations({
+    description: "Folder paths relative to the project root that belong to this layer. Longest-prefix match wins; ties resolve to the lower (earlier) layer index.",
+  }),
+  reason: NonEmptyString.annotations({
+    description: "Why these folders form a layer. Documents the architectural intent.",
+  }),
+});
+export type LayerDefinition = typeof LayerDefinition.Type;
+
+const FolderChildLimitOverride = Schema.Struct({
+  folder: NonEmptyString.annotations({
+    description: "Folder path relative to src, or '.' for the source root.",
+  }),
+  maxChildren: Schema.optional(PositiveInt).annotations({
+    description: "Maximum direct production/semantic children allowed for this folder.",
+  }),
+  maxChildrenIncludingTests: Schema.optional(PositiveInt).annotations({
+    description: "Maximum direct children allowed for this folder when test children are included.",
+  }),
+  maxUnpairedTestChildren: Schema.optional(NonNegativeInt).annotations({
+    description: "Maximum direct unpaired test children allowed for this folder.",
+  }),
+  reason: NonEmptyString.annotations({
+    description: "Why this folder has a different direct-child budget.",
+  }),
+});
+type FolderChildLimitOverride = typeof FolderChildLimitOverride.Type;
+
+const ArchitectureOptionsSchema = Schema.Struct({
+  projectRoot: Schema.optional(NonEmptyString),
+  tsconfigPath: Schema.optional(NonEmptyString),
+
+  // Inventory barrel thresholds.
+  minExportedSiblingModules: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 4 }),
+  ),
+  maxExportedSiblingRatio: Ratio.pipe(
+    Schema.optionalWith({ default: () => 0.6 }),
+  ),
+  countTypeOnlyExports: Schema.Boolean.pipe(
+    Schema.optionalWith({ default: () => true }),
+  ),
+
+  allowedPublicSubpaths: Schema.Array(SubpathAllowance).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<SubpathAllowance> => [] }),
+  ),
+  allowedTestPublicSubpaths: Schema.Array(SubpathAllowance).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<SubpathAllowance> => [] }),
+  ),
+
+  forbiddenSubpathSegments: Schema.Array(NonEmptyString).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<string> => [] }),
+  ),
+  implementationPathSegments: Schema.Array(NonEmptyString).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<string> => [] }),
+  ),
+
+  // Public surface caps.
+  maxSubpathExports: NonNegativeInt.pipe(
+    Schema.optionalWith({ default: () => 5 }),
+  ),
+  maxWildcardExports: NonNegativeInt.pipe(
+    Schema.optionalWith({ default: () => 0 }),
+  ),
+  maxPublicExports: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 20 }),
+  ),
+  maxPublicReexports: NonNegativeInt.pipe(
+    Schema.optionalWith({ default: () => 12 }),
+  ),
+  minPublicFacadeModules: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 6 }),
+  ),
+
+  // Folder graph thresholds.
+  minPackageMeshFolders: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 6 }),
+  ),
+  maxFolderEdgeDensity: Ratio.pipe(
+    Schema.optionalWith({ default: () => 0.35 }),
+  ),
+  maxFolderCycles: NonNegativeInt.pipe(
+    Schema.optionalWith({ default: () => 0 }),
+  ),
+  maxFolderChildren: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 10 }),
+  ),
+  maxFolderChildrenIncludingTests: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 20 }),
+  ),
+  maxUnpairedTestChildren: NonNegativeInt.pipe(
+    Schema.optionalWith({ default: () => 20 }),
+  ),
+  minFolderReadmeChildren: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 4 }),
+  ),
+  folderReadmeFileNames: Schema.Array(NonEmptyString).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<string> => ["README.md"] }),
+  ),
+  maxFolderImportDistance: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 4 }),
+  ),
+  folderChildCountOverrides: Schema.Array(FolderChildLimitOverride).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<FolderChildLimitOverride> => [] }),
+  ),
+
+  // Boundary-shape heuristics. These are sample-size guardrails; topology
+  // remains the primary signal.
+  minExplicitApiConcreteFiles: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 2 }),
+  ),
+  minImplicitBoundaryIncomingFiles: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 2 }),
+  ),
+  minImplicitBoundaryOutgoingFiles: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 2 }),
+  ),
+  minImplicitBoundaryExports: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 2 }),
+  ),
+  minSharedKernelExports: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 6 }),
+  ),
+  minSharedKernelConsumers: PositiveInt.pipe(
+    Schema.optionalWith({ default: () => 4 }),
+  ),
+  maxSharedKernelMedianOverlap: Ratio.pipe(
+    Schema.optionalWith({ default: () => 0.25 }),
+  ),
+
+  sharedFolderNames: Schema.Array(SharedFolderAllowance).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<SharedFolderAllowance> => [] }),
+  ),
+
+  facadeFiles: Schema.Array(FacadeFileAllowance).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<FacadeFileAllowance> => [] }),
+  ),
+
+  publicTypePackages: Schema.Array(PublicTypeAllowance).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<PublicTypeAllowance> => [] }),
+  ),
+
+  infrastructureTypePackages: Schema.Array(InfrastructureAllowance).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<InfrastructureAllowance> => [] }),
+  ),
+
+  layers: Schema.Array(LayerDefinition).pipe(
+    Schema.optionalWith({ default: (): ReadonlyArray<LayerDefinition> => [] }),
+  ),
+
+  packageRuntime: PackageRuntime.pipe(
+    Schema.optionalWith({ default: () => "universal" as const }),
+  ),
+
+  cacheTtlMs: Schema.Number.pipe(
+    Schema.greaterThanOrEqualTo(0),
+    Schema.optionalWith({ default: () => 5_000 }),
+  ),
+});
+
+// Encoded = what users write in eslint.config.js (allowance arrays optional, etc.).
+// Type    = what the analyzer reads (defaults filled in, all arrays present).
+export type ArchitectureOptionsInput = typeof ArchitectureOptionsSchema.Encoded;
+export type ArchitectureOptions = typeof ArchitectureOptionsSchema.Type;
+
+export function decodeArchitectureOptions(raw: unknown) {
+  return Schema.decodeUnknownEither(ArchitectureOptionsSchema)(raw);
+}
+
+export function architectureOptionsJsonSchema(): unknown {
+  return JSONSchema.make(ArchitectureOptionsSchema);
+}

--- a/lsp/architecture/analyzer/project/config.empty-defaults.test.ts
+++ b/lsp/architecture/analyzer/project/config.empty-defaults.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+const REASON_BEARING_OPTIONS = [
+  "publicTypePackages",
+  "infrastructureTypePackages",
+  "allowedPublicSubpaths",
+  "allowedTestPublicSubpaths",
+  "sharedFolderNames",
+] as const;
+const STRICTNESS_OPTIONS = ["forbiddenSubpathSegments", "implementationPathSegments"] as const;
+
+it("Property: every reason-bearing list option resolves to an empty array when omitted", () => {
+  fc.assert(
+    fc.property(fc.constantFrom(...REASON_BEARING_OPTIONS), (optionName) => {
+      const resolved = resolveArchitectureOptions({});
+      expect(resolved[optionName]).toEqual([]);
+    }),
+    { numRuns: 40 },
+  );
+});
+
+it("Property: every strictness list resolves to an empty array when omitted", () => {
+  fc.assert(
+    fc.property(fc.constantFrom(...STRICTNESS_OPTIONS), (optionName) => {
+      const resolved = resolveArchitectureOptions({});
+      expect(resolved[optionName]).toEqual([]);
+    }),
+    { numRuns: 20 },
+  );
+});
+
+it("Property: layers resolves to an empty array when omitted", () => {
+  fc.assert(
+    fc.property(fc.constant(undefined), () => {
+      const resolved = resolveArchitectureOptions({});
+      expect(resolved.layers).toEqual([]);
+    }),
+    { numRuns: 5 },
+  );
+});

--- a/lsp/architecture/analyzer/project/config.ts
+++ b/lsp/architecture/analyzer/project/config.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { Data, Either } from "effect";
+import { ArrayFormatter } from "effect/ParseResult";
+import {
+  decodeArchitectureOptions,
+  type ArchitectureOptions,
+} from "./config-schema.js";
+
+// Memoize the schema decode on the raw input reference. ESLint hands the
+// same rawOptions object to create() for every (rule × file) in a lint
+// pass; without this WeakMap, that's thousands of identical decode
+// invocations. We memoize the decoded shape (not the resolved shape) so
+// that callers passing a different projectRoot override still pay the
+// cheap path.resolve cost but skip the expensive decode.
+const decodedCache = new WeakMap<object, ArchitectureOptions>();
+
+export interface ArchitectureOptionsIssue {
+  readonly path: ReadonlyArray<PropertyKey>;
+  readonly message: string;
+}
+
+export class ArchitectureOptionsError extends Data.TaggedError("ArchitectureOptionsError")<{
+  readonly message: string;
+  readonly issues: ReadonlyArray<ArchitectureOptionsIssue>;
+}> {}
+
+// projectRoot is guaranteed absolute, tsconfigPath either resolved or null.
+export interface ResolvedArchitectureOptions
+  extends Omit<ArchitectureOptions, "projectRoot" | "tsconfigPath"> {
+  readonly projectRoot: string;
+  readonly tsconfigPath: string | null;
+}
+
+function decodeOrThrow(raw: unknown): ArchitectureOptions {
+  if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+    const cached = decodedCache.get(raw);
+    if (cached) return cached;
+  }
+
+  return Either.match(decodeArchitectureOptions(raw), {
+    onLeft: (parseError) => {
+      const issues: ArchitectureOptionsIssue[] = ArrayFormatter.formatErrorSync(parseError).map((issue) => ({
+        path: issue.path,
+        message: issue.message,
+      }));
+      const summary = issues
+        .map((issue) =>
+          issue.path.length > 0
+            ? `  • ${issue.path.join(".")}: ${issue.message}`
+            : `  • ${issue.message}`,
+        )
+        .join("\n");
+      throw new ArchitectureOptionsError({
+        message: `Invalid agent-code-guard architecture options:\n${summary}`,
+        issues,
+      });
+    },
+    onRight: (parsed) => {
+      if (typeof raw === "object" && raw !== null && !Array.isArray(raw)) {
+        decodedCache.set(raw, parsed);
+      }
+      return parsed;
+    },
+  });
+}
+
+export function resolveArchitectureOptions(
+  raw: unknown = {},
+  overrideProjectRoot?: string,
+): ResolvedArchitectureOptions {
+  const parsed = decodeOrThrow(raw);
+  const projectRoot = path.resolve(overrideProjectRoot ?? parsed.projectRoot ?? process.cwd());
+
+  return {
+    ...parsed,
+    projectRoot,
+    tsconfigPath: parsed.tsconfigPath
+      ? path.resolve(projectRoot, parsed.tsconfigPath)
+      : null,
+  };
+}
+
+export { architectureOptionsJsonSchema } from "./config-schema.js";
+export type { ArchitectureOptionsInput } from "./config-schema.js";

--- a/lsp/architecture/analyzer/project/diagnostics/index.ts
+++ b/lsp/architecture/analyzer/project/diagnostics/index.ts
@@ -1,0 +1,92 @@
+/**
+ * @file Architecture diagnostic core types. Defines the shared
+ * diagnostic, report, package-json, and package-export shapes that
+ * every analysis pass returns, plus the deduplication helper.
+ */
+
+import type { ArchitectureRuleId } from "../../rule-ids.js";
+
+/** Severity reported by an architecture diagnostic. */
+export type ArchitectureSeverity = "error" | "warn";
+
+export type {
+  LayerDefinition,
+  ArchitectureOptions,
+} from "../config-schema.js";
+
+export type { ArchitectureDiagnosticRuleId } from "../../rule-ids.js";
+export type { ResolvedArchitectureOptions } from "../config.js";
+
+/** A single architecture finding pointed at one file. */
+export interface ArchitectureDiagnostic {
+  /** Architecture rule id (matches the ESLint rule id). */
+  readonly ruleId: ArchitectureRuleId;
+  /** Absolute path of the file the finding is attached to. */
+  readonly file: string;
+  /** Severity reported on the finding. */
+  readonly severity: ArchitectureSeverity;
+  /** Human-readable message describing the finding. */
+  readonly message: string;
+}
+
+/** Result of a full architecture analysis run. */
+export interface ArchitectureReport {
+  /** Deduplicated diagnostics produced by every analysis pass. */
+  readonly diagnostics: readonly ArchitectureDiagnostic[];
+
+  /**
+   * Diagnostics grouped by absolute file path so the per-file ESLint
+   * rule listener can look up its findings in O(1) instead of scanning
+   * the whole array on every `(file × rule)` invocation. Files with no
+   * findings are absent from the map.
+   */
+  readonly diagnosticsByFile: ReadonlyMap<string, readonly ArchitectureDiagnostic[]>;
+}
+
+/** Parsed shape of the analyzer's view of `package.json`. */
+export interface PackageJson {
+  /** Package name from `package.json`. */
+  readonly name?: string;
+  /** Legacy `main` entry path. */
+  readonly main?: string;
+  /** Legacy `types` entry path. */
+  readonly types?: string;
+  /** Modern `exports` map (left as raw JSON for downstream walking). */
+  readonly exports?: unknown;
+  /** Runtime dependencies keyed by package name. */
+  readonly dependencies: ReadonlyMap<string, string>;
+  /** Dev-only dependencies keyed by package name. */
+  readonly devDependencies: ReadonlyMap<string, string>;
+  /** Peer dependencies keyed by package name. */
+  readonly peerDependencies: ReadonlyMap<string, string>;
+}
+
+/** One flat entry from a package's `exports` / `main` / `types` map. */
+export interface PackageExportEntry {
+  /** Public subpath under the package (e.g. `.`, `./foo`). */
+  readonly publicPath: string;
+  /** Target path the public subpath resolves to. */
+  readonly targetPath: string;
+}
+
+/**
+ * Drop duplicate diagnostics whose `(ruleId, file, message)` triple
+ * already appeared. Preserves first-seen order.
+ * @param diagnostics Diagnostics from one or more analysis passes.
+ * @returns Deduplicated diagnostics in original encounter order.
+ */
+export function uniqueDiagnostics(
+  diagnostics: readonly ArchitectureDiagnostic[],
+): readonly ArchitectureDiagnostic[] {
+  const seen = new Set<string>();
+  const unique: ArchitectureDiagnostic[] = [];
+
+  for (const diagnostic of diagnostics) {
+    const key = `${diagnostic.ruleId}\0${diagnostic.file}\0${diagnostic.message}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(diagnostic);
+  }
+
+  return unique;
+}

--- a/lsp/architecture/analyzer/project/index.ts
+++ b/lsp/architecture/analyzer/project/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @file Project barrel. Re-exports the source-model helpers, source
+ * paths, source files, and diagnostic / option types that downstream
+ * analysis passes consume.
+ */
+
+export {
+  explicitFacadeModule,
+  exportedDeclarationName,
+  generatedModule,
+  hasExportModifier,
+  isStarExportDeclaration,
+  isTestLikePath,
+  jaccardOverlap,
+  normalizePath,
+  resolveImplementationModule,
+  resolveProductionModule,
+  unionSets,
+  type ExportConsumer,
+  type ExternalModuleEdge,
+  type FolderEdge,
+  type LocalModuleEdge,
+  type ModuleEdgeKind,
+  type ProjectArchitectureGraph,
+  type SourceModule,
+} from "./source-model/index.js";

--- a/lsp/architecture/analyzer/project/package-exports/index.ts
+++ b/lsp/architecture/analyzer/project/package-exports/index.ts
@@ -1,0 +1,61 @@
+/**
+ * @file Package-exports flattening. Walks the `package.json` exports
+ * tree (subpath maps + conditional maps) into a flat list of
+ * public-path / target-path pairs the architecture rules consume.
+ */
+
+import type { PackageExportEntry, PackageJson } from "../diagnostics/index.js";
+import { isJsonObject } from "../package-json.js";
+
+/**
+ * Flatten a `package.json` into the list of public path / target path
+ * entries it exposes. Reads `exports` when present and falls back to
+ * `main` / `types` otherwise.
+ * @param packageJson Parsed `package.json` contents.
+ * @returns Public-path-to-target-path entries; empty when no exports
+ * are declared.
+ */
+export function collectPackageExportEntries(
+  packageJson: PackageJson,
+): readonly PackageExportEntry[] {
+  if (packageJson.exports !== undefined) {
+    return collectExportsValue(packageJson.exports, ".");
+  }
+
+  const entries: PackageExportEntry[] = [];
+  if (packageJson.main) entries.push({ publicPath: ".", targetPath: packageJson.main });
+  if (packageJson.types) entries.push({ publicPath: ".", targetPath: packageJson.types });
+  return entries;
+}
+
+/**
+ * Recursively walk a node-exports value (string, array, or conditional
+ * map) and emit one entry per target path. Subpath maps (`"./foo": ...`)
+ * descend into their values; condition maps (`"import": ...`,
+ * `"types": ...`) flatten through.
+ * @param value Raw value at this position in the exports tree.
+ * @param publicPath The public path key accumulated from parent
+ * subpath entries (root call typically passes `"."`).
+ * @returns Flattened public-path-to-target-path entries.
+ */
+export function collectExportsValue(
+  value: unknown,
+  publicPath: string,
+): readonly PackageExportEntry[] {
+  if (typeof value === "string") return [{ publicPath, targetPath: value }];
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectExportsValue(item, publicPath));
+  }
+  if (!isJsonObject(value)) return [];
+
+  const entries = Object.entries(value);
+  const hasSubpathKeys = entries.some(([key]) => key === "." || key.startsWith("./"));
+
+  if (hasSubpathKeys) {
+    return entries.flatMap(([key, nestedValue]) =>
+      key === "." || key.startsWith("./") ? collectExportsValue(nestedValue, key) : [],
+    );
+  }
+
+  return entries.flatMap(([, nestedValue]) => collectExportsValue(nestedValue, publicPath));
+}

--- a/lsp/architecture/analyzer/project/package-json.ts
+++ b/lsp/architecture/analyzer/project/package-json.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { PackageJson } from "./diagnostics/index.js";
+
+interface JsonObject {
+  readonly [key: string]: unknown;
+}
+
+export function readPackageJson(projectRoot: string): PackageJson | null {
+  const packageJsonPath = path.join(projectRoot, "package.json");
+  if (!fs.existsSync(packageJsonPath)) return null;
+
+  const parsed = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as unknown;
+  if (!isJsonObject(parsed)) return null;
+
+  return {
+    name: readString(parsed.name),
+    main: readString(parsed.main),
+    types: readString(parsed.types),
+    exports: parsed.exports,
+    dependencies: readStringMap(parsed.dependencies),
+    devDependencies: readStringMap(parsed.devDependencies),
+    peerDependencies: readStringMap(parsed.peerDependencies),
+  };
+}
+
+export function emptyPackageJson(): PackageJson {
+  return {
+    dependencies: new Map(),
+    devDependencies: new Map(),
+    peerDependencies: new Map(),
+  };
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readStringMap(value: unknown): ReadonlyMap<string, string> {
+  if (!isJsonObject(value)) return new Map();
+
+  const entries = Object.entries(value).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string",
+  );
+  return new Map(entries);
+}

--- a/lsp/architecture/analyzer/project/source-files.test.ts
+++ b/lsp/architecture/analyzer/project/source-files.test.ts
@@ -1,0 +1,285 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+it("maps package targets back to candidate source paths", () => {
+  const root = path.resolve("/repo");
+  expect(candidateSourcePaths("dist/index.js", root)).toEqual([
+    path.resolve(root, "dist/index.ts"),
+    path.resolve(root, "dist/index.tsx"),
+    path.resolve(root, "dist/index.mts"),
+    path.resolve(root, "dist/index.cts"),
+    path.resolve(root, "src/index.ts"),
+    path.resolve(root, "src/index.tsx"),
+    path.resolve(root, "src/index.mts"),
+    path.resolve(root, "src/index.cts"),
+  ]);
+
+  const sourceFile = ts.createSourceFile(
+    path.resolve(root, "src/index.ts"),
+    "export const ok = true;",
+    ts.ScriptTarget.Latest,
+  );
+  const sourceFiles = new Map([[path.resolve(root, "src/index.ts"), sourceFile]]);
+  expect(sourcePathForPackageTarget("./dist/index.js", root, sourceFiles)).toBe(
+    path.resolve(root, "src/index.ts"),
+  );
+  expect(sourcePathForPackageTarget("dist/index.js", root, sourceFiles)).toBe(
+    path.resolve(root, "src/index.ts"),
+  );
+  expect(sourcePathForPackageTarget(".\\dist\\index.js", root, sourceFiles)).toBe(
+    path.resolve(root, "src/index.ts"),
+  );
+  expect(sourcePathForPackageTarget("./dist/missing.js", root, sourceFiles)).toBeNull();
+});
+
+it("Property: package target candidates map dist outputs back to source roots", () => {
+  fc.assert(
+    fc.property(
+      fc.array(segmentArb, { minLength: 1, maxLength: 4 }),
+      fc.boolean(),
+      (segments, fromDist) => {
+        const root = path.resolve("/repo");
+        const target = `${fromDist ? "dist/" : ""}${segments.join("/")}.js`;
+        const expectedPrefixes = fromDist
+          ? [target, `src/${segments.join("/")}.js`]
+          : [target];
+
+        expect(candidateSourcePaths(target, root)).toEqual(
+          candidatePathsForPrefixes(root, expectedPrefixes),
+        );
+      },
+    ),
+    { numRuns: 80 },
+  );
+});
+
+function candidatePathsForPrefixes(root: string, prefixes: readonly string[]): readonly string[] {
+  return prefixes.flatMap((prefix) => candidatePathsForPrefix(root, prefix));
+}
+
+function candidatePathsForPrefix(root: string, prefix: string): readonly string[] {
+  return SOURCE_EXTENSIONS.map((extension) =>
+    path.resolve(root, replaceKnownExtension(prefix, extension)),
+  );
+}
+
+it("creates TypeScript programs only when configuration can be read and parsed", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-source-program-"));
+  try {
+    expect(createProgram(resolveArchitectureOptions({ projectRoot: root }))).toBeNull();
+    expect(
+      createProgram(
+        resolveArchitectureOptions({
+          projectRoot: root,
+          tsconfigPath: "missing-tsconfig.json",
+        }),
+      ),
+    ).toBeNull();
+
+    fs.writeFileSync(path.join(root, "tsconfig.json"), "{ invalid json");
+    expect(createProgram(resolveArchitectureOptions({ projectRoot: root }))).toBeNull();
+
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { module: "DefinitelyNotAModuleKind" } }),
+    );
+    expect(createProgram(resolveArchitectureOptions({ projectRoot: root }))).toBeNull();
+
+    fs.mkdirSync(path.join(root, "src"), { recursive: true });
+    fs.writeFileSync(path.join(root, "src", "index.ts"), "export const ok = true;\n");
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          strict: true,
+        },
+        include: ["src/**/*"],
+      }),
+    );
+
+    expect(createProgram(resolveArchitectureOptions({ projectRoot: root }))).not.toBeNull();
+    expect(
+      createProgram(
+        resolveArchitectureOptions({
+          projectRoot: path.dirname(root),
+          tsconfigPath: path.join(path.basename(root), "tsconfig.json"),
+        }),
+      ),
+    ).not.toBeNull();
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+it("filters project source files to sorted non-declaration files inside the package root", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-project-files-"));
+  try {
+    const fileNames = [
+      path.join(root, "src", "z.ts"),
+      path.join(root, "src", "a.ts"),
+      path.join(root, "src", "types.d.ts"),
+      path.join(root, "node_modules", "dep", "index.ts"),
+    ];
+    for (const fileName of fileNames) {
+      fs.mkdirSync(path.dirname(fileName), { recursive: true });
+      fs.writeFileSync(fileName, "export const value = true;\n");
+    }
+
+    const program = ts.createProgram(fileNames, {
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      target: ts.ScriptTarget.ES2022,
+    });
+
+    expect(projectSourceFiles(program, root).map((sourceFile) => sourceFile.fileName)).toEqual([
+      path.join(root, "src", "a.ts"),
+      path.join(root, "src", "z.ts"),
+    ]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+it("Property: package report file selection follows public entrypoint priority", () => {
+  const priority = ["src/index.ts", "src/index.tsx", "index.ts", "index.tsx"];
+
+  fc.assert(
+    fc.property(fc.subarray(["src/index.ts", "src/index.tsx", "index.ts", "index.tsx"]), (present) => {
+      const root = path.resolve("/repo");
+      const sourceFiles = [
+        ts.createSourceFile(
+          path.resolve(root, "src/not-public.ts"),
+          "export const internal = true;",
+          ts.ScriptTarget.Latest,
+        ),
+        ...[...present].reverse().map((relativePath) =>
+          ts.createSourceFile(
+            path.resolve(root, relativePath),
+            "export const ok = true;",
+            ts.ScriptTarget.Latest,
+          ),
+        ),
+      ];
+      const expectedRelativePath = priority.find((relativePath) =>
+        present.includes(relativePath),
+      );
+
+      expect(findPackageReportFile(sourceFiles, root)).toBe(
+        expectedRelativePath
+          ? path.resolve(root, expectedRelativePath)
+          : path.resolve(root, "src/not-public.ts"),
+      );
+    }),
+    { numRuns: 20 },
+  );
+
+  for (const relativePath of priority) {
+    const root = path.resolve("/repo");
+    const sourceFiles = [
+      ts.createSourceFile(
+        path.resolve(root, "src/not-public.ts"),
+        "export const internal = true;",
+        ts.ScriptTarget.Latest,
+      ),
+      ts.createSourceFile(
+        path.resolve(root, relativePath),
+        "export const ok = true;",
+        ts.ScriptTarget.Latest,
+      ),
+    ];
+    expect(findPackageReportFile(sourceFiles, root)).toBe(path.resolve(root, relativePath));
+  }
+
+  const fallback = ts.createSourceFile("/repo/src/other.ts", "export const ok = true;", ts.ScriptTarget.Latest);
+  expect(findPackageReportFile([fallback], "/repo")).toBe(fallback.fileName);
+  expect(findPackageReportFile([], "/repo")).toBe(path.join("/repo", "package.json"));
+});
+
+it("selects public API source files from package exports and falls back to conventional index files", () => {
+  const root = path.resolve("/repo");
+  const sourceFiles = ["src/index.ts", "src/cli.ts", "src/private.ts", "src/alt.tsx"].map(
+    (relativePath) =>
+      ts.createSourceFile(
+        path.join(root, relativePath),
+        "export const ok = true;\n",
+        ts.ScriptTarget.Latest,
+      ),
+  );
+  const program = programFromSourceFiles(sourceFiles);
+  const options = resolveArchitectureOptions({ projectRoot: root });
+  const packageJson = packageJsonForExports({
+    ".": "./dist/index.js",
+    "./cli": "./dist/cli.js",
+    "./missing": "./dist/missing.js",
+  });
+
+  expect(
+    publicApiSourceFiles(program, packageJson, options).map((sourceFile) =>
+      path.relative(root, sourceFile.fileName).replaceAll("\\", "/"),
+    ),
+  ).toEqual(["src/index.ts", "src/cli.ts"]);
+
+  expect(
+    publicApiSourceFiles(
+      program,
+      packageJsonForExports({ "./cli": "./dist/cli.js" }),
+      options,
+    ).map((sourceFile) =>
+      path.relative(root, sourceFile.fileName).replaceAll("\\", "/"),
+    ),
+  ).toEqual(["src/cli.ts"]);
+
+  expect(
+    publicApiSourceFiles(program, packageJsonForExports(undefined), options).map((sourceFile) =>
+      path.relative(root, sourceFile.fileName).replaceAll("\\", "/"),
+    ),
+  ).toEqual(["src/index.ts"]);
+
+  const fallbackProgram = programFromSourceFiles([
+    ts.createSourceFile(
+      path.join(root, "src", "alt.tsx"),
+      "export const ok = true;\n",
+      ts.ScriptTarget.Latest,
+    ),
+  ]);
+
+  expect(
+    publicApiSourceFiles(fallbackProgram, packageJsonForExports(undefined), options).map((sourceFile) =>
+      path.relative(root, sourceFile.fileName).replaceAll("\\", "/"),
+    ),
+  ).toEqual([]);
+});
+
+it("Property: conventional public API fallback follows every index candidate", () => {
+  fc.assert(
+    fc.property(
+      fc.constantFrom("src/index.ts", "src/index.tsx", "index.ts", "index.tsx"),
+      (relativePath) => {
+        const root = path.resolve("/repo");
+        const program = programFromSourceFiles([
+          ts.createSourceFile(
+            path.join(root, relativePath),
+            "export const ok = true;\n",
+            ts.ScriptTarget.Latest,
+          ),
+        ]);
+
+        expect(
+          publicApiSourceFiles(
+            program,
+            packageJsonForExports(undefined),
+            resolveArchitectureOptions({ projectRoot: root }),
+          ).map((sourceFile) =>
+            path.relative(root, sourceFile.fileName).replaceAll("\\", "/"),
+          ),
+        ).toEqual([relativePath]);
+      },
+    ),
+    { numRuns: 20 },
+  );
+});

--- a/lsp/architecture/analyzer/project/source-files.ts
+++ b/lsp/architecture/analyzer/project/source-files.ts
@@ -1,0 +1,131 @@
+import path from "node:path";
+import ts from "typescript";
+import { replaceKnownExtension, SOURCE_EXTENSIONS, withTrailingSeparator } from "./source-paths.js";
+import { collectPackageExportEntries } from "./package-exports/index.js";
+import type { PackageJson, ResolvedArchitectureOptions } from "./diagnostics/index.js";
+
+const PUBLIC_ENTRYPOINT_CANDIDATES = [
+  "src/index.ts",
+  "src/index.tsx",
+  "index.ts",
+  "index.tsx",
+] as const;
+
+export function createProgram(options: ResolvedArchitectureOptions): ts.Program | null {
+  const configPath =
+    options.tsconfigPath ??
+    ts.findConfigFile(options.projectRoot, ts.sys.fileExists, "tsconfig.json");
+  if (!configPath) return null;
+
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    path.dirname(configPath),
+  );
+  if (parsed.errors.length > 0) return null;
+
+  return ts.createProgram(parsed.fileNames, parsed.options);
+}
+
+export function projectSourceFiles(
+  program: ts.Program,
+  projectRoot: string,
+): readonly ts.SourceFile[] {
+  const root = withTrailingSeparator(path.resolve(projectRoot));
+  return program
+    .getSourceFiles()
+    .filter((sourceFile) => isProjectSourceFile(sourceFile, root))
+    .sort((left, right) => left.fileName.localeCompare(right.fileName));
+}
+
+export function findPackageReportFile(
+  sourceFiles: readonly ts.SourceFile[],
+  projectRoot: string,
+): string {
+  const sourceFileNames = new Set(
+    sourceFiles.map((sourceFile) => path.resolve(sourceFile.fileName)),
+  );
+  const candidates = PUBLIC_ENTRYPOINT_CANDIDATES.map(
+    (candidate) => path.resolve(projectRoot, candidate),
+  );
+
+  return (
+    candidates.find((candidate) => sourceFileNames.has(candidate)) ??
+    sourceFiles[0]?.fileName ??
+    path.join(projectRoot, "package.json")
+  );
+}
+
+export function publicApiSourceFiles(
+  program: ts.Program,
+  packageJson: PackageJson,
+  options: ResolvedArchitectureOptions,
+): readonly ts.SourceFile[] {
+  const projectFiles = projectSourceFiles(program, options.projectRoot);
+  const byPath = new Map(
+    projectFiles.map((sourceFile) => [path.resolve(sourceFile.fileName), sourceFile] as const),
+  );
+  const publicFiles = packageJsonPublicFiles(packageJson, options.projectRoot, byPath);
+  if (publicFiles.size === 0) addEntrypointPublicFiles(publicFiles, options.projectRoot, byPath);
+  return [...publicFiles];
+}
+
+function packageJsonPublicFiles(
+  packageJson: PackageJson,
+  projectRoot: string,
+  byPath: ReadonlyMap<string, ts.SourceFile>,
+): Set<ts.SourceFile> {
+  const publicFiles = new Set<ts.SourceFile>();
+  for (const entry of collectPackageExportEntries(packageJson)) {
+    const sourcePath = sourcePathForPackageTarget(entry.targetPath, projectRoot, byPath);
+    const sourceFile = sourcePath ? byPath.get(sourcePath) : undefined;
+    if (sourceFile) publicFiles.add(sourceFile);
+  }
+  return publicFiles;
+}
+
+function addEntrypointPublicFiles(
+  publicFiles: Set<ts.SourceFile>,
+  projectRoot: string,
+  byPath: ReadonlyMap<string, ts.SourceFile>,
+): void {
+  for (const candidate of PUBLIC_ENTRYPOINT_CANDIDATES) {
+    const sourceFile = byPath.get(path.resolve(projectRoot, candidate));
+    if (sourceFile) publicFiles.add(sourceFile);
+  }
+}
+
+export function sourcePathForPackageTarget(
+  targetPath: string,
+  projectRoot: string,
+  sourceFiles: ReadonlyMap<string, ts.SourceFile>,
+): string | null {
+  const normalizedTarget = targetPath.replaceAll("\\", "/");
+  const targetWithoutPrefix = normalizedTarget.startsWith("./")
+    ? normalizedTarget.slice(2)
+    : normalizedTarget;
+  const candidates = candidateSourcePaths(targetWithoutPrefix, projectRoot);
+  return candidates.find((candidate) => sourceFiles.has(candidate)) ?? null;
+}
+
+export function candidateSourcePaths(targetWithoutPrefix: string, projectRoot: string): string[] {
+  const relativePaths = targetWithoutPrefix.startsWith("dist/")
+    ? [targetWithoutPrefix, `src/${targetWithoutPrefix.slice("dist/".length)}`]
+    : [targetWithoutPrefix];
+
+  return relativePaths.flatMap((relativePath) =>
+    SOURCE_EXTENSIONS.map((extension) =>
+      path.resolve(projectRoot, replaceKnownExtension(relativePath, extension)),
+    ),
+  );
+}
+
+function isProjectSourceFile(sourceFile: ts.SourceFile, projectRootWithSlash: string): boolean {
+  const fileName = path.resolve(sourceFile.fileName);
+  return (
+    fileName.startsWith(projectRootWithSlash) &&
+    !sourceFile.isDeclarationFile &&
+    !fileName.includes(`${path.sep}node_modules${path.sep}`)
+  );
+}

--- a/lsp/architecture/analyzer/project/source-model/graph-model.ts
+++ b/lsp/architecture/analyzer/project/source-model/graph-model.ts
@@ -1,0 +1,64 @@
+export type ModuleEdgeKind = "import" | "reexport";
+
+export interface LocalModuleEdge {
+  readonly from: string;
+  readonly to: string;
+  readonly kind: ModuleEdgeKind;
+  readonly typeOnly: boolean;
+  readonly specifier: string;
+}
+
+export interface ExternalModuleEdge {
+  readonly from: string;
+  readonly packageName: string;
+  readonly kind: ModuleEdgeKind;
+  readonly typeOnly: boolean;
+  readonly specifier: string;
+}
+
+export interface SourceModule {
+  readonly fileName: string;
+  readonly relativePath: string;
+  readonly folder: string;
+  readonly topFolder: string;
+  readonly isIndex: boolean;
+  readonly isPublic: boolean;
+  readonly isTestLike: boolean;
+  readonly localEdges: readonly LocalModuleEdge[];
+  readonly externalEdges: readonly ExternalModuleEdge[];
+  readonly exportedSymbols: readonly string[];
+  readonly exportedSymbolCount: number;
+  readonly localReexportCount: number;
+  readonly starExportCount: number;
+  readonly topLevelStatementCount: number;
+}
+
+export interface ExportConsumer {
+  readonly targetFile: string;
+  readonly exportName: string;
+  readonly consumerFile: string;
+  readonly kind: ModuleEdgeKind;
+  readonly typeOnly: boolean;
+}
+
+export interface FolderEdge {
+  readonly from: string;
+  readonly to: string;
+  readonly kind: ModuleEdgeKind;
+  readonly files: readonly string[];
+}
+
+export interface ProjectArchitectureGraph {
+  readonly projectRoot: string;
+  readonly reportFile: string;
+  readonly modules: readonly SourceModule[];
+  readonly modulesByFileName: ReadonlyMap<string, SourceModule>;
+  readonly publicModules: readonly SourceModule[];
+  readonly localEdges: readonly LocalModuleEdge[];
+  readonly externalEdges: readonly ExternalModuleEdge[];
+  readonly exportConsumers: readonly ExportConsumer[];
+  readonly exportConsumersByFileName: ReadonlyMap<string, readonly ExportConsumer[]>;
+  readonly folderEdges: readonly FolderEdge[];
+  readonly folders: readonly string[];
+  readonly folderLayerIndex: ReadonlyMap<string, number | null>;
+}

--- a/lsp/architecture/analyzer/project/source-model/index.ts
+++ b/lsp/architecture/analyzer/project/source-model/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @file Source-model barrel. Re-exports the source-fact predicates,
+ * module classification helpers, and graph-model types used by the
+ * import-graph construction and downstream analysis passes.
+ */
+
+export {
+  exportedDeclarationName,
+  hasExportModifier,
+  isStarExportDeclaration,
+  isTestLikePath,
+  normalizePath,
+} from "./source-facts.js";
+export {
+  explicitFacadeModule,
+  generatedModule,
+  jaccardOverlap,
+  resolveImplementationModule,
+  resolveProductionModule,
+  unionSets,
+} from "./module-classification.js";
+export type {
+  ExportConsumer,
+  ExternalModuleEdge,
+  FolderEdge,
+  LocalModuleEdge,
+  ModuleEdgeKind,
+  ProjectArchitectureGraph,
+  SourceModule,
+} from "./graph-model.js";

--- a/lsp/architecture/analyzer/project/source-model/module-classification.ts
+++ b/lsp/architecture/analyzer/project/source-model/module-classification.ts
@@ -1,0 +1,55 @@
+import { normalizePath } from "./source-facts.js";
+import type { ResolvedArchitectureOptions } from "../api/index.js";
+import type { SourceModule } from "./graph-model.js";
+
+export function explicitFacadeModule(
+  module: SourceModule,
+  options: ResolvedArchitectureOptions,
+): boolean {
+  return module.isIndex || options.facadeFiles.some((entry) =>
+    normalizedFacadeFile(entry.file) === module.relativePath
+  );
+}
+
+export function generatedModule(module: SourceModule): boolean {
+  return /(^|\/)(__generated__|generated)(\/|$)/.test(module.relativePath) ||
+    /\.(generated|gen)\.[cm]?[tj]sx?$/.test(module.relativePath);
+}
+
+export function resolveProductionModule(module: SourceModule | undefined): module is SourceModule {
+  return module !== undefined && !module.isTestLike && !generatedModule(module);
+}
+
+export function resolveImplementationModule(module: SourceModule | undefined): module is SourceModule {
+  return resolveProductionModule(module) && !module.isPublic;
+}
+
+export function unionSets<T>(sets: readonly ReadonlySet<T>[]): ReadonlySet<T> {
+  const union = new Set<T>();
+  for (const set of sets) {
+    for (const value of set) union.add(value);
+  }
+  return union;
+}
+
+export function jaccardOverlap<T>(left: ReadonlySet<T>, right: ReadonlySet<T>): number {
+  const union = unionSets([left, right]);
+  if (union.size === 0) return 0;
+  return setIntersectionSize(left, right) / union.size;
+}
+
+function normalizedFacadeFile(file: string): string {
+  const withoutDot = normalizePath(file).replace(/^\.\//, "");
+  return withoutDot.startsWith("src/") ? withoutDot : `src/${withoutDot}`;
+}
+
+function setIntersectionSize<T>(
+  left: ReadonlySet<T>,
+  right: ReadonlySet<T>,
+): number {
+  let count = 0;
+  for (const value of left) {
+    if (right.has(value)) count += 1;
+  }
+  return count;
+}

--- a/lsp/architecture/analyzer/project/source-model/source-facts.ts
+++ b/lsp/architecture/analyzer/project/source-model/source-facts.ts
@@ -1,0 +1,60 @@
+import ts from "typescript";
+
+export function isTestLikePath(fileName: string): boolean {
+  const normalized = normalizePath(fileName);
+  return (
+    /\.(test|spec)\.[cm]?[tj]sx?$/.test(normalized) ||
+    /(^|\/)(__tests__|tests?|testing|test-utils|test-support|fixtures?|__fixtures__)(\/|$)/.test(
+      normalized,
+    )
+  );
+}
+
+export function isStarExportDeclaration(statement: ts.Statement): boolean {
+  return (
+    ts.isExportDeclaration(statement) &&
+    statement.exportClause === undefined
+  );
+}
+
+export function hasExportModifier(statement: ts.Statement): boolean {
+  return Boolean(
+    ts.canHaveModifiers(statement) &&
+      ts.getModifiers(statement)?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword),
+  );
+}
+
+export function exportedDeclarationName(statement: ts.Statement): string | null {
+  if (ts.isVariableStatement(statement)) return variableStatementName(statement);
+  return nonVariableDeclarationName(statement);
+}
+
+export function normalizePath(pathLike: string): string {
+  return pathLike.replaceAll("\\", "/");
+}
+
+function variableStatementName(statement: ts.VariableStatement): string | null {
+  for (const declaration of statement.declarationList.declarations) {
+    const name = declaration.name;
+    return ts.isIdentifier(name) ? name.text : null;
+  }
+  return null;
+}
+
+function nonVariableDeclarationName(statement: ts.Statement): string | null {
+  for (const reader of NON_VARIABLE_DECLARATION_NAME_READERS) {
+    const name = reader(statement);
+    if (name !== undefined) return name;
+  }
+  return null;
+}
+
+type DeclarationNameReader = (statement: ts.Statement) => string | null | undefined;
+
+const NON_VARIABLE_DECLARATION_NAME_READERS: readonly DeclarationNameReader[] = [
+  (statement) => ts.isFunctionDeclaration(statement) ? statement.name?.text ?? null : undefined,
+  (statement) => ts.isClassDeclaration(statement) ? statement.name?.text ?? null : undefined,
+  (statement) => ts.isInterfaceDeclaration(statement) ? statement.name.text : undefined,
+  (statement) => ts.isTypeAliasDeclaration(statement) ? statement.name.text : undefined,
+  (statement) => ts.isEnumDeclaration(statement) ? statement.name.text : undefined,
+];

--- a/lsp/architecture/analyzer/project/source-paths.ts
+++ b/lsp/architecture/analyzer/project/source-paths.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+
+export const SOURCE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts"] as const;
+export const OUTPUT_EXTENSIONS = [".js", ".jsx", ".mjs", ".cjs"] as const;
+
+export function hasSourceExtension(fileName: string): boolean {
+  return SOURCE_EXTENSIONS.some((extension) => fileName.endsWith(extension));
+}
+
+export function stripKnownExtension(fileName: string): string {
+  const extension = [".d.ts", ...SOURCE_EXTENSIONS, ...OUTPUT_EXTENSIONS].find((candidate) =>
+    fileName.endsWith(candidate),
+  );
+  return extension ? fileName.slice(0, -extension.length) : fileName;
+}
+
+export function replaceKnownExtension(fileName: string, nextExtension: string): string {
+  const extension = [".d.ts", ...SOURCE_EXTENSIONS, ...OUTPUT_EXTENSIONS].find((candidate) =>
+    fileName.endsWith(candidate),
+  );
+  return extension
+    ? `${fileName.slice(0, -extension.length)}${nextExtension}`
+    : `${fileName}${nextExtension}`;
+}
+
+export function candidateFileNames(absolutePath: string): readonly string[] {
+  const extensionCandidates = SOURCE_EXTENSIONS.map((extension) =>
+    path.resolve(replaceKnownExtension(absolutePath, extension)),
+  );
+  const stripped = stripKnownExtension(absolutePath);
+  const strippedCandidates = SOURCE_EXTENSIONS.map((extension) =>
+    path.resolve(`${stripped}${extension}`),
+  );
+
+  return [...new Set([...extensionCandidates, ...strippedCandidates])];
+}
+
+export function withTrailingSeparator(directory: string): string {
+  return directory.endsWith(path.sep) ? directory : `${directory}${path.sep}`;
+}

--- a/lsp/architecture/analyzer/rule-ids.ts
+++ b/lsp/architecture/analyzer/rule-ids.ts
@@ -1,0 +1,43 @@
+// Single source of truth for architecture rule identifiers. Imported by the
+// rule registry, the diagnostic-emission cache, and the directive parser so
+// the list cannot drift between them.
+
+export const ARCHITECTURE_DIAGNOSTIC_RULE_IDS = [
+  "no-inventory-barrel",
+  "no-internal-subpath-export",
+  "no-public-vendor-type-leak",
+  "no-export-star-boundary",
+  "no-folder-cycle",
+  "no-root-internal-cycle",
+  "no-large-public-surface",
+  "no-cross-domain-sibling-import",
+  "no-upward-layer-import",
+  "no-public-test-helper-leak",
+  "no-implementation-file-public-entry",
+  "no-public-infra-type-leak",
+  "no-package-mesh",
+  "no-large-folder",
+  "folder-readme-required",
+  "no-distant-folder-import",
+  "require-curated-public-facade",
+  "require-boundary-owned-types",
+  "folder-explicit-api-required",
+  "file-implicit-boundary-module",
+  "shared-kernel-cohesion",
+  "no-trivial-sink-file",
+  "no-fat-orchestrator",
+] as const;
+
+export type ArchitectureDiagnosticRuleId =
+  (typeof ARCHITECTURE_DIAGNOSTIC_RULE_IDS)[number];
+
+// A pseudo-rule used only to surface malformed `@agent-code-guard/architecture-exception:`
+// directive comments. It is reported alongside any architecture rule that
+// could legitimately fire, so users always see the parse error regardless of
+// which rules they have enabled.
+export const ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID =
+  "architecture-directive-parse-error" as const;
+
+export type ArchitectureRuleId =
+  | ArchitectureDiagnosticRuleId
+  | typeof ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID;

--- a/lsp/architecture/analyzer/test-support/analyzer-fixtures.ts
+++ b/lsp/architecture/analyzer/test-support/analyzer-fixtures.ts
@@ -1,0 +1,295 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fc from "fast-check";
+import { analyzeWorkspace } from "../index.js";
+import { clearArchitectureCache } from "../project/api/index.js";
+import type {
+  ArchitectureDiagnostic,
+  ArchitectureOptions,
+} from "../project/diagnostics/index.js";
+
+const tempRoots: string[] = [];
+
+export const segmentArb = fc.stringMatching(/^[a-z][a-z0-9]{0,7}$/);
+export const ratioArb = fc.constantFrom(0, 0.25, 0.5, 0.6, 0.75, 1);
+
+export function cleanupArchitectureFixtures(): void {
+  clearArchitectureCache();
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+export function makeProject(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-architecture-"));
+  tempRoots.push(root);
+  for (const [relativePath, contents] of Object.entries(projectFiles(files))) {
+    const absolutePath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, contents);
+  }
+  return root;
+}
+
+function projectFiles(files: Record<string, string>): Record<string, string> {
+  return {
+    "package.json": JSON.stringify(defaultPackageJson(), null, 2),
+    "tsconfig.json": JSON.stringify(defaultTsconfig(), null, 2),
+    "src/index.ts": "export interface PublicApi { readonly id: string; }\n",
+    ...files,
+  };
+}
+
+function defaultPackageJson(): Record<string, unknown> {
+  return {
+    name: "fixture",
+    version: "1.0.0",
+    type: "module",
+    exports: {
+      ".": {
+        import: "./dist/index.js",
+        types: "./dist/index.d.ts",
+      },
+    },
+  };
+}
+
+function defaultTsconfig(): Record<string, unknown> {
+  return {
+    compilerOptions: {
+      target: "ES2022",
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      strict: true,
+      skipLibCheck: true,
+      declaration: true,
+      outDir: "./dist",
+      rootDir: "./src",
+    },
+    include: ["src/**/*"],
+  };
+}
+
+export function diagnosticsFor(
+  root: string,
+  options: Omit<ArchitectureOptions, "projectRoot"> = {},
+): readonly ArchitectureDiagnostic[] {
+  return analyzeWorkspace({ projectRoot: root, ...options }).diagnostics;
+}
+
+export function diagnosticsByRule(
+  root: string,
+  ruleId: ArchitectureDiagnostic["ruleId"],
+  options: Omit<ArchitectureOptions, "projectRoot"> = {},
+): readonly ArchitectureDiagnostic[] {
+  return diagnosticsFor(root, options).filter((diagnostic) => diagnostic.ruleId === ruleId);
+}
+
+export function diagnosticMessages(
+  root: string,
+  options: Omit<ArchitectureOptions, "projectRoot"> = {},
+): readonly string[] {
+  return diagnosticsFor(root, options).map((diagnostic) => diagnostic.message);
+}
+
+export function sourceModuleFiles(
+  directory: string,
+  moduleCount: number,
+): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: moduleCount }, (_, index) => [
+      `${directory}/m${index}.ts`,
+      `export const M${index} = ${index};\n`,
+    ]),
+  );
+}
+
+export function barrelExports(directory: string, exportCount: number): string {
+  return Array.from(
+    { length: exportCount },
+    (_, index) => `export { M${index} } from "./m${index}";`,
+  ).join("\n");
+}
+
+interface FolderApiFixtureInput {
+  readonly apiFolder: string;
+  readonly consumerFolder: string;
+  readonly concreteCount: number;
+  readonly consumerCount: number;
+  readonly hasFacade: boolean;
+}
+
+export function folderApiFixture(input: FolderApiFixtureInput): Record<string, string> {
+  return {
+    ...folderApiConcreteFiles(input.apiFolder, input.concreteCount),
+    ...folderApiConsumerFiles(input),
+    ...(input.hasFacade ? { [`src/${input.apiFolder}/index.ts`]: "export const facade = 1;\n" } : {}),
+  };
+}
+
+function folderApiConcreteFiles(
+  apiFolder: string,
+  concreteCount: number,
+): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: concreteCount }, (_, index) => [
+      `src/${apiFolder}/m${index}.ts`,
+      `export const M${index} = ${index};\n`,
+    ]),
+  );
+}
+
+function folderApiConsumerFiles(input: FolderApiFixtureInput): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: input.consumerCount }, (_, consumerIndex) => [
+      `src/${input.consumerFolder}/use${consumerIndex}.ts`,
+      folderApiConsumerSource(input.apiFolder, input.concreteCount, input.hasFacade),
+    ]),
+  );
+}
+
+function folderApiConsumerSource(
+  apiFolder: string,
+  concreteCount: number,
+  hasFacade: boolean,
+): string {
+  const names = Array.from({ length: concreteCount }, (_, index) => `M${index}`);
+  const imports = names.map((name, index) =>
+    `import { ${name} } from "../${apiFolder}/m${index}";`
+  );
+  const facadeImport = hasFacade ? [`import { facade } from "../${apiFolder}";`] : [];
+  const terms = [...names, ...(hasFacade ? ["facade"] : [])].join(" + ");
+  return [...imports, ...facadeImport, `export const used = ${terms};`].join("\n");
+}
+
+export function implicitBoundaryFixture(
+  boundaryName: string,
+  callerCount: number,
+  helperCount: number,
+): Record<string, string> {
+  return {
+    ...implicitBoundaryHelperFiles(helperCount),
+    ...implicitBoundaryCallerFiles(boundaryName, callerCount),
+    [`src/${boundaryName}.ts`]: implicitBoundarySource(callerCount, helperCount),
+  };
+}
+
+function implicitBoundaryHelperFiles(helperCount: number): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: helperCount }, (_, index) => [
+      `src/impl/h${index}.ts`,
+      `export const h${index} = () => ${index};\n`,
+    ]),
+  );
+}
+
+function implicitBoundaryCallerFiles(
+  boundaryName: string,
+  callerCount: number,
+): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: callerCount }, (_, index) => [
+      `src/app/caller${index}.ts`,
+      `import { run${index} } from "../${boundaryName}";\nexport const caller${index} = run${index}();\n`,
+    ]),
+  );
+}
+
+function implicitBoundarySource(callerCount: number, helperCount: number): string {
+  const imports = Array.from(
+    { length: helperCount },
+    (_, index) => `import { h${index} } from "./impl/h${index}";`,
+  );
+  const exports = Array.from(
+    { length: callerCount },
+    (_, index) => `export const run${index} = () => h${index % helperCount}();`,
+  );
+  return [...imports, ...exports].join("\n");
+}
+
+export function sharedKernelCohesionFixture(
+  exportCount: number,
+  consumerCount: number,
+  cohesive: boolean,
+): Record<string, string> {
+  const names = Array.from({ length: exportCount }, (_, index) => `s${index}`);
+  return {
+    "src/utils/kernel.ts": names
+      .map((name, index) => `export const ${name} = ${index};`)
+      .join("\n"),
+    ...sharedKernelConsumerFiles(names, consumerCount, cohesive),
+  };
+}
+
+function sharedKernelConsumerFiles(
+  names: readonly string[],
+  consumerCount: number,
+  cohesive: boolean,
+): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: consumerCount }, (_, consumerIndex) => [
+      `src/consumers/c${consumerIndex}.ts`,
+      sharedKernelConsumerSource(
+        consumerIndex,
+        cohesive ? names : names.filter((_, index) => index % consumerCount === consumerIndex),
+      ),
+    ]),
+  );
+}
+
+function sharedKernelConsumerSource(
+  consumerIndex: number,
+  names: readonly string[],
+): string {
+  return [
+    `import { ${names.join(", ")} } from "../utils/kernel";`,
+    `export const consumer${consumerIndex} = ${names.join(" + ")};`,
+  ].join("\n");
+}
+
+export function packageJsonWithExports(exportsValue: unknown): string {
+  return JSON.stringify(
+    {
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: exportsValue,
+    },
+    null,
+    2,
+  );
+}
+
+export function packageJsonWithDependency(packageName: string): string {
+  return JSON.stringify(
+    {
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      dependencies: { [packageName]: "1.0.0" },
+      exports: defaultPackageJson().exports,
+    },
+    null,
+    2,
+  );
+}
+
+export function nodeModuleTypePackage(packageName: string, typeName: string): Record<string, string> {
+  return {
+    [`node_modules/${packageName}/package.json`]: JSON.stringify({
+      name: packageName,
+      version: "1.0.0",
+      types: "index.d.ts",
+    }),
+    [`node_modules/${packageName}/index.d.ts`]:
+      `export interface ${typeName}<T = unknown> { readonly id: string; readonly value?: T; }\n`,
+  };
+}
+
+export function hasRule(
+  diagnostics: readonly ArchitectureDiagnostic[],
+  ruleId: ArchitectureDiagnostic["ruleId"],
+): boolean {
+  return diagnostics.some((diagnostic) => diagnostic.ruleId === ruleId);
+}

--- a/lsp/architecture/analyzer/test-support/helper-fixtures.ts
+++ b/lsp/architecture/analyzer/test-support/helper-fixtures.ts
@@ -1,0 +1,294 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import * as fc from "fast-check";
+import ts from "typescript";
+import { checkPackageExports } from "../package-api/index.js";
+import { checkPublicVendorTypeLeaks } from "../type-surface/index.js";
+import { resolveArchitectureOptions } from "../project/config.js";
+import { createProgram } from "../project/source-files.js";
+import { readPackageJson } from "../package-api/index.js";
+import {
+  SOURCE_EXTENSIONS,
+} from "../project/source-paths.js";
+import type {
+  ArchitectureDiagnostic,
+  PackageJson,
+} from "../project/diagnostics/index.js";
+
+export { fs, os, path, fc, ts };
+export {
+  exportDeclarationIsTypeOnly,
+  exportedSiblingModuleKeys,
+  eligibleSiblingModuleKeys,
+  inventoryBarrelDiagnostic,
+  isExcludedSourceFile,
+  isIndexSourceFile,
+  siblingModuleKeyFromSpecifier,
+  sourceModuleKey,
+} from "../exports/inventory-barrels.js";
+export {
+  checkPackageExports,
+  packagePathSegments,
+  packageReportPath,
+  pathHasForbiddenSegment,
+} from "../package-api/index.js";
+export {
+  checkPublicVendorTypeLeaks,
+  externalReExportDiagnostics,
+  normalizeTypePackageName,
+  packageAllowedInPublicTypes,
+  packageNameFromFileName,
+  packageNameFromSpecifier,
+} from "../type-surface/index.js";
+export {
+  cachedProjectArchitecture,
+  clearArchitectureCache,
+  clearWorkspaceCache,
+  getOrCreateWorkspaceCache,
+} from "../project/cache/index.js";
+export { uniqueDiagnostics } from "../project/diagnostics/index.js";
+export { resolveArchitectureOptions } from "../project/config.js";
+export { collectExportsValue, collectPackageExportEntries } from "../package-api/index.js";
+export { readPackageJson } from "../package-api/index.js";
+export {
+  candidateSourcePaths,
+  createProgram,
+  findPackageReportFile,
+  projectSourceFiles,
+  publicApiSourceFiles,
+  sourcePathForPackageTarget,
+} from "../project/source-files.js";
+export {
+  folderEdgeDensity,
+  stronglyConnectedFolderComponents,
+} from "../imports/folder-graph/index.js";
+export {
+  buildProjectGraph,
+  folderKeyForFile,
+  layerIndexFor,
+  resolveLocalSpecifier,
+  topFolder,
+} from "../imports/project-graph/index.js";
+export {
+  exportedDeclarationName,
+  hasExportModifier,
+  isStarExportDeclaration,
+  isTestLikePath,
+} from "../project/index.js";
+export {
+  hasSourceExtension,
+  OUTPUT_EXTENSIONS,
+  replaceKnownExtension,
+  SOURCE_EXTENSIONS,
+  stripKnownExtension,
+  withTrailingSeparator,
+} from "../project/source-paths.js";
+export type { ArchitectureDiagnostic, PackageJson } from "../project/diagnostics/index.js";
+
+export const segmentArb = fc.stringMatching(/^[a-z][a-z0-9-]{0,8}$/);
+export const packageSegmentArb = fc.stringMatching(/^[a-z][a-z0-9-]{0,12}$/);
+export const scopedPackageArb = fc.tuple(packageSegmentArb, packageSegmentArb);
+export const sourceExtensionArb = fc.constantFrom(...SOURCE_EXTENSIONS);
+export const testOnlySegmentArb = fc.constantFrom(
+  "test",
+  "tests",
+  "testing",
+  "test-utils",
+  "test-support",
+  "fixtures",
+  "__fixtures__",
+  "__tests__",
+);
+
+export type DependencyKind = "dependencies" | "devDependencies" | "peerDependencies";
+
+export function exportSourceFileFor(modules: readonly string[], typeOnly: boolean): ts.SourceFile {
+  const keyword = typeOnly ? "export type" : "export";
+  return ts.createSourceFile(
+    "index.ts",
+    modules.map((moduleName, index) => `${keyword} { M${index} } from "./${moduleName}";`).join("\n"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+export function writeSiblingModules(
+  directory: string,
+  eligibleCount: number,
+  exportedCount: number,
+): ts.SourceFile {
+  fs.mkdirSync(directory, { recursive: true });
+  const exportLines = siblingExportLines(exportedCount);
+  const indexPath = path.join(directory, "index.ts");
+  fs.writeFileSync(indexPath, exportLines.join("\n"));
+  writeSiblingModuleFiles(directory, eligibleCount);
+  fs.writeFileSync(path.join(directory, "ignored.test.ts"), "export const ignored = true;\n");
+  return ts.createSourceFile(
+    indexPath,
+    exportLines.join("\n"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+export function packageJsonForExports(exportsValue: unknown): PackageJson {
+  return {
+    name: "pkg",
+    exports: exportsValue,
+    dependencies: new Map(),
+    devDependencies: new Map(),
+    peerDependencies: new Map(),
+  };
+}
+
+export function packageExportDiagnostics(
+  exportsValue: unknown,
+  options: Parameters<typeof resolveArchitectureOptions>[0] = {},
+): readonly ArchitectureDiagnostic[] {
+  return checkPackageExports(
+    packageJsonForExports(exportsValue),
+    resolveArchitectureOptions({ projectRoot: "/repo", ...options }),
+    "/repo/package.json",
+  );
+}
+
+export function diagnosticsForRule(
+  diagnostics: readonly ArchitectureDiagnostic[],
+  ruleId: ArchitectureDiagnostic["ruleId"],
+): readonly ArchitectureDiagnostic[] {
+  return diagnostics.filter((diagnostic) => diagnostic.ruleId === ruleId);
+}
+
+export function programFromSourceFiles(sourceFiles: readonly ts.SourceFile[]): ts.Program {
+  return { getSourceFiles: () => [...sourceFiles] } as ts.Program;
+}
+
+export function sourceFileAt(root: string, relativePath: string, text: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path.resolve(root, relativePath),
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+export function sourceFilesByRelativePath(
+  root: string,
+  files: Record<string, string>,
+): readonly ts.SourceFile[] {
+  return Object.entries(files).map(([relativePath, text]) =>
+    sourceFileAt(root, relativePath, text),
+  );
+}
+
+export function writePublicTypeProject(
+  packageName: string,
+  publicSource: string,
+  dependencyKind: DependencyKind = "dependencies",
+): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-public-type-"));
+  for (const [relativePath, contents] of Object.entries(
+    publicTypeProjectFiles(packageName, publicSource, dependencyKind),
+  )) {
+    writeFixtureFile(root, relativePath, contents);
+  }
+  return root;
+}
+
+export function writeNodePackage(root: string, packageName: string, declarations: string): void {
+  writeFixtureFile(
+    root,
+    `node_modules/${packageName}/package.json`,
+    JSON.stringify({ name: packageName, version: "1.0.0", types: "index.d.ts" }),
+  );
+  writeFixtureFile(root, `node_modules/${packageName}/index.d.ts`, declarations);
+}
+
+export function publicTypeDiagnostics(
+  root: string,
+  options: Parameters<typeof resolveArchitectureOptions>[0] = {},
+): readonly ArchitectureDiagnostic[] {
+  const normalizedOptions = resolveArchitectureOptions({ projectRoot: root, ...options });
+  const program = createProgram(normalizedOptions);
+  const packageJson = readPackageJson(root);
+  if (program === null || packageJson === null) return [];
+  return checkPublicVendorTypeLeaks(program, packageJson, normalizedOptions);
+}
+
+export function nestedReadonlyObjectType(leafType: string, depth: number): string {
+  return Array.from({ length: depth }).reduceRight(
+    (inner, _unused, index) => `{ readonly step${index}: ${inner}; }`,
+    leafType,
+  );
+}
+
+function siblingExportLines(exportedCount: number): readonly string[] {
+  return Array.from(
+    { length: exportedCount },
+    (_, index) => `export { M${index} } from "./m${index}";`,
+  );
+}
+
+function writeSiblingModuleFiles(directory: string, eligibleCount: number): void {
+  for (let index = 0; index < eligibleCount; index += 1) {
+    fs.writeFileSync(path.join(directory, `m${index}.ts`), `export const M${index} = ${index};\n`);
+  }
+}
+
+function publicTypeProjectFiles(
+  packageName: string,
+  publicSource: string,
+  dependencyKind: DependencyKind,
+): Record<string, string> {
+  return {
+    "package.json": JSON.stringify(publicTypePackageJson(packageName, dependencyKind), null, 2),
+    "tsconfig.json": JSON.stringify(publicTypeTsconfig(), null, 2),
+    "src/index.ts": publicSource,
+    [`node_modules/${packageName}/package.json`]: JSON.stringify({
+      name: packageName,
+      version: "1.0.0",
+      types: "index.d.ts",
+    }),
+    [`node_modules/${packageName}/index.d.ts`]:
+      "export interface VendorShape<T = unknown> { readonly value: T; }\n",
+  };
+}
+
+function publicTypePackageJson(
+  packageName: string,
+  dependencyKind: DependencyKind,
+): Record<string, unknown> {
+  return {
+    name: "fixture",
+    version: "1.0.0",
+    type: "module",
+    [dependencyKind]: { [packageName]: "1.0.0" },
+    exports: { ".": { import: "./dist/index.js", types: "./dist/index.d.ts" } },
+  };
+}
+
+function publicTypeTsconfig(): Record<string, unknown> {
+  return {
+    compilerOptions: {
+      target: "ES2022",
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      strict: true,
+      skipLibCheck: true,
+      declaration: true,
+      outDir: "./dist",
+      rootDir: "./src",
+    },
+    include: ["src/**/*"],
+  };
+}
+
+function writeFixtureFile(root: string, relativePath: string, contents: string): void {
+  const absolutePath = path.join(root, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents);
+}

--- a/lsp/architecture/analyzer/type-surface/index.ts
+++ b/lsp/architecture/analyzer/type-surface/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @file Type-surface analysis barrel. Re-exports the public vendor /
+ * infrastructure type-leak checks and the boundary-owned type
+ * requirement enforced on package exports.
+ */
+
+export {
+  checkPublicVendorTypeLeaks,
+  externalReExportDiagnostics,
+  normalizeTypePackageName,
+  packageAllowedInPublicTypes,
+  packageNameFromFileName,
+  packageNameFromSpecifier,
+} from "./type-leaks.js";

--- a/lsp/architecture/analyzer/type-surface/public-signatures.test.ts
+++ b/lsp/architecture/analyzer/type-surface/public-signatures.test.ts
@@ -1,0 +1,192 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+it("Property: public signature diagnostics inspect properties, unions, generics, calls, and constructors", () => {
+  expect.hasAssertions();
+  fc.assert(
+    fc.property(packageSegmentArb, assertPublicSignatureLeakCoverage),
+    { numRuns: 3 },
+  );
+});
+
+it("limits public signature traversal depth while preserving exact-boundary leaks", () => {
+  const root = writePublicTypeProject("vendor-lib", depthBoundaryPublicSource());
+
+  try {
+    writeNodePackage(
+      root,
+      "allowed-lib",
+      [
+        "export interface PublicBox<T> { readonly boxed: T; }",
+        "export interface OpaqueBox<T> {}",
+      ].join("\n"),
+    );
+    const leakedExportNames = leakedDepthBoundaryExports(root);
+
+    expect(leakedExportNames).toContain("PublicExactDepth");
+    expect(leakedExportNames).toContain("PublicAllowedGenericExact");
+    expect(leakedExportNames).toContain("PublicAllowedOpaqueGenericExact");
+    expect(leakedExportNames.filter((exportName) => exportName.startsWith("PublicTooDeep")))
+      .toEqual([]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function assertPublicSignatureLeakCoverage(packageName: string): void {
+  const root = writePublicTypeProject(packageName, publicSignatureFixtureSource(packageName));
+  try {
+    const messages = diagnosticsForRule(
+      publicTypeDiagnostics(root),
+      "no-public-vendor-type-leak",
+    ).map((diagnostic) => diagnostic.message);
+    expectMissingVendorLeakMessages(messages, packageName);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function publicSignatureFixtureSource(packageName: string): string {
+  return [
+    `import type { VendorShape } from "${packageName}";`,
+    `import type * as VendorNamespace from "${packageName}";`,
+    "export interface PublicProperties { readonly raw: VendorShape; }",
+    "export interface PublicNamespace { readonly raw: VendorNamespace.VendorShape; }",
+    `export interface PublicImportType { readonly raw: import("${packageName}").VendorShape; }`,
+    "export type PublicUnion = { readonly own: string } | VendorShape;",
+    "export interface PublicGeneric { readonly items: ReadonlyArray<VendorShape<string>>; }",
+    "export interface PublicCallable { readonly run: (input: VendorShape) => VendorShape; }",
+    "export interface PublicParamOnly { readonly accept: (input: VendorShape) => void; }",
+    "export interface PublicReturnOnly { readonly create: () => VendorShape; }",
+    "export interface PublicConstructable { readonly make: new (input: VendorShape) => VendorShape; }",
+    "export const identity = (input: VendorShape): VendorShape => input;",
+  ].join("\n");
+}
+
+function expectMissingVendorLeakMessages(
+  messages: readonly string[],
+  packageName: string,
+): void {
+  const missingExportNames = expectedPublicSignatureExportNames().filter(
+    (exportName) => !hasExpectedVendorLeak(messages, packageName, exportName),
+  );
+  expect(missingExportNames).toEqual([]);
+}
+
+function hasExpectedVendorLeak(
+  messages: readonly string[],
+  packageName: string,
+  exportName: string,
+): boolean {
+  for (const message of messages) {
+    if (
+      message.includes(`export "${exportName}" references`) &&
+      message.includes(packageName) &&
+      message.includes("types. Wrap vendor types behind domain-owned public types") &&
+      message.includes("publicTypePackages")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function expectedPublicSignatureExportNames(): readonly string[] {
+  return [
+    "PublicProperties",
+    "PublicNamespace",
+    "PublicImportType",
+    "PublicUnion",
+    "PublicGeneric",
+    "PublicCallable",
+    "PublicParamOnly",
+    "PublicReturnOnly",
+    "PublicConstructable",
+    "identity",
+  ];
+}
+
+function depthBoundaryPublicSource(): string {
+  return [
+    'import type { VendorShape } from "vendor-lib";',
+    "type LocalBox<T> = { readonly boxed: T };",
+    'import type { OpaqueBox, PublicBox } from "allowed-lib";',
+    `export type PublicExactDepth = ${nestedReadonlyObjectType("VendorShape", 8)};`,
+    `export interface PublicAllowedGenericExact { readonly box: PublicBox<${nestedReadonlyObjectType("VendorShape", 6)}>; }`,
+    `export interface PublicAllowedOpaqueGenericExact { readonly box: OpaqueBox<${nestedReadonlyObjectType("VendorShape", 6)}>; }`,
+    `export type PublicTooDeepProperty = ${nestedReadonlyObjectType("VendorShape", 9)};`,
+    `export type PublicTooDeepUnion = ${nestedReadonlyObjectType("{ readonly own: string } | VendorShape", 8)};`,
+    `export interface PublicTooDeepReturn { readonly run: () => ${nestedReadonlyObjectType("VendorShape", 7)}; }`,
+    `export interface PublicTooDeepParam { readonly run: (input: ${nestedReadonlyObjectType("VendorShape", 7)}) => void; }`,
+    `export interface PublicTooDeepGeneric { readonly items: LocalBox<${nestedReadonlyObjectType("VendorShape", 7)}>; }`,
+    `export interface PublicAllowedGenericTooDeep { readonly box: PublicBox<${nestedReadonlyObjectType("VendorShape", 7)}>; }`,
+    `export interface PublicAllowedOpaqueGenericTooDeep { readonly box: OpaqueBox<${nestedReadonlyObjectType("VendorShape", 7)}>; }`,
+  ].join("\n");
+}
+
+function leakedDepthBoundaryExports(root: string): readonly string[] {
+  const messages = diagnosticsForRule(
+    publicTypeDiagnostics(root, {
+      publicTypePackages: [{ package: "allowed-lib", reason: "test fixture" }],
+    }),
+    "no-public-vendor-type-leak",
+  ).map((diagnostic) => diagnostic.message);
+
+  return messages.flatMap((message) => {
+    const match = /export "([^"]+)" references/.exec(message);
+    return match ? [match[1]] : [];
+  });
+}
+
+it("warns for peer dependency public types while dependencies and devDependencies are errors", () => {
+  const source = [
+    'import type { VendorShape } from "vendor-lib";',
+    "export interface PublicShape { readonly raw: VendorShape; }",
+  ].join("\n");
+  const dependencyRoot = writePublicTypeProject("vendor-lib", source, "dependencies");
+  const devDependencyRoot = writePublicTypeProject("vendor-lib", source, "devDependencies");
+  const peerDependencyRoot = writePublicTypeProject("vendor-lib", source, "peerDependencies");
+
+  try {
+    expect(
+      diagnosticsForRule(publicTypeDiagnostics(dependencyRoot), "no-public-vendor-type-leak")
+        .map((diagnostic) => diagnostic.severity),
+    ).toEqual(["error"]);
+    expect(
+      diagnosticsForRule(publicTypeDiagnostics(devDependencyRoot), "no-public-vendor-type-leak")
+        .map((diagnostic) => diagnostic.severity),
+    ).toEqual(["error"]);
+    expect(
+      diagnosticsForRule(publicTypeDiagnostics(peerDependencyRoot), "no-public-vendor-type-leak")
+        .map((diagnostic) => diagnostic.severity),
+    ).toEqual(["warn"]);
+    expect(
+      diagnosticsForRule(
+        publicTypeDiagnostics(dependencyRoot, { publicTypePackages: [{ package: "vendor-lib", reason: "test fixture" }] }),
+        "no-public-vendor-type-leak",
+      ),
+    ).toEqual([]);
+  } finally {
+    fs.rmSync(dependencyRoot, { recursive: true, force: true });
+    fs.rmSync(devDependencyRoot, { recursive: true, force: true });
+    fs.rmSync(peerDependencyRoot, { recursive: true, force: true });
+  }
+});
+
+it("Property: package specifier and @types normalization preserve package identity", () => {
+  fc.assert(
+    fc.property(packageSegmentArb, scopedPackageArb, (plainPackage, [scope, name]) => {
+      expect(packageNameFromSpecifier(`${plainPackage}/sub/path`)).toBe(plainPackage);
+      expect(packageNameFromSpecifier(`@${scope}/${name}/sub/path`)).toBe(
+        `@${scope}/${name}`,
+      );
+      expect(normalizeTypePackageName(`@types/${plainPackage}`)).toBe(plainPackage);
+      expect(normalizeTypePackageName(`@types/${scope}__${name}`)).toBe(
+        `@${scope}/${name}`,
+      );
+    }),
+    { numRuns: 100 },
+  );
+});

--- a/lsp/architecture/analyzer/type-surface/public-types.test.ts
+++ b/lsp/architecture/analyzer/type-surface/public-types.test.ts
@@ -1,0 +1,204 @@
+import { expect, it } from "vitest";
+import * as h from "../test-support/helper-fixtures.js";
+
+const { fs, os, path, fc, ts, exportDeclarationIsTypeOnly, exportedSiblingModuleKeys, eligibleSiblingModuleKeys, inventoryBarrelDiagnostic, isExcludedSourceFile, isIndexSourceFile, siblingModuleKeyFromSpecifier, sourceModuleKey, checkPackageExports, packagePathSegments, packageReportPath, pathHasForbiddenSegment, checkPublicVendorTypeLeaks, externalReExportDiagnostics, normalizeTypePackageName, packageAllowedInPublicTypes, packageNameFromFileName, packageNameFromSpecifier, cachedProjectArchitecture, clearArchitectureCache, uniqueDiagnostics, resolveArchitectureOptions, collectExportsValue, collectPackageExportEntries, readPackageJson, candidateSourcePaths, createProgram, findPackageReportFile, projectSourceFiles, publicApiSourceFiles, sourcePathForPackageTarget, folderEdgeDensity, stronglyConnectedFolderComponents, buildProjectGraph, exportedDeclarationName, folderKeyForFile, hasExportModifier, isTestLikePath, isStarExportDeclaration, layerIndexFor, resolveLocalSpecifier, topFolder, hasSourceExtension, OUTPUT_EXTENSIONS, replaceKnownExtension, SOURCE_EXTENSIONS, stripKnownExtension, withTrailingSeparator, segmentArb, packageSegmentArb, scopedPackageArb, sourceExtensionArb, testOnlySegmentArb, exportSourceFileFor, writeSiblingModules, packageJsonForExports, packageExportDiagnostics, diagnosticsForRule, programFromSourceFiles, sourceFileAt, sourceFilesByRelativePath, writePublicTypeProject, writeNodePackage, publicTypeDiagnostics, nestedReadonlyObjectType } = h;
+
+it("normalizes external type package names", () => {
+  expect(packageNameFromSpecifier("node:stream")).toBe("node");
+  expect(packageNameFromSpecifier("@scope/pkg/subpath")).toBe("@scope/pkg");
+  expect(packageNameFromSpecifier("./local")).toBeNull();
+  expect(packageNameFromSpecifier("/absolute")).toBeNull();
+  expect(packageNameFromSpecifier("")).toBeNull();
+  expect(normalizeTypePackageName("@types/react")).toBe("react");
+  expect(normalizeTypePackageName("@types/node")).toBe("node");
+  expect(normalizeTypePackageName("@types/aws__lambda")).toBe("@aws/lambda");
+  expect(normalizeTypePackageName("@types/aws__lambda__extra")).toBe(
+    "aws__lambda__extra",
+  );
+  expect(normalizeTypePackageName("@types/prefix_aws__lambda")).toBe(
+    "prefix_aws__lambda",
+  );
+  expect(packageNameFromFileName("/repo/node_modules/@types/react/index.d.ts")).toBe("react");
+  expect(packageNameFromFileName("C:\\repo\\node_modules\\@types\\react\\index.d.ts"))
+    .toBe("react");
+  expect(packageNameFromFileName("/repo/node_modules/openai/index.d.ts")).toBe("openai");
+  expect(packageNameFromFileName("/repo/node_modules/")).toBeNull();
+  expect(packageNameFromFileName("/repo/node_modules/typescript/lib/lib.dom.d.ts")).toBeNull();
+  expect(packageNameFromFileName("/repo/node_modules/typescript/lib/lib.dom.d.ts.map"))
+    .toBe("typescript");
+  expect(packageNameFromFileName("/repo/src/generated/client.ts")).toBe("generated-vendor");
+  expect(packageNameFromFileName("/repo/src/mygenerated/client.ts")).toBeNull();
+  expect(packageNameFromFileName("/repo/src/domain/model.ts")).toBeNull();
+});
+
+it("applies public type allowlist policy", () => {
+  expect(
+    packageAllowedInPublicTypes("node", {
+      packageRuntime: "node",
+      publicTypePackages: [],
+    }),
+  ).toBe(true);
+  expect(
+    packageAllowedInPublicTypes("react", {
+      packageRuntime: "universal",
+      publicTypePackages: [{ package: "react", reason: "test fixture" }],
+    }),
+  ).toBe(true);
+  expect(
+    packageAllowedInPublicTypes("node", {
+      packageRuntime: "universal",
+      publicTypePackages: [],
+    }),
+  ).toBe(false);
+  expect(
+    packageAllowedInPublicTypes("openai", {
+      packageRuntime: "node",
+      publicTypePackages: [],
+    }),
+  ).toBe(false);
+  expect(
+    packageAllowedInPublicTypes("openai", {
+      packageRuntime: "universal",
+      publicTypePackages: [],
+    }),
+  ).toBe(false);
+});
+
+it("Property: external public re-export diagnostics follow ownership and allowlist policy", () => {
+  expect.hasAssertions();
+  fc.assert(
+    fc.property(packageSegmentArb, fc.boolean(), assertExternalReExportPolicy),
+    { numRuns: 40 },
+  );
+});
+
+it("ignores local public re-exports for vendor type leak checks", () => {
+  const localSourceFile = ts.createSourceFile(
+    "/repo/src/index.ts",
+    ['export type { Local } from "./local";', 'export type { Absolute } from "/repo/local";'].join("\n"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  expect(
+    externalReExportDiagnostics(
+      localSourceFile,
+      resolveArchitectureOptions({ projectRoot: "/repo" }),
+    ),
+  ).toEqual([]);
+});
+
+function assertExternalReExportPolicy(packageName: string, allowed: boolean): void {
+  const specifier = `${packageName}/subpath`;
+  const sourceFile = ts.createSourceFile(
+    "/repo/src/index.ts",
+    `export type { VendorShape } from "${specifier}";`,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const diagnostics = externalReExportDiagnostics(
+    sourceFile,
+    resolveArchitectureOptions({
+      projectRoot: "/repo",
+      infrastructureTypePackages: [],
+      publicTypePackages: allowed ? [{ package: packageName, reason: "test: explicitly allowed" }] : [],
+    }),
+  );
+
+  if (allowed) {
+    expect(diagnostics).toEqual([]);
+    return;
+  }
+
+  expect(diagnostics).toHaveLength(1);
+  const diagnostic = diagnostics[0];
+  if (diagnostic === undefined) {
+    throw new Error("expected vendor re-export diagnostic");
+  }
+  expect(diagnostic).toEqual(expect.objectContaining({
+    ruleId: "no-public-vendor-type-leak",
+    file: sourceFile.fileName,
+    severity: "error",
+    message: expect.stringContaining(packageName),
+  }));
+  expect(diagnostic.message).toContain(specifier);
+  expect(diagnostic.message).toContain("domain-owned public types");
+  expect(diagnostic.message).toContain("publicTypePackages");
+}
+
+it("reports infrastructure and Node public re-export policy separately", () => {
+  expectInfrastructureReExportDiagnostics();
+  expectNodePublicReExportPolicy();
+});
+
+function expectInfrastructureReExportDiagnostics(): void {
+  const diagnostics = infrastructureReExportDiagnostics();
+  expect(diagnostics).toEqual([
+    expect.objectContaining({
+      ruleId: "no-public-vendor-type-leak",
+      severity: "error",
+      message: expect.stringContaining("domain-owned public types"),
+    }),
+    expect.objectContaining({
+      ruleId: "no-public-infra-type-leak",
+      severity: "error",
+      message: expect.stringContaining(
+        `Public API references infrastructure package "kysely"`,
+      ),
+    }),
+  ]);
+
+  const infraDiagnostic = diagnostics[1];
+  if (infraDiagnostic === undefined) {
+    throw new Error("expected infrastructure diagnostic");
+  }
+  expect(infraDiagnostic.message).toContain(
+    "Database, logging, transport, and SDK implementation choices",
+  );
+  expect(infraDiagnostic.message).toContain("package-owned ports or DTOs");
+}
+
+function expectNodePublicReExportPolicy(): void {
+  const nodeSourceFile = ts.createSourceFile(
+    "/repo/src/index.ts",
+    'export type { Readable } from "node:stream";',
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  expect(
+    externalReExportDiagnostics(
+      nodeSourceFile,
+      resolveArchitectureOptions({ projectRoot: "/repo", packageRuntime: "universal" }),
+    ),
+  ).toEqual([
+    expect.objectContaining({
+      ruleId: "no-public-vendor-type-leak",
+      severity: "warn",
+    }),
+  ]);
+  expect(
+    externalReExportDiagnostics(
+      nodeSourceFile,
+      resolveArchitectureOptions({ projectRoot: "/repo", packageRuntime: "node" }),
+    ),
+  ).toEqual([]);
+}
+
+function infrastructureReExportDiagnostics(): ReturnType<typeof externalReExportDiagnostics> {
+  const infraSourceFile = ts.createSourceFile(
+    "/repo/src/index.ts",
+    'export type { Kysely } from "kysely";',
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  return externalReExportDiagnostics(
+    infraSourceFile,
+    resolveArchitectureOptions({
+      projectRoot: "/repo",
+      infrastructureTypePackages: [{ package: "kysely", reason: "test fixture" }],
+    }),
+  );
+}

--- a/lsp/architecture/analyzer/type-surface/type-leaks.ts
+++ b/lsp/architecture/analyzer/type-surface/type-leaks.ts
@@ -1,0 +1,317 @@
+import ts from "typescript";
+import { uniqueDiagnostics } from "../project/api/index.js";
+import { publicApiSourceFiles } from "../project/api/index.js";
+import type {
+  ResolvedArchitectureOptions,
+  PackageJson,
+  ArchitectureDiagnostic,
+  ArchitectureSeverity,
+} from "../project/api/index.js";
+
+const MAX_TYPE_DEPTH = 8;
+
+interface TypeVisitContext {
+  readonly checker: ts.TypeChecker;
+  readonly location: ts.Node;
+  readonly visit: (type: ts.Type, depth: number) => void;
+}
+
+export function checkPublicVendorTypeLeaks(
+  program: ts.Program,
+  packageJson: PackageJson,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  const checker = program.getTypeChecker();
+  const diagnostics = publicApiSourceFiles(program, packageJson, options).flatMap(
+    (sourceFile) => [
+      ...externalReExportDiagnostics(sourceFile, options),
+      ...exportedSignatureDiagnostics(checker, sourceFile, packageJson, options),
+    ],
+  );
+
+  return uniqueDiagnostics(diagnostics);
+}
+
+export function externalReExportDiagnostics(
+  sourceFile: ts.SourceFile,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  return sourceFile.statements.flatMap((statement) => {
+    if (!ts.isExportDeclaration(statement)) return [];
+    if (!statement.moduleSpecifier || !ts.isStringLiteral(statement.moduleSpecifier)) return [];
+
+    const packageName = packageNameFromSpecifier(statement.moduleSpecifier.text);
+    if (packageName === null || packageAllowedInPublicTypes(packageName, options)) return [];
+
+    return [
+      {
+        ruleId: "no-public-vendor-type-leak",
+        file: sourceFile.fileName,
+        severity: publicTypeReExportSeverity(packageName),
+        message:
+          `Public API re-exports "${packageName}" types from "${statement.moduleSpecifier.text}". ` +
+          "Wrap vendor types behind domain-owned public types, or list the package in " +
+          "publicTypePackages when it is intentionally part of the contract.",
+      },
+      ...infraTypeLeakDiagnostic(sourceFile.fileName, packageName, options),
+    ];
+  });
+}
+
+export function packageNameFromSpecifier(specifier: string): string | null {
+  if (specifier.startsWith(".")) return null;
+  if (specifier.startsWith("node:")) return "node";
+
+  const [firstSegment, secondSegment] = specifier.split("/");
+  if (!firstSegment) return null;
+  if (firstSegment.startsWith("@")) {
+    return secondSegment ? `${firstSegment}/${secondSegment}` : firstSegment;
+  }
+
+  return firstSegment;
+}
+
+export function packageNameFromFileName(fileName: string): string | null {
+  const normalized = fileName.replaceAll("\\", "/");
+  if (/\/node_modules\/typescript\/lib\/lib\..+\.d\.ts$/.test(normalized)) return null;
+
+  const marker = "/node_modules/";
+  const markerIndex = normalized.lastIndexOf(marker);
+  if (markerIndex === -1) {
+    return /\/(__generated__|generated)\//.test(normalized) ? "generated-vendor" : null;
+  }
+
+  const afterNodeModules = normalized.slice(markerIndex + marker.length);
+  const rawPackageName = packageNameFromNodeModulesPath(afterNodeModules);
+  return rawPackageName ? normalizeTypePackageName(rawPackageName) : null;
+}
+
+export function normalizeTypePackageName(packageName: string): string {
+  if (!packageName.startsWith("@types/")) return packageName;
+
+  const withoutPrefix = packageName.slice("@types/".length);
+  const scopedMatch = /^([^_]+)__([^_]+)$/.exec(withoutPrefix);
+  return scopedMatch ? `@${scopedMatch[1]}/${scopedMatch[2]}` : withoutPrefix;
+}
+
+export function packageAllowedInPublicTypes(
+  packageName: string,
+  options: Pick<ResolvedArchitectureOptions, "packageRuntime" | "publicTypePackages">,
+): boolean {
+  if (options.publicTypePackages.some((entry) => entry.package === packageName)) return true;
+  if (packageName !== "node") return false;
+  return options.packageRuntime === "node";
+}
+
+function exportedSignatureDiagnostics(
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  packageJson: PackageJson,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) return [];
+
+  return checker.getExportsOfModule(moduleSymbol).flatMap((exportedSymbol) => {
+    const declaration = exportedSymbol.valueDeclaration ?? exportedSymbol.declarations?.[0];
+    if (!declaration) return [];
+
+    const exportedType = typeForExportedSymbol(checker, exportedSymbol, declaration);
+    const leakedPackages = externalPackagesFromType(
+      checker,
+      exportedType,
+      declaration,
+      options,
+    );
+
+    return [...leakedPackages].flatMap((packageName) => [
+      {
+        ruleId: "no-public-vendor-type-leak",
+        file: sourceFile.fileName,
+        severity: publicTypeLeakSeverity(packageName, packageJson),
+        message:
+          `Public API export "${exportedSymbol.getName()}" references "${packageName}" ` +
+          "types. Wrap vendor types behind domain-owned public types, or list the " +
+          "package in publicTypePackages when it is intentionally part of the contract.",
+      },
+      ...infraTypeLeakDiagnostic(sourceFile.fileName, packageName, options),
+    ]);
+  });
+}
+
+function publicTypeLeakSeverity(
+  packageName: string,
+  packageJson: PackageJson,
+): ArchitectureSeverity {
+  if (packageName === "node") return "warn";
+  return packageJson.peerDependencies.has(packageName) ? "warn" : "error";
+}
+
+function publicTypeReExportSeverity(packageName: string): ArchitectureSeverity {
+  return packageName === "node" ? "warn" : "error";
+}
+
+function infraTypeLeakDiagnostic(
+  fileName: string,
+  packageName: string,
+  options: ResolvedArchitectureOptions,
+): readonly ArchitectureDiagnostic[] {
+  if (!options.infrastructureTypePackages.some((entry) => entry.package === packageName)) return [];
+
+  return [
+    {
+      ruleId: "no-public-infra-type-leak",
+      file: fileName,
+      severity: "error",
+      message:
+        `Public API references infrastructure package "${packageName}". Database, ` +
+        "logging, transport, and SDK implementation choices should be hidden behind " +
+        "package-owned ports or DTOs.",
+    },
+  ];
+}
+
+function typeForExportedSymbol(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol,
+  declaration: ts.Declaration,
+): ts.Type {
+  if (ts.isInterfaceDeclaration(declaration) || ts.isTypeAliasDeclaration(declaration)) {
+    return checker.getDeclaredTypeOfSymbol(symbol);
+  }
+
+  return checker.getTypeOfSymbolAtLocation(symbol, declaration);
+}
+
+function externalPackagesFromType(
+  checker: ts.TypeChecker,
+  type: ts.Type,
+  location: ts.Node,
+  options: ResolvedArchitectureOptions,
+): ReadonlySet<string> {
+  const packages = new Set<string>();
+  const seenTypes = new Set<ts.Type>();
+
+  function visit(currentType: ts.Type, depth: number): void {
+    if (depth > MAX_TYPE_DEPTH || seenTypes.has(currentType)) return;
+    seenTypes.add(currentType);
+
+    const owningPackage = packageNameFromType(currentType);
+    if (owningPackage) {
+      if (!packageAllowedInPublicTypes(owningPackage, options)) packages.add(owningPackage);
+      visitTypeArguments(context, currentType, depth);
+      return;
+    }
+
+    visitCompositeType(context, currentType, depth);
+  }
+
+  const context = { checker, location, visit };
+  visit(type, 0);
+  return packages;
+}
+
+function visitCompositeType(
+  context: TypeVisitContext,
+  type: ts.Type,
+  depth: number,
+): void {
+  visitUnionMembers(context, type, depth);
+  visitTypeArguments(context, type, depth);
+  visitSignatures(context, type, depth);
+  visitProperties(context, type, depth);
+}
+
+function visitUnionMembers(
+  context: TypeVisitContext,
+  type: ts.Type,
+  depth: number,
+): void {
+  if (!type.isUnionOrIntersection()) return;
+  for (const member of type.types) context.visit(member, depth + 1);
+}
+
+function visitSignatures(
+  context: TypeVisitContext,
+  type: ts.Type,
+  depth: number,
+): void {
+  const signatures = [
+    ...type.getCallSignatures(),
+    ...type.getConstructSignatures(),
+  ];
+  for (const signature of signatures) visitSignature(context, signature, depth);
+}
+
+function visitSignature(
+  context: TypeVisitContext,
+  signature: ts.Signature,
+  depth: number,
+): void {
+  context.visit(signature.getReturnType(), depth + 1);
+  for (const parameter of signature.getParameters()) {
+    visitSignatureParameter(context, parameter, depth);
+  }
+}
+
+function visitSignatureParameter(
+  context: TypeVisitContext,
+  parameter: ts.Symbol,
+  depth: number,
+): void {
+  const declaration =
+    parameter.valueDeclaration ?? parameter.declarations?.[0] ?? context.location;
+  context.visit(
+    context.checker.getTypeOfSymbolAtLocation(parameter, declaration),
+    depth + 1,
+  );
+}
+
+function visitProperties(
+  context: TypeVisitContext,
+  type: ts.Type,
+  depth: number,
+): void {
+  for (const property of type.getProperties()) {
+    const declaration = property.declarations?.[0];
+    if (declaration) {
+      context.visit(
+        context.checker.getTypeOfSymbolAtLocation(property, declaration),
+        depth + 1,
+      );
+    }
+  }
+}
+
+function visitTypeArguments(
+  context: TypeVisitContext,
+  type: ts.Type,
+  depth: number,
+): void {
+  for (const argument of context.checker.getTypeArguments(type as ts.TypeReference)) {
+    context.visit(argument, depth + 1);
+  }
+}
+
+function packageNameFromType(type: ts.Type): string | null {
+  const aliasPackage = resolvePackageNameFromSymbol(type.aliasSymbol);
+  return aliasPackage ?? resolvePackageNameFromSymbol(type.symbol);
+}
+
+function resolvePackageNameFromSymbol(symbol: ts.Symbol | undefined): string | null {
+  if (symbol === undefined) return null;
+  const declarations = symbol.getDeclarations() ?? [];
+  for (const declaration of declarations) {
+    const packageName = packageNameFromFileName(declaration.getSourceFile().fileName);
+    if (packageName !== null) return packageName;
+  }
+
+  return null;
+}
+
+function packageNameFromNodeModulesPath(afterNodeModules: string): string | null {
+  const [firstSegment, secondSegment] = afterNodeModules.split("/");
+  return firstSegment.startsWith("@") && secondSegment
+    ? `${firstSegment}/${secondSegment}`
+    : firstSegment;
+}

--- a/lsp/architecture/check.ts
+++ b/lsp/architecture/check.ts
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * @file CI shim. Reads `tsconfig.json` from cwd, runs the
- * architecture analyzer once, prints each finding, and exits
- * non-zero when any error-severity diagnostic is present.
- *
- * Invocation: `node lsp/architecture/check.js` from the consuming
- * repo. No flags, no argparse — CI users wire this into their job
- * script directly.
+ * @file CI shim. Runs the architecture analyzer against the cwd's
+ * project, prints each finding, and exits non-zero on any
+ * error-severity diagnostic. Invocation: `node lsp/architecture/check.js`.
  */
 
 import process from "node:process";

--- a/lsp/architecture/check.ts
+++ b/lsp/architecture/check.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/**
+ * @file CI shim. Reads `tsconfig.json` from cwd, runs the
+ * architecture analyzer once, prints each finding, and exits
+ * non-zero when any error-severity diagnostic is present.
+ *
+ * Invocation: `node lsp/architecture/check.js` from the consuming
+ * repo. No flags, no argparse — CI users wire this into their job
+ * script directly.
+ */
+
+import process from "node:process";
+import { analyzeWorkspace } from "./analyzer/index.js";
+
+function main(): void {
+  const report = analyzeWorkspace({ projectRoot: process.cwd() });
+  let hasError = false;
+  for (const finding of report.diagnostics) {
+    if (finding.severity === "error") hasError = true;
+    const line = `${finding.severity.toUpperCase()} ${finding.ruleId} ${finding.file}: ${finding.message}`;
+    process.stdout.write(`${line}\n`);
+  }
+  process.exit(hasError ? 1 : 0);
+}
+
+main();

--- a/lsp/architecture/docs/lsp.md
+++ b/lsp/architecture/docs/lsp.md
@@ -1,0 +1,111 @@
+# LSP server
+
+`agent-code-guard-lsp` is a long-lived Language Server Protocol implementation
+that runs the same architecture analyzer as `eslint-plugin-agent-code-guard`
+but publishes diagnostics directly to your editor. No per-process ESLint
+cold-start; the analyzer's report stays warm across edits.
+
+## Install
+
+The LSP ships as a [Claude Code plugin](https://code.claude.com/docs/en/plugins-reference).
+Sideload from a local clone:
+
+```bash
+git clone https://github.com/chughtapan/agent-code-guard
+cd agent-code-guard
+pnpm install
+pnpm build
+claude --plugin .
+```
+
+Editors that consume Claude Code's LSP plugins (VS Code with the Claude Code
+extension, Cursor, Claude Desktop) get architecture diagnostics on every open
+TypeScript file from then on.
+
+## Capabilities
+
+| Capability | Behavior |
+|---|---|
+| `textDocumentSync.openClose` | true |
+| `textDocumentSync.change` | `Incremental` (V1: stored, not re-analyzed) |
+| `textDocumentSync.save` | `includeText: false` (server reads from disk) |
+| `workspace.workspaceFolders.supported` | true |
+| `workspace.workspaceFolders.changeNotifications` | true |
+
+## Diagnostic lifecycle
+
+| Event | What the server does |
+|---|---|
+| `initialize` | Registers each `workspaceFolders[i]` as a `WorkspaceEngine`. Each engine spins up a `chokidar` watcher scoped to `package.json`, `tsconfig*.json`, and `.ts` / `.tsx` / `.mts` / `.cts` files under the folder. |
+| `textDocument/didOpen` | Stores the document. Runs the architecture analyzer for the workspace. Publishes diagnostics for the opened URI. |
+| `textDocument/didChange` | Updates the in-memory document store. **Does not re-analyze** — V1 is save-time only. |
+| `textDocument/didSave` | Force-invalidates the workspace cache (`clearWorkspaceCache`). Re-runs the analyzer. Publishes diagnostics for every open document in the workspace. |
+| `textDocument/didClose` | Drops the document. Publishes empty diagnostics (clears editor squigglies). |
+| Watcher fires (out-of-band edit) | Invalidates the cache. Publishes diagnostics for every open document in the affected workspace. |
+
+## Diagnostic shape
+
+Architecture diagnostics are project-level findings (e.g., "this folder
+participates in a cycle"). The LSP server emits them as `Diagnostic` records
+pinned to the start of each participating file. Editors group findings by the
+`code` field (the rule ID).
+
+```jsonc
+{
+  "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 1 } },
+  "severity": 1,                              // 1 = Error, 2 = Warning
+  "code": "no-folder-cycle",
+  "source": "agent-code-guard",
+  "message": "Folder src/services is in a cycle with src/models, src/db"
+}
+```
+
+Severity maps from the analyzer's `error` / `warn` to LSP's `Error` / `Warning`.
+
+## Performance
+
+| Operation | Typical wall time |
+|---|---|
+| Cold open of a workspace | 3–5 s (analyzer first build, ~1500-file project) |
+| Subsequent `didOpen` after cold | < 100 ms (disk cache hit) |
+| `didSave` round-trip (lint + publish) | 200–500 ms (cache fresh, only requested files filtered) |
+| Watcher → republish | 100–300 ms after the chokidar event |
+
+The disk cache at `<workspace>/node_modules/.cache/agent-code-guard/report.json`
+is shared with `eslint-plugin-agent-code-guard`. If you already ran ESLint
+once, the LSP boot is warm. The watermark covers source files, `package.json`,
+`tsconfig.json`, and analyzer version — edits to any of them invalidate.
+
+## What V1 does not do
+
+- **Live overlay diagnostics on `didChange`.** Editing without saving doesn't
+  re-publish. The analyzer reads from disk; a `LanguageService`-host overlay
+  (so unsaved buffer contents flow into the analyzer) is a follow-up. The
+  `programFingerprint` plumbing in `WorkspaceCache` is ready for it.
+- **Multi-root workspaces with overlapping package roots.** Each workspace
+  folder gets its own engine keyed on its URI; nested folders that share a
+  `package.json` ancestor outside the registered roots aren't handled
+  specially. Real-world cases are rare; a `findNearestPackageRoot` walk on
+  every `didOpen` is the fix when this comes up.
+- **Workspace-folder removal.** `workspace/didChangeWorkspaceFolders` for
+  removed folders doesn't release that folder's engine — engines live for the
+  LSP process lifetime in V1.
+
+## Lifecycle
+
+The server runs inside `Effect.scoped(makeLspServer(connection))`. When the
+parent process closes stdio (Claude Code shutdown, editor exit), Node exits
+and the ambient `Scope`'s finalizers fire: every workspace engine's
+`chokidar` watcher closes, every `WorkspaceCache` clears. No manual
+`dispose()` paths; the lifecycle is the Effect runtime's responsibility.
+
+## Configuration
+
+V1 LSP doesn't read per-workspace overrides — every registered workspace uses
+the analyzer's default options. Future versions can wire
+`workspace/configuration` requests through `resolveArchitectureOptions` to
+respect a `agent-code-guard` section in `settings.json` / `.editorconfig`.
+
+For now, the analyzer's defaults apply. If you need different thresholds for
+LSP than for ESLint CI, run ESLint with the override; LSP will catch the
+same defaults the analyzer ships with.

--- a/lsp/architecture/dogfood.ts
+++ b/lsp/architecture/dogfood.ts
@@ -1,0 +1,185 @@
+/**
+ * @file Spawns dist/server/index.js as a subprocess, talks real LSP
+ * protocol to it via stdin/stdout, and reports the diagnostics the
+ * server publishes for a few files in this package. End-to-end smoke
+ * test of the architecture LSP against its own analyzer source.
+ *
+ * Run: pnpm dogfood (from lsp/architecture/).
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// `import.meta.dirname` resolves to `dist/` after `pnpm build`. The
+// LSP binary lives next to this script inside `dist/server/`; the
+// workspace passed to the LSP is the package source root (one level
+// up from `dist/`) so the analyzer sees the analyzer + server TS
+// files directly.
+const LSP_BIN = path.join(import.meta.dirname, "server", "index.js");
+const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+}
+
+interface JsonRpcMessage {
+  jsonrpc: "2.0";
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+class LspClient {
+  readonly #proc;
+  readonly #pending = new Map<number, PendingRequest>();
+  #nextId = 1;
+  #buffer = Buffer.alloc(0);
+  readonly diagnostics: Array<{ uri: string; diagnostics: ReadonlyArray<unknown> }> = [];
+
+  constructor() {
+    this.#proc = spawn("node", [LSP_BIN], {
+      stdio: ["pipe", "pipe", "inherit"],
+    });
+    this.#proc.stdout.on("data", (chunk: Buffer) => this.#handleChunk(chunk));
+    this.#proc.on("exit", (code) => {
+      if (code !== null && code !== 0) console.error(`LSP exited with ${code}`);
+    });
+  }
+
+  send(method: string, params: unknown, isRequest: boolean): Promise<unknown> {
+    if (isRequest) {
+      const id = this.#nextId++;
+      const message: JsonRpcMessage = { jsonrpc: "2.0", id, method, params };
+      this.#write(message);
+      return new Promise((resolve, reject) => {
+        this.#pending.set(id, { resolve, reject });
+      });
+    }
+    this.#write({ jsonrpc: "2.0", method, params });
+    return Promise.resolve(undefined);
+  }
+
+  shutdown(): void {
+    this.#proc.kill();
+  }
+
+  #write(message: JsonRpcMessage): void {
+    const body = JSON.stringify(message);
+    const header = `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n`;
+    this.#proc.stdin.write(header + body);
+  }
+
+  #handleChunk(chunk: Buffer): void {
+    this.#buffer = Buffer.concat([this.#buffer, chunk]);
+    while (true) {
+      const headerEnd = this.#buffer.indexOf("\r\n\r\n");
+      if (headerEnd < 0) return;
+      const header = this.#buffer.subarray(0, headerEnd).toString("utf8");
+      const match = /Content-Length: (\d+)/.exec(header);
+      if (match === null) {
+        this.#buffer = this.#buffer.subarray(headerEnd + 4);
+        continue;
+      }
+      const length = parseInt(match[1], 10);
+      const bodyStart = headerEnd + 4;
+      if (this.#buffer.length < bodyStart + length) return;
+      const body = this.#buffer.subarray(bodyStart, bodyStart + length).toString("utf8");
+      this.#buffer = this.#buffer.subarray(bodyStart + length);
+      this.#dispatch(JSON.parse(body) as JsonRpcMessage);
+    }
+  }
+
+  #dispatch(msg: JsonRpcMessage): void {
+    if (msg.method === "textDocument/publishDiagnostics" && msg.params !== undefined) {
+      this.diagnostics.push(msg.params as { uri: string; diagnostics: ReadonlyArray<unknown> });
+      return;
+    }
+    if (typeof msg.id === "number") {
+      const pending = this.#pending.get(msg.id);
+      if (pending !== undefined) {
+        this.#pending.delete(msg.id);
+        if (msg.error !== undefined) pending.reject(msg.error);
+        else pending.resolve(msg.result);
+      }
+    }
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function main(): Promise<void> {
+  console.log("==> spawning LSP server:", LSP_BIN);
+  const client = new LspClient();
+
+  try {
+    console.log("==> sending initialize for", PACKAGE_ROOT);
+    const initResult = await client.send(
+      "initialize",
+      {
+        processId: process.pid,
+        capabilities: {},
+        rootUri: pathToFileURL(PACKAGE_ROOT).toString(),
+        workspaceFolders: [
+          { uri: pathToFileURL(PACKAGE_ROOT).toString(), name: "architecture-lsp" },
+        ],
+      },
+      true,
+    );
+    console.log("    initialize result:", JSON.stringify(initResult, null, 2).slice(0, 200), "...");
+    await client.send("initialized", {}, false);
+
+    const targets = [
+      "analyzer/index.ts",
+      "server/lsp-server.ts",
+      "server/workspace-engine.ts",
+      "server/diagnostic-converter.ts",
+    ];
+
+    for (const rel of targets) {
+      const filePath = path.join(PACKAGE_ROOT, rel);
+      const uri = pathToFileURL(filePath).toString();
+      console.log(`==> didOpen ${rel}`);
+      await client.send(
+        "textDocument/didOpen",
+        {
+          textDocument: {
+            uri,
+            languageId: "typescript",
+            version: 1,
+            text: "",
+          },
+        },
+        false,
+      );
+    }
+
+    // Wait for the analyzer's cold build + first batch of publishDiagnostics.
+    console.log("==> waiting up to 15s for diagnostics ...");
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline && client.diagnostics.length < targets.length) {
+      await sleep(200);
+    }
+
+    console.log(`\n==> received ${client.diagnostics.length} publishDiagnostics events:\n`);
+    for (const pub of client.diagnostics) {
+      const rel = path.relative(PACKAGE_ROOT, pub.uri.replace("file://", ""));
+      console.log(`  ${rel}: ${pub.diagnostics.length} diagnostics`);
+      for (const d of pub.diagnostics) {
+        const { code, message, severity } = d as { code: string; message: string; severity: number };
+        const sev = severity === 1 ? "ERROR" : "WARN";
+        console.log(`    [${sev}] ${code}`);
+        console.log(`           ${message.slice(0, 140)}${message.length > 140 ? "…" : ""}`);
+      }
+    }
+  } finally {
+    client.shutdown();
+  }
+}
+
+await main();

--- a/lsp/architecture/dogfood.ts
+++ b/lsp/architecture/dogfood.ts
@@ -9,7 +9,7 @@
 
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // `import.meta.dirname` resolves to `dist/` after `pnpm build`. The
 // LSP binary lives next to this script inside `dist/server/`; the
@@ -168,7 +168,7 @@ async function main(): Promise<void> {
 
     console.log(`\n==> received ${client.diagnostics.length} publishDiagnostics events:\n`);
     for (const pub of client.diagnostics) {
-      const rel = path.relative(PACKAGE_ROOT, pub.uri.replace("file://", ""));
+      const rel = path.relative(PACKAGE_ROOT, fileURLToPath(pub.uri));
       console.log(`  ${rel}: ${pub.diagnostics.length} diagnostics`);
       for (const d of pub.diagnostics) {
         const { code, message, severity } = d as { code: string; message: string; severity: number };

--- a/lsp/architecture/index.ts
+++ b/lsp/architecture/index.ts
@@ -1,9 +1,5 @@
 /**
- * @file Top-level barrel for the architecture LSP package. Exposes
- * the analyzer entry (`analyzeWorkspace`) for non-LSP callers (CI
- * shim, tests) and re-exports the diagnostic types so consumers
- * can type-check against the analyzer's output without reaching
- * into nested paths.
+ * @file Public entry for the architecture LSP package.
  */
 
 export { analyzeWorkspace } from "./analyzer/index.js";

--- a/lsp/architecture/index.ts
+++ b/lsp/architecture/index.ts
@@ -1,0 +1,22 @@
+/**
+ * @file Top-level barrel for the architecture LSP package. Exposes
+ * the analyzer entry (`analyzeWorkspace`) for non-LSP callers (CI
+ * shim, tests) and re-exports the diagnostic types so consumers
+ * can type-check against the analyzer's output without reaching
+ * into nested paths.
+ */
+
+export { analyzeWorkspace } from "./analyzer/index.js";
+export type {
+  ArchitectureDiagnostic,
+  ArchitectureDiagnosticRuleId,
+  ArchitectureOptionsInput,
+  ArchitectureReport,
+  ArchitectureSeverity,
+  ResolvedArchitectureOptions,
+} from "./analyzer/project/api/index.js";
+export {
+  ARCHITECTURE_DIAGNOSTIC_RULE_IDS,
+  ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID,
+  type ArchitectureRuleId,
+} from "./analyzer/rule-ids.js";

--- a/lsp/architecture/package.json
+++ b/lsp/architecture/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "pnpm clean && tsc",
+    "pretest": "pnpm build",
     "test": "vitest run",
     "dogfood": "pnpm build && node dist/dogfood.js"
   },

--- a/lsp/architecture/package.json
+++ b/lsp/architecture/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@safer-by-default/architecture-lsp",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Architecture analyzer + LSP server for safer-by-default. Single-process workspace-aware diagnostics for the architecture doctrine in PRINCIPLES.md.",
+  "type": "module",
+  "bin": {
+    "safer-architecture-lsp": "./dist/server/index.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "pnpm clean && tsc",
+    "test": "vitest run",
+    "dogfood": "pnpm build && node dist/dogfood.js"
+  },
+  "dependencies": {
+    "chokidar": "^5.0.0",
+    "effect": "^3.21.1",
+    "typescript": "^5.4.0",
+    "vscode-languageserver": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "fast-check": "^4.7.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/lsp/architecture/pnpm-lock.yaml
+++ b/lsp/architecture/pnpm-lock.yaml
@@ -1,0 +1,1013 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
+      effect:
+        specifier: ^3.21.1
+        version: 3.21.2
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+      vscode-languageserver:
+        specifier: ^9.0.1
+        version: 9.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
+      fast-check:
+        specifier: ^4.7.0
+        version: 4.8.0
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.19)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
+    engines: {node: '>=12.17.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pure-rand@8.4.0:
+    resolution: {integrity: sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.19))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.19)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fast-check@4.8.0:
+    dependencies:
+      pure-rand: 8.4.0
+
+  fsevents@2.3.3:
+    optional: true
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pure-rand@6.1.0: {}
+
+  pure-rand@8.4.0: {}
+
+  readdirp@5.0.0: {}
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@22.19.19):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.19)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.19):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.14
+      rollup: 4.60.4
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.19):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.19))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.19)
+      vite-node: 2.1.9(@types/node@22.19.19)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/lsp/architecture/server/diagnostic-converter.ts
+++ b/lsp/architecture/server/diagnostic-converter.ts
@@ -1,0 +1,67 @@
+/**
+ * @file Convert analyzer `ArchitectureDiagnostic` values into LSP
+ * `Diagnostic` values for `publishDiagnostics`. Architecture findings
+ * are file-level (not line-range-bound) — they map to the start of the
+ * file with `agent-code-guard` as the source and the rule id as the
+ * code. Editors group findings by `code` automatically.
+ */
+
+import { pathToFileURL } from "node:url";
+import {
+  type Diagnostic,
+  DiagnosticSeverity,
+} from "vscode-languageserver";
+import type { ArchitectureDiagnostic } from "../analyzer/project/api/index.js";
+import { ruleDocUrl } from "./rule-docs.js";
+
+const FILE_HEAD_RANGE = {
+  start: { line: 0, character: 0 },
+  end: { line: 0, character: 1 },
+};
+
+/**
+ * Convert one analyzer diagnostic to an LSP diagnostic. The
+ * `codeDescription.href` field is the editor-visible "Learn more"
+ * URL; it points at the rule's PRINCIPLES.md anchor.
+ * @param finding Analyzer's architecture diagnostic.
+ * @returns LSP diagnostic, pinned to the start of the file.
+ */
+export function toLspDiagnostic(finding: ArchitectureDiagnostic): Diagnostic {
+  return {
+    range: FILE_HEAD_RANGE,
+    severity:
+      finding.severity === "error"
+        ? DiagnosticSeverity.Error
+        : DiagnosticSeverity.Warning,
+    code: finding.ruleId,
+    codeDescription: { href: ruleDocUrl(finding.ruleId) },
+    source: "agent-code-guard",
+    message: finding.message,
+  };
+}
+
+function fileToUri(filePath: string): string {
+  return pathToFileURL(filePath).toString();
+}
+
+/**
+ * Group analyzer diagnostics by file URI. The LSP server publishes
+ * one `publishDiagnostics` per URI, so we batch findings here.
+ * @param findings Findings from one or more files.
+ * @returns Map of URI to LSP diagnostics for that URI.
+ */
+export function groupByUri(
+  findings: readonly ArchitectureDiagnostic[],
+): ReadonlyMap<string, readonly Diagnostic[]> {
+  const groups = new Map<string, Diagnostic[]>();
+  for (const finding of findings) {
+    const uri = fileToUri(finding.file);
+    let bucket = groups.get(uri);
+    if (bucket === undefined) {
+      bucket = [];
+      groups.set(uri, bucket);
+    }
+    bucket.push(toLspDiagnostic(finding));
+  }
+  return groups;
+}

--- a/lsp/architecture/server/diagnostic-converter.ts
+++ b/lsp/architecture/server/diagnostic-converter.ts
@@ -12,7 +12,7 @@ import {
   DiagnosticSeverity,
 } from "vscode-languageserver";
 import type { ArchitectureDiagnostic } from "../analyzer/project/api/index.js";
-import { ruleDocUrl } from "./rule-docs.js";
+import { ruleCodeDescription } from "./rule-docs.js";
 
 const FILE_HEAD_RANGE = {
   start: { line: 0, character: 0 },
@@ -34,28 +34,32 @@ export function toLspDiagnostic(finding: ArchitectureDiagnostic): Diagnostic {
         ? DiagnosticSeverity.Error
         : DiagnosticSeverity.Warning,
     code: finding.ruleId,
-    codeDescription: { href: ruleDocUrl(finding.ruleId) },
+    codeDescription: ruleCodeDescription(finding.ruleId),
     source: "agent-code-guard",
     message: finding.message,
   };
 }
 
-function fileToUri(filePath: string): string {
-  return pathToFileURL(filePath).toString();
-}
-
 /**
  * Group analyzer diagnostics by file URI. The LSP server publishes
- * one `publishDiagnostics` per URI, so we batch findings here.
+ * one `publishDiagnostics` per URI, so findings are batched here.
+ * Per-file URI conversion is memoized within the batch — architecture
+ * findings are file-level and the same file commonly carries
+ * findings from several rules.
  * @param findings Findings from one or more files.
  * @returns Map of URI to LSP diagnostics for that URI.
  */
 export function groupByUri(
   findings: readonly ArchitectureDiagnostic[],
 ): ReadonlyMap<string, readonly Diagnostic[]> {
+  const uriByFile = new Map<string, string>();
   const groups = new Map<string, Diagnostic[]>();
   for (const finding of findings) {
-    const uri = fileToUri(finding.file);
+    let uri = uriByFile.get(finding.file);
+    if (uri === undefined) {
+      uri = pathToFileURL(finding.file).toString();
+      uriByFile.set(finding.file, uri);
+    }
     let bucket = groups.get(uri);
     if (bucket === undefined) {
       bucket = [];

--- a/lsp/architecture/server/document-store.ts
+++ b/lsp/architecture/server/document-store.ts
@@ -1,0 +1,73 @@
+/**
+ * @file In-memory store of currently-open LSP documents. Tracks URI,
+ * version, text, and the workspace folder each document belongs to.
+ * Pure data plus Effect-wrapped accessors so the LSP handlers don't
+ * leak imperative state outside this module.
+ */
+
+import { Effect, Ref } from "effect";
+
+interface OpenDocument {
+  readonly uri: string;
+  readonly version: number;
+  readonly text: string;
+  readonly languageId: string;
+}
+
+export interface DocumentStore {
+  readonly open: (doc: OpenDocument) => Effect.Effect<void>;
+  readonly update: (
+    uri: string,
+    version: number,
+    text: string,
+  ) => Effect.Effect<void>;
+  readonly close: (uri: string) => Effect.Effect<void>;
+  readonly get: (uri: string) => Effect.Effect<OpenDocument | null>;
+  readonly listUris: () => Effect.Effect<readonly string[]>;
+}
+
+/**
+ * Build a fresh document store backed by an Effect `Ref`. Each
+ * accessor returns an Effect so the store is composable inside the
+ * LSP handler pipelines without leaking the underlying Map.
+ * @returns Effect producing a `DocumentStore`.
+ */
+export const makeDocumentStore = (): Effect.Effect<DocumentStore> =>
+  Effect.gen(function* () {
+    const ref = yield* Ref.make<ReadonlyMap<string, OpenDocument>>(new Map());
+
+    const open = (doc: OpenDocument): Effect.Effect<void> =>
+      Ref.update(ref, (map) => {
+        const next = new Map(map);
+        next.set(doc.uri, doc);
+        return next;
+      });
+
+    const update = (
+      uri: string,
+      version: number,
+      text: string,
+    ): Effect.Effect<void> =>
+      Ref.update(ref, (map) => {
+        const existing = map.get(uri);
+        if (existing === undefined) return map;
+        const next = new Map(map);
+        next.set(uri, { ...existing, version, text });
+        return next;
+      });
+
+    const close = (uri: string): Effect.Effect<void> =>
+      Ref.update(ref, (map) => {
+        const next = new Map(map);
+        next.delete(uri);
+        return next;
+      });
+
+    const get = (uri: string): Effect.Effect<OpenDocument | null> =>
+      Ref.get(ref).pipe(Effect.map((map) => map.get(uri) ?? null));
+
+    const listUris = (): Effect.Effect<readonly string[]> =>
+      Ref.get(ref).pipe(Effect.map((map) => [...map.keys()]));
+
+    return { open, update, close, get, listUris };
+  });

--- a/lsp/architecture/server/index.ts
+++ b/lsp/architecture/server/index.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * @file `agent-code-guard-lsp` CLI bin. Builds a stdio LSP connection,
+ * boots the Effect-shaped server inside `Effect.scoped`, and runs
+ * forever (until the parent process closes stdin/stdout).
+ */
+
+import { Effect } from "effect";
+import {
+  ProposedFeatures,
+  StreamMessageReader,
+  StreamMessageWriter,
+  createConnection,
+} from "vscode-languageserver/node.js";
+import { makeLspServer } from "./lsp-server.js";
+
+function reportFatal(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`[agent-code-guard-lsp] fatal: ${message}\n`);
+  process.exit(1);
+}
+
+function main(): void {
+  // Use explicit stream readers/writers on process stdio so the bin
+  // works under Claude Code's plugin runtime (which spawns us with
+  // no transport flags) and under direct invocation alike.
+  const connection = createConnection(
+    ProposedFeatures.all,
+    new StreamMessageReader(process.stdin),
+    new StreamMessageWriter(process.stdout),
+  );
+  // Effect.scoped owns the workspace engines' watchers + caches; when
+  // the parent process closes stdio Node exits and the scope's
+  // finalizers run for cleanup.
+  Effect.runPromise(Effect.scoped(makeLspServer(connection))).catch(reportFatal);
+}
+
+main();

--- a/lsp/architecture/server/lsp-server.ts
+++ b/lsp/architecture/server/lsp-server.ts
@@ -1,0 +1,248 @@
+/**
+ * @file Stdio LSP server entry. Builds a vscode-languageserver
+ * `Connection`, registers handlers wired through Effect so the
+ * `WorkspaceEngine` (and its `Scope`-managed watcher + cache) live
+ * inside the Effect runtime. The server stays up until the parent
+ * process closes stdio; the ambient `Scope` releases every workspace
+ * engine on shutdown.
+ *
+ * V1 scope: save-time analysis. `didChange` updates the document
+ * store but doesn't re-lint; `didSave` clears the cache and republishes.
+ * The chokidar watcher catches out-of-band edits (git checkouts,
+ * external tools) and the invalidations stream triggers a republish.
+ * Live edit-in-flight diagnostics (TS LanguageService overlay) is
+ * deferred to a follow-up.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Deferred, Effect, Scope, Stream } from "effect";
+import {
+  type Connection,
+  type InitializeParams,
+  type InitializeResult,
+  type PublishDiagnosticsParams,
+  TextDocumentSyncKind,
+} from "vscode-languageserver";
+import { clearWorkspaceCache } from "../analyzer/project/cache/index.js";
+import { groupByUri } from "./diagnostic-converter.js";
+import { type DocumentStore, makeDocumentStore } from "./document-store.js";
+import { type WorkspaceEngine } from "./workspace-engine.js";
+import { type WorkspaceRegistry, makeWorkspaceRegistry } from "./workspace-registry.js";
+
+interface ServerDeps {
+  readonly connection: Connection;
+  readonly docs: DocumentStore;
+  readonly registry: WorkspaceRegistry;
+
+  /**
+   * Resolves after the workspaces named in `initialize.workspaceFolders`
+   * have been registered. Every text-document handler awaits this so
+   * a `didOpen` arriving before registration completes still publishes
+   * diagnostics once the engine exists.
+   */
+  readonly ready: Deferred.Deferred<void>;
+}
+
+const findEngineForUri = (
+  registry: WorkspaceRegistry,
+  uri: string,
+): Effect.Effect<WorkspaceEngine | null> =>
+  Effect.gen(function* () {
+    const filePath = fileURLToPath(uri);
+    const roots = yield* registry.listProjectRoots();
+    // Pick the longest matching project root so nested workspaces map
+    // to the most specific one.
+    let best: { root: string; len: number } | null = null;
+    for (const root of roots) {
+      if (!filePath.startsWith(root + path.sep) && filePath !== root) continue;
+      if (best === null || root.length > best.len) best = { root, len: root.length };
+    }
+    if (best === null) return null;
+    return yield* registry.findByProjectRoot(best.root);
+  });
+
+const publishForUris = (
+  deps: ServerDeps,
+  engine: WorkspaceEngine,
+  uris: readonly string[],
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const filePaths = uris.map((uri) => fileURLToPath(uri));
+    const findings = yield* engine.lintPaths(filePaths).pipe(
+      Effect.catchAll(() => Effect.succeed([])),
+    );
+    const grouped = groupByUri(findings);
+    for (const uri of uris) {
+      const diagnostics = [...(grouped.get(uri) ?? [])];
+      yield* Effect.sync(() => {
+        const params: PublishDiagnosticsParams = { uri, diagnostics };
+        deps.connection.sendDiagnostics(params);
+      });
+    }
+  });
+
+const publishAllOpen = (
+  deps: ServerDeps,
+  engine: WorkspaceEngine,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const allUris = yield* deps.docs.listUris();
+    const inWorkspace: string[] = [];
+    for (const uri of allUris) {
+      const filePath = fileURLToPath(uri);
+      if (
+        filePath === engine.projectRoot ||
+        filePath.startsWith(engine.projectRoot + path.sep)
+      ) {
+        inWorkspace.push(uri);
+      }
+    }
+    if (inWorkspace.length > 0) yield* publishForUris(deps, engine, inWorkspace);
+  });
+
+const handleInitialize = (params: InitializeParams): InitializeResult => ({
+  capabilities: {
+    textDocumentSync: {
+      openClose: true,
+      change: TextDocumentSyncKind.Incremental,
+      save: { includeText: false },
+    },
+    workspace: {
+      workspaceFolders: {
+        supported: true,
+        changeNotifications: true,
+      },
+    },
+  },
+  serverInfo: { name: "agent-code-guard", version: "0.1.0" },
+});
+
+const registerInitialWorkspaces = (
+  deps: ServerDeps,
+  params: InitializeParams,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const folders = params.workspaceFolders ?? [];
+    for (const folder of folders) {
+      const root = fileURLToPath(folder.uri);
+      const engine = yield* deps.registry.register(root);
+      // Re-publish for any docs in this workspace when its watcher fires.
+      yield* Effect.forkScoped(
+        Stream.runForEach(engine.invalidations, () => publishAllOpen(deps, engine)),
+      );
+    }
+  });
+
+const handleDidOpen = (
+  deps: ServerDeps,
+  td: { uri: string; languageId: string; version: number; text: string },
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* deps.docs.open(td);
+    yield* Deferred.await(deps.ready);
+    const engine = yield* findEngineForUri(deps.registry, td.uri);
+    if (engine === null) return;
+    yield* publishForUris(deps, engine, [td.uri]);
+  });
+
+const handleDidSave = (
+  deps: ServerDeps,
+  uri: string,
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* Deferred.await(deps.ready);
+    const engine = yield* findEngineForUri(deps.registry, uri);
+    if (engine === null) return;
+    // Force-invalidate so the next lint sees the saved content, even
+    // if the watcher is slower than our handler.
+    yield* Effect.sync(() => clearWorkspaceCache(engine.projectRoot));
+    yield* publishAllOpen(deps, engine);
+  });
+
+const handleDidClose = (deps: ServerDeps, uri: string): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* deps.docs.close(uri);
+    yield* Effect.sync(() => {
+      deps.connection.sendDiagnostics({ uri, diagnostics: [] });
+    });
+  });
+
+const setupTextHandlers = (deps: ServerDeps): void => {
+  deps.connection.onInitialized(() => {
+    // Initial workspace registration is wired in the Effect program
+    // (see makeLspServer). Nothing to do here yet.
+  });
+
+  deps.connection.onDidOpenTextDocument((params) => {
+    Effect.runFork(handleDidOpen(deps, params.textDocument));
+  });
+
+  deps.connection.onDidChangeTextDocument((params) => {
+    const last = params.contentChanges.at(-1);
+    if (last === undefined || !("text" in last)) return;
+    // V1: update the document store but don't re-analyze on every
+    // keystroke. Live overlay diagnostics is a follow-up.
+    Effect.runFork(
+      deps.docs.update(params.textDocument.uri, params.textDocument.version, last.text),
+    );
+  });
+
+  deps.connection.onDidSaveTextDocument((params) => {
+    Effect.runFork(handleDidSave(deps, params.textDocument.uri));
+  });
+
+  deps.connection.onDidCloseTextDocument((params) => {
+    Effect.runFork(handleDidClose(deps, params.textDocument.uri));
+  });
+};
+
+/**
+ * Build the LSP server. Returns an Effect that resolves when the
+ * server has bound its handlers and started listening on the supplied
+ * connection. The Effect stays alive (Effect.never) so the ambient
+ * `Scope` keeps every workspace engine alive until shutdown.
+ * @param connection vscode-languageserver Connection (stdio in
+ * production, in-memory for tests).
+ * @returns Long-running Effect requiring a `Scope`.
+ */
+export const makeLspServer = (
+  connection: Connection,
+): Effect.Effect<void, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const docs = yield* makeDocumentStore();
+    const registry = yield* makeWorkspaceRegistry();
+    const ready = yield* Deferred.make<void>();
+    const deps: ServerDeps = { connection, docs, registry, ready };
+
+    // Capture initialize params so we can register workspaces inside
+    // the Effect runtime (so engines join the ambient scope).
+    let initParams: InitializeParams | null = null;
+    yield* Effect.sync(() => {
+      connection.onInitialize((params) => {
+        initParams = params;
+        return handleInitialize(params);
+      });
+    });
+
+    setupTextHandlers(deps);
+
+    yield* Effect.sync(() => connection.listen());
+
+    // Poll for initialize to arrive, then register workspaces under
+    // the ambient Scope so engines release on server shutdown.
+    // Resolve `ready` once registration completes so handlers waiting
+    // on it can proceed.
+    yield* Effect.forkScoped(
+      Effect.gen(function* () {
+        while (initParams === null) {
+          yield* Effect.sleep("50 millis");
+        }
+        yield* registerInitialWorkspaces(deps, initParams);
+        yield* Deferred.succeed(ready, undefined);
+      }),
+    );
+
+    yield* Effect.never;
+  }).pipe(Effect.withSpan("makeLspServer"));
+

--- a/lsp/architecture/server/rule-docs.ts
+++ b/lsp/architecture/server/rule-docs.ts
@@ -1,0 +1,73 @@
+/**
+ * @file Per-rule PRINCIPLES.md anchors. Each architecture rule
+ * projects from one or two principles; the diagnostic-converter
+ * surfaces this as `codeDescription.href` so the editor's "Learn
+ * more" UI links to the canonical doctrine entry.
+ *
+ * URLs pin to `main` so anchors auto-resolve as PRINCIPLES.md
+ * evolves. The anchor slugs follow GitHub's heading-to-anchor
+ * algorithm: lowercase, spaces and dots become hyphens, all other
+ * non-alphanumeric characters are stripped. Verified against the
+ * current PRINCIPLES.md headings.
+ */
+
+import type { ArchitectureRuleId } from "../analyzer/rule-ids.js";
+
+const PRINCIPLES_BASE =
+  "https://github.com/chughtapan/safer-by-default/blob/main/PRINCIPLES.md";
+
+// PRINCIPLES.md heading anchors. Names match the principle numbers
+// 1-8 plus auxiliary sections used by the architecture taxonomy.
+const ANCHOR_VALIDATE_BOUNDARY = "#2-validate-at-every-boundary--schemas-where-data-enters-types-inside";
+const ANCHOR_DISCIPLINE = "#5-discipline-over-capability";
+const ANCHOR_BUDGET_GATE = "#6-the-budget-gate--scope-is-a-hard-budget";
+const ANCHOR_RATCHET = "#8-the-ratchet--escalate-up-not-around";
+
+/**
+ * Map every architecture rule id to the PRINCIPLES.md anchor that
+ * names the doctrine it enforces. Architecture rules are mostly
+ * projections of the discipline section (Principles 5-8) plus the
+ * boundary-validation principle (2) for vendor-type leak rules.
+ *
+ * The directive-parse pseudo-rule points at the discipline anchor
+ * because malformed directives are a discipline failure (an unanchored
+ * suppression bypassing the architecture contract).
+ */
+const ARCHITECTURE_RULE_ANCHORS: Readonly<Record<ArchitectureRuleId, string>> = {
+  "no-inventory-barrel": ANCHOR_DISCIPLINE,
+  "no-internal-subpath-export": ANCHOR_DISCIPLINE,
+  "no-public-vendor-type-leak": ANCHOR_VALIDATE_BOUNDARY,
+  "no-export-star-boundary": ANCHOR_DISCIPLINE,
+  "no-folder-cycle": ANCHOR_RATCHET,
+  "no-root-internal-cycle": ANCHOR_RATCHET,
+  "no-large-public-surface": ANCHOR_BUDGET_GATE,
+  "no-cross-domain-sibling-import": ANCHOR_RATCHET,
+  "no-upward-layer-import": ANCHOR_RATCHET,
+  "no-public-test-helper-leak": ANCHOR_DISCIPLINE,
+  "no-implementation-file-public-entry": ANCHOR_DISCIPLINE,
+  "no-public-infra-type-leak": ANCHOR_VALIDATE_BOUNDARY,
+  "no-package-mesh": ANCHOR_RATCHET,
+  "no-large-folder": ANCHOR_BUDGET_GATE,
+  "folder-readme-required": ANCHOR_DISCIPLINE,
+  "no-distant-folder-import": ANCHOR_RATCHET,
+  "require-curated-public-facade": ANCHOR_DISCIPLINE,
+  "require-boundary-owned-types": ANCHOR_VALIDATE_BOUNDARY,
+  "folder-explicit-api-required": ANCHOR_BUDGET_GATE,
+  "file-implicit-boundary-module": ANCHOR_BUDGET_GATE,
+  "shared-kernel-cohesion": ANCHOR_DISCIPLINE,
+  "no-trivial-sink-file": ANCHOR_DISCIPLINE,
+  "no-fat-orchestrator": ANCHOR_DISCIPLINE,
+  "architecture-directive-parse-error": ANCHOR_DISCIPLINE,
+};
+
+/**
+ * Build the PRINCIPLES.md URL for the doctrine entry a given
+ * architecture rule enforces. Unknown rule ids fall back to the
+ * PRINCIPLES.md root — every architecture finding carries an
+ * actionable link.
+ */
+export function ruleDocUrl(ruleId: string): string {
+  const anchor = ARCHITECTURE_RULE_ANCHORS[ruleId as ArchitectureRuleId];
+  if (anchor === undefined) return PRINCIPLES_BASE;
+  return `${PRINCIPLES_BASE}${anchor}`;
+}

--- a/lsp/architecture/server/rule-docs.ts
+++ b/lsp/architecture/server/rule-docs.ts
@@ -1,14 +1,8 @@
 /**
- * @file Per-rule PRINCIPLES.md anchors. Each architecture rule
- * projects from one or two principles; the diagnostic-converter
- * surfaces this as `codeDescription.href` so the editor's "Learn
- * more" UI links to the canonical doctrine entry.
- *
- * URLs pin to `main` so anchors auto-resolve as PRINCIPLES.md
- * evolves. The anchor slugs follow GitHub's heading-to-anchor
- * algorithm: lowercase, spaces and dots become hyphens, all other
- * non-alphanumeric characters are stripped. Verified against the
- * current PRINCIPLES.md headings.
+ * @file Per-rule PRINCIPLES.md anchors. URLs pin to `main` so the
+ * anchor resolves against the current heading text; the slug follows
+ * GitHub's heading-to-anchor algorithm (lowercase, spaces and dots
+ * to hyphens, drop other non-alphanumeric).
  */
 
 import type { ArchitectureRuleId } from "../analyzer/rule-ids.js";
@@ -16,58 +10,69 @@ import type { ArchitectureRuleId } from "../analyzer/rule-ids.js";
 const PRINCIPLES_BASE =
   "https://github.com/chughtapan/safer-by-default/blob/main/PRINCIPLES.md";
 
-// PRINCIPLES.md heading anchors. Names match the principle numbers
-// 1-8 plus auxiliary sections used by the architecture taxonomy.
-const ANCHOR_VALIDATE_BOUNDARY = "#2-validate-at-every-boundary--schemas-where-data-enters-types-inside";
-const ANCHOR_DISCIPLINE = "#5-discipline-over-capability";
-const ANCHOR_BUDGET_GATE = "#6-the-budget-gate--scope-is-a-hard-budget";
-const ANCHOR_RATCHET = "#8-the-ratchet--escalate-up-not-around";
-
-/**
- * Map every architecture rule id to the PRINCIPLES.md anchor that
- * names the doctrine it enforces. Architecture rules are mostly
- * projections of the discipline section (Principles 5-8) plus the
- * boundary-validation principle (2) for vendor-type leak rules.
- *
- * The directive-parse pseudo-rule points at the discipline anchor
- * because malformed directives are a discipline failure (an unanchored
- * suppression bypassing the architecture contract).
- */
+/** PRINCIPLES.md anchor for each architecture rule. */
 const ARCHITECTURE_RULE_ANCHORS: Readonly<Record<ArchitectureRuleId, string>> = {
-  "no-inventory-barrel": ANCHOR_DISCIPLINE,
-  "no-internal-subpath-export": ANCHOR_DISCIPLINE,
-  "no-public-vendor-type-leak": ANCHOR_VALIDATE_BOUNDARY,
-  "no-export-star-boundary": ANCHOR_DISCIPLINE,
-  "no-folder-cycle": ANCHOR_RATCHET,
-  "no-root-internal-cycle": ANCHOR_RATCHET,
-  "no-large-public-surface": ANCHOR_BUDGET_GATE,
-  "no-cross-domain-sibling-import": ANCHOR_RATCHET,
-  "no-upward-layer-import": ANCHOR_RATCHET,
-  "no-public-test-helper-leak": ANCHOR_DISCIPLINE,
-  "no-implementation-file-public-entry": ANCHOR_DISCIPLINE,
-  "no-public-infra-type-leak": ANCHOR_VALIDATE_BOUNDARY,
-  "no-package-mesh": ANCHOR_RATCHET,
-  "no-large-folder": ANCHOR_BUDGET_GATE,
-  "folder-readme-required": ANCHOR_DISCIPLINE,
-  "no-distant-folder-import": ANCHOR_RATCHET,
-  "require-curated-public-facade": ANCHOR_DISCIPLINE,
-  "require-boundary-owned-types": ANCHOR_VALIDATE_BOUNDARY,
-  "folder-explicit-api-required": ANCHOR_BUDGET_GATE,
-  "file-implicit-boundary-module": ANCHOR_BUDGET_GATE,
-  "shared-kernel-cohesion": ANCHOR_DISCIPLINE,
-  "no-trivial-sink-file": ANCHOR_DISCIPLINE,
-  "no-fat-orchestrator": ANCHOR_DISCIPLINE,
-  "architecture-directive-parse-error": ANCHOR_DISCIPLINE,
+  "no-inventory-barrel": "#5-discipline-over-capability",
+  "no-internal-subpath-export": "#5-discipline-over-capability",
+  "no-public-vendor-type-leak": "#2-validate-at-every-boundary--schemas-where-data-enters-types-inside",
+  "no-export-star-boundary": "#5-discipline-over-capability",
+  "no-folder-cycle": "#8-the-ratchet--escalate-up-not-around",
+  "no-root-internal-cycle": "#8-the-ratchet--escalate-up-not-around",
+  "no-large-public-surface": "#6-the-budget-gate--scope-is-a-hard-budget",
+  "no-cross-domain-sibling-import": "#8-the-ratchet--escalate-up-not-around",
+  "no-upward-layer-import": "#8-the-ratchet--escalate-up-not-around",
+  "no-public-test-helper-leak": "#5-discipline-over-capability",
+  "no-implementation-file-public-entry": "#5-discipline-over-capability",
+  "no-public-infra-type-leak": "#2-validate-at-every-boundary--schemas-where-data-enters-types-inside",
+  "no-package-mesh": "#8-the-ratchet--escalate-up-not-around",
+  "no-large-folder": "#6-the-budget-gate--scope-is-a-hard-budget",
+  "folder-readme-required": "#5-discipline-over-capability",
+  "no-distant-folder-import": "#8-the-ratchet--escalate-up-not-around",
+  "require-curated-public-facade": "#5-discipline-over-capability",
+  "require-boundary-owned-types": "#2-validate-at-every-boundary--schemas-where-data-enters-types-inside",
+  "folder-explicit-api-required": "#6-the-budget-gate--scope-is-a-hard-budget",
+  "file-implicit-boundary-module": "#6-the-budget-gate--scope-is-a-hard-budget",
+  "shared-kernel-cohesion": "#5-discipline-over-capability",
+  "no-trivial-sink-file": "#5-discipline-over-capability",
+  "no-fat-orchestrator": "#5-discipline-over-capability",
+  "architecture-directive-parse-error": "#5-discipline-over-capability",
 };
 
+const FALLBACK_CODE_DESCRIPTION: { readonly href: string } = Object.freeze({
+  href: PRINCIPLES_BASE,
+});
+
+/** Pre-built frozen `codeDescription` per rule id. */
+const ARCHITECTURE_RULE_CODE_DESCRIPTIONS: Readonly<
+  Record<ArchitectureRuleId, { readonly href: string }>
+> = Object.freeze(
+  Object.fromEntries(
+    Object.entries(ARCHITECTURE_RULE_ANCHORS).map(([id, anchor]) => [
+      id,
+      Object.freeze({ href: `${PRINCIPLES_BASE}${anchor}` }),
+    ]),
+  ) as Record<ArchitectureRuleId, { readonly href: string }>,
+);
+
 /**
- * Build the PRINCIPLES.md URL for the doctrine entry a given
- * architecture rule enforces. Unknown rule ids fall back to the
- * PRINCIPLES.md root — every architecture finding carries an
- * actionable link.
+ * PRINCIPLES.md URL for the doctrine entry a given architecture rule
+ * enforces. Unknown rule ids fall back to the PRINCIPLES.md root.
+ * The parameter is `string` because the analyzer's
+ * `ArchitectureDiagnostic.ruleId` is `string`; exhaustiveness is
+ * enforced by `ARCHITECTURE_RULE_ANCHORS`' `Record<ArchitectureRuleId,
+ * …>` type, which fails compilation if a rule id added to
+ * `rule-ids.ts` is missing an anchor.
  */
 export function ruleDocUrl(ruleId: string): string {
-  const anchor = ARCHITECTURE_RULE_ANCHORS[ruleId as ArchitectureRuleId];
-  if (anchor === undefined) return PRINCIPLES_BASE;
-  return `${PRINCIPLES_BASE}${anchor}`;
+  return ruleCodeDescription(ruleId).href;
+}
+
+/** `codeDescription` for `ruleId`. Returns a shared frozen object. */
+export function ruleCodeDescription(
+  ruleId: string,
+): { readonly href: string } {
+  return (
+    ARCHITECTURE_RULE_CODE_DESCRIPTIONS[ruleId as ArchitectureRuleId] ??
+    FALLBACK_CODE_DESCRIPTION
+  );
 }

--- a/lsp/architecture/server/test-support/fixtures.ts
+++ b/lsp/architecture/server/test-support/fixtures.ts
@@ -1,0 +1,86 @@
+/**
+ * @file Plain-Node fixture helpers for engine tests. Lives outside
+ * the Effect-shaped test file so the lint rule that flags raw
+ * `node:fs` in Effect files doesn't trip on temp-dir scaffolding.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const tempDirs = new Set<string>();
+
+/**
+ * Create a temp dir with a minimal TS project the analyzer can lint.
+ * @returns The absolute project root.
+ */
+export function makeFixtureProject(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-engine-"));
+  tempDirs.add(root);
+  writeFixtureProject(root);
+  return root;
+}
+
+/**
+ * Remove every fixture dir created during this test run. Tests call
+ * this in `afterEach` so temp dirs don't leak.
+ */
+export function cleanupFixtures(): void {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+}
+
+/**
+ * Append a write to one of the fixture project's source files. Used
+ * to trigger watcher events.
+ * @param projectRoot Absolute project root from `makeFixtureProject`.
+ * @param relativePath Path under the project root (e.g. `src/m0.ts`).
+ * @param contents File contents to write.
+ */
+export function writeFile(projectRoot: string, relativePath: string, contents: string): void {
+  fs.writeFileSync(path.join(projectRoot, relativePath), contents);
+}
+
+function writeFixtureProject(projectRoot: string): void {
+  fs.writeFileSync(
+    path.join(projectRoot, "package.json"),
+    JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(projectRoot, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        strict: true,
+        skipLibCheck: true,
+        declaration: true,
+        outDir: "./dist",
+        rootDir: "./src",
+      },
+      include: ["src/**/*"],
+    }),
+  );
+  fs.mkdirSync(path.join(projectRoot, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectRoot, "src", "index.ts"),
+    [
+      'export { M0 } from "./m0.js";',
+      'export { M1 } from "./m1.js";',
+      'export { M2 } from "./m2.js";',
+      'export { M3 } from "./m3.js";',
+    ].join("\n"),
+  );
+  for (let i = 0; i < 4; i += 1) {
+    fs.writeFileSync(
+      path.join(projectRoot, "src", `m${i}.ts`),
+      `export const M${i} = ${i};\n`,
+    );
+  }
+}

--- a/lsp/architecture/server/workspace-engine.ts
+++ b/lsp/architecture/server/workspace-engine.ts
@@ -1,0 +1,183 @@
+/**
+ * @file Long-lived per-workspace engine that the LSP server consumes.
+ * Effect-shaped: the file watcher and PubSub are acquired through a
+ * `Scope` (callers wrap with `Effect.scoped` so the engine cannot leak
+ * resources), and `lintPaths` returns an `Effect` so callers can
+ * compose it with the rest of the LSP pipeline. Wraps the
+ * `WorkspaceCache` (Phase 5b) without changing it.
+ */
+
+import path from "node:path";
+import { type FSWatcher, watch as chokidarWatch } from "chokidar";
+import { Data, Effect, PubSub, Scope, Stream } from "effect";
+import type ts from "typescript";
+import {
+  clearWorkspaceCache,
+  getOrCreateWorkspaceCache,
+} from "../analyzer/project/cache/index.js";
+import type {
+  ArchitectureDiagnostic,
+  ResolvedArchitectureOptions,
+} from "../analyzer/project/api/index.js";
+
+/** Tag for engine-internal failure modes. */
+export class WorkspaceEngineError extends Data.TaggedError("WorkspaceEngineError")<{
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+const IGNORED_SEGMENTS = ["node_modules", ".cache", "dist", "coverage"];
+const ANALYZER_INPUT_SUFFIXES = [".ts", ".tsx", ".mts", ".cts"];
+const ANALYZER_INPUT_BASENAMES = new Set(["package.json"]);
+const TSCONFIG_PREFIX = "tsconfig";
+
+function isIgnoredPath(filePath: string): boolean {
+  for (const segment of IGNORED_SEGMENTS) {
+    if (filePath.includes(`${path.sep}${segment}${path.sep}`)) return true;
+    if (filePath.endsWith(`${path.sep}${segment}`)) return true;
+  }
+  return false;
+}
+
+function isAnalyzerInput(filePath: string): boolean {
+  const base = path.basename(filePath);
+  if (ANALYZER_INPUT_BASENAMES.has(base)) return true;
+  if (base.startsWith(TSCONFIG_PREFIX) && base.endsWith(".json")) return true;
+  for (const suffix of ANALYZER_INPUT_SUFFIXES) {
+    if (base.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+/** Public surface of the engine. Created via `makeWorkspaceEngine`. */
+export interface WorkspaceEngine {
+  /**
+   * Look up diagnostics for the requested files. Hits the workspace
+   * cache (Phase 5b) and filters `diagnosticsByFile` to the requested
+   * set so the caller can `publishDiagnostics` per file.
+   * @param paths Absolute file paths.
+   * @param programProvider Optional `ts.Program` source (LSP
+   * `LanguageService` for overlay support).
+   * @param programFingerprint Required when `programProvider` is
+   * supplied; stable identifier of the program (e.g., monotonic LSP
+   * version) so overlay reports don't collide with the disk-backed one.
+   */
+  readonly lintPaths: (
+    paths: readonly string[],
+    programProvider?: () => ts.Program | null,
+    programFingerprint?: string,
+  ) => Effect.Effect<readonly ArchitectureDiagnostic[], WorkspaceEngineError>;
+
+  /**
+   * Stream of cache-invalidation signals. The cache is already cleared
+   * by the time a value is emitted; subscribers should re-publish
+   * diagnostics for their open documents.
+   */
+  readonly invalidations: Stream.Stream<void>;
+
+  /** Absolute project root this engine is scoped to. */
+  readonly projectRoot: string;
+}
+
+const acquireWatcher = (
+  projectRoot: string,
+): Effect.Effect<FSWatcher, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.async<FSWatcher>((resume) => {
+      // chokidar 5.x dropped glob support: watch the project root
+      // recursively and filter events in the listener instead.
+      const w = chokidarWatch(projectRoot, {
+        ignored: (filePath: string): boolean => isIgnoredPath(filePath),
+        ignoreInitial: true,
+        persistent: true,
+      });
+      w.on("ready", () => resume(Effect.succeed(w)));
+    }),
+    (w) =>
+      Effect.tryPromise({
+        try: () => w.close(),
+        catch: (cause) =>
+          new WorkspaceEngineError({ message: "watcher.close failed", cause }),
+      }).pipe(Effect.orDie),
+  );
+
+const wireWatcherToPubSub = (
+  watcher: FSWatcher,
+  pubsub: PubSub.PubSub<void>,
+  projectRoot: string,
+): void => {
+  const onChange = (filePath: string): void => {
+    if (!isAnalyzerInput(filePath)) return;
+    clearWorkspaceCache(projectRoot);
+    Effect.runFork(PubSub.publish(pubsub, undefined));
+  };
+  watcher.on("change", onChange);
+  watcher.on("add", onChange);
+  watcher.on("unlink", onChange);
+};
+
+const buildLintPaths =
+  (options: ResolvedArchitectureOptions) =>
+  (
+    paths: readonly string[],
+    programProvider?: () => ts.Program | null,
+    programFingerprint?: string,
+  ): Effect.Effect<readonly ArchitectureDiagnostic[], WorkspaceEngineError> =>
+    Effect.try({
+      try: () => {
+        const cache = getOrCreateWorkspaceCache(options.projectRoot);
+        const report = cache.get(options, programProvider, programFingerprint);
+        const found: ArchitectureDiagnostic[] = [];
+        for (const filePath of paths) {
+          const findings = report.diagnosticsByFile.get(path.resolve(filePath));
+          if (findings !== undefined) found.push(...findings);
+        }
+        return found;
+      },
+      catch: (cause) =>
+        new WorkspaceEngineError({
+          message: `lintPaths failed for ${options.projectRoot}`,
+          cause,
+        }),
+    });
+
+/**
+ * Acquire a workspace engine. The returned `Effect` requires a `Scope`
+ * (callers compose with `Effect.scoped` or a `Layer.scoped`); closing
+ * the scope releases the watcher and the PubSub, and clears this
+ * workspace's cache. No manual `dispose()` to forget.
+ * @param options Resolved architecture options for this workspace.
+ * @returns Effect producing the engine; depends on a Scope.
+ */
+export const makeWorkspaceEngine = (
+  options: ResolvedArchitectureOptions,
+): Effect.Effect<WorkspaceEngine, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const pubsub = yield* PubSub.unbounded<void>();
+    const watcher = yield* acquireWatcher(options.projectRoot);
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => clearWorkspaceCache(options.projectRoot)),
+    );
+    wireWatcherToPubSub(watcher, pubsub, options.projectRoot);
+    return {
+      projectRoot: options.projectRoot,
+      invalidations: Stream.fromPubSub(pubsub),
+      lintPaths: buildLintPaths(options),
+    };
+  }).pipe(Effect.withSpan("makeWorkspaceEngine"));
+
+/**
+ * Run an Effect with an engine acquired and released around it. The
+ * engine is built fresh, used by `use`, then disposed when the inner
+ * Effect resolves. Convenience over `Effect.scoped(makeWorkspaceEngine(…))`
+ * for one-shot callers (CLI tools, integration tests) that don't hold
+ * the engine across multiple operations.
+ * @param options Resolved architecture options for the workspace.
+ * @param use Function consuming the engine.
+ * @returns Effect with the engine's lifetime scoped to `use`.
+ */
+export const withWorkspaceEngine = <A, E, R>(
+  options: ResolvedArchitectureOptions,
+  use: (engine: WorkspaceEngine) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | WorkspaceEngineError, Exclude<R, Scope.Scope>> =>
+  Effect.scoped(Effect.flatMap(makeWorkspaceEngine(options), use));

--- a/lsp/architecture/server/workspace-registry.ts
+++ b/lsp/architecture/server/workspace-registry.ts
@@ -1,0 +1,101 @@
+/**
+ * @file Per-LSP-process registry of `WorkspaceEngine` instances. The
+ * LSP server registers one engine per workspace folder; this module
+ * memoizes engines on `projectRoot` so reopening a folder reuses the
+ * existing engine + cache.
+ *
+ * V1 design: engines live for the registry's `Scope` lifetime (i.e.,
+ * the LSP process). Per-workspace teardown via `unregister` is a
+ * follow-up — the LSP doesn't yet send `workspace/didChangeWorkspaceFolders`
+ * for removals in a way that warrants the scope-fork complexity.
+ */
+
+import { Effect, Ref, Scope } from "effect";
+import { resolveArchitectureOptions, type ArchitectureOptionsInput } from "../analyzer/project/api/index.js";
+import { type WorkspaceEngine, makeWorkspaceEngine } from "./workspace-engine.js";
+
+type EngineMap = ReadonlyMap<string, WorkspaceEngine>;
+
+function lookupEngine(map: EngineMap, projectRoot: string): WorkspaceEngine | undefined {
+  return map.get(projectRoot);
+}
+
+function insertEngine(
+  map: EngineMap,
+  projectRoot: string,
+  engine: WorkspaceEngine,
+): EngineMap {
+  const next = new Map(map);
+  next.set(projectRoot, engine);
+  return next;
+}
+
+function makeInserter(
+  projectRoot: string,
+  engine: WorkspaceEngine,
+): (map: EngineMap) => EngineMap {
+  return (map) => insertEngine(map, projectRoot, engine);
+}
+
+function makeLookup(projectRoot: string): (map: EngineMap) => WorkspaceEngine | null {
+  return (map) => lookupOrNull(map, projectRoot);
+}
+
+function lookupOrNull(map: EngineMap, projectRoot: string): WorkspaceEngine | null {
+  return map.get(projectRoot) ?? null;
+}
+
+function listKeys(map: EngineMap): readonly string[] {
+  return [...map.keys()];
+}
+
+export interface WorkspaceRegistry {
+  readonly register: (
+    projectRoot: string,
+    options?: ArchitectureOptionsInput,
+  ) => Effect.Effect<WorkspaceEngine, never, Scope.Scope>;
+
+  readonly findByProjectRoot: (
+    projectRoot: string,
+  ) => Effect.Effect<WorkspaceEngine | null>;
+
+  readonly listProjectRoots: () => Effect.Effect<readonly string[]>;
+}
+
+/**
+ * Build a registry whose engines share the ambient `Scope`. All
+ * registered engines release when that scope closes — which for the
+ * LSP server is process exit.
+ * @returns Effect producing the registry.
+ */
+export const makeWorkspaceRegistry = (): Effect.Effect<WorkspaceRegistry> =>
+  Effect.gen(function* () {
+    const ref = yield* Ref.make<ReadonlyMap<string, WorkspaceEngine>>(new Map());
+
+    const register = (
+      projectRoot: string,
+      options?: ArchitectureOptionsInput,
+    ): Effect.Effect<WorkspaceEngine, never, Scope.Scope> =>
+      Effect.gen(function* () {
+        const map = yield* Ref.get(ref);
+        const existing = lookupEngine(map, projectRoot);
+        if (existing !== undefined) return existing;
+        const resolved = resolveArchitectureOptions({
+          ...(options ?? {}),
+          projectRoot,
+        });
+        const engine = yield* makeWorkspaceEngine(resolved);
+        yield* Ref.update(ref, makeInserter(projectRoot, engine));
+        return engine;
+      });
+
+    const findByProjectRoot = (
+      projectRoot: string,
+    ): Effect.Effect<WorkspaceEngine | null> =>
+      Effect.map(Ref.get(ref), makeLookup(projectRoot));
+
+    const listProjectRoots = (): Effect.Effect<readonly string[]> =>
+      Effect.map(Ref.get(ref), listKeys);
+
+    return { register, findByProjectRoot, listProjectRoots };
+  });

--- a/lsp/architecture/tests/check.test.ts
+++ b/lsp/architecture/tests/check.test.ts
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { clearArchitectureCache } from "../analyzer/project/cache/index.js";
+import {
+  cleanupFixtures,
+  makeFixtureProject,
+} from "../server/test-support/fixtures.js";
+import { makeProject, cleanupArchitectureFixtures } from "../analyzer/test-support/analyzer-fixtures.js";
+
+afterEach(() => {
+  cleanupFixtures();
+  cleanupArchitectureFixtures();
+  clearArchitectureCache();
+});
+
+// The check.ts CI shim is the project-level "is this codebase clean"
+// surface: it must exit 0 against a healthy fixture and non-zero
+// against a fixture that fires any error-severity diagnostic. Both
+// behaviors are gated through `analyzeWorkspace`; the script is a thin
+// process boundary on top.
+
+const CHECK_SCRIPT = path.resolve(import.meta.dirname, "..", "dist", "check.js");
+
+it("check: exits 0 on a project with no error-severity findings", () => {
+  const root = makeFixtureProject();
+  const result = spawnSync("node", [CHECK_SCRIPT], { cwd: root, encoding: "utf8" });
+  expect(result.status).toBe(0);
+});
+
+it("check: exits 1 on a project with an error-severity finding", () => {
+  // Construct a fixture that fires `no-internal-subpath-export`
+  // (error severity) via a wildcard export. The default
+  // `maxWildcardExports` is 0, so a single wildcard subpath fires.
+  const root = makeProject({
+    "package.json": JSON.stringify({
+      name: "fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: {
+        ".": { import: "./dist/index.js", types: "./dist/index.d.ts" },
+        "./*": { import: "./dist/*.js" },
+      },
+    }),
+    "src/index.ts": "export const x = 1;\n",
+  });
+  const result = spawnSync("node", [CHECK_SCRIPT], { cwd: root, encoding: "utf8" });
+  expect(result.status).toBe(1);
+});

--- a/lsp/architecture/tests/check.test.ts
+++ b/lsp/architecture/tests/check.test.ts
@@ -14,12 +14,6 @@ afterEach(() => {
   clearArchitectureCache();
 });
 
-// The check.ts CI shim is the project-level "is this codebase clean"
-// surface: it must exit 0 against a healthy fixture and non-zero
-// against a fixture that fires any error-severity diagnostic. Both
-// behaviors are gated through `analyzeWorkspace`; the script is a thin
-// process boundary on top.
-
 const CHECK_SCRIPT = path.resolve(import.meta.dirname, "..", "dist", "check.js");
 
 it("check: exits 0 on a project with no error-severity findings", () => {

--- a/lsp/architecture/tests/lsp-server.test.ts
+++ b/lsp/architecture/tests/lsp-server.test.ts
@@ -62,23 +62,27 @@ it("diagnostic-converter: maps single finding to LSP diagnostic at file head", (
   expect(lsp.message).toBe("cycle detected");
 });
 
-it("diagnostic-converter: every diagnostic carries a codeDescription.href to PRINCIPLES.md", () => {
-  const ruleIds = [
-    "no-inventory-barrel",
-    "no-public-vendor-type-leak",
-    "no-folder-cycle",
-    "no-large-public-surface",
-    "shared-kernel-cohesion",
-    "architecture-directive-parse-error",
-  ] as const;
-  for (const ruleId of ruleIds) {
+it("diagnostic-converter: every architecture rule id carries a codeDescription.href to PRINCIPLES.md", async () => {
+  // Iterate every rule id the analyzer can emit, including the
+  // directive-parse pseudo-rule. The `Record<ArchitectureRuleId, …>`
+  // type on `ARCHITECTURE_RULE_ANCHORS` forces every new rule id in
+  // `rule-ids.ts` to land with an anchor — this test guards the
+  // runtime side: every anchor resolves to a real principle, not to
+  // the fallback PRINCIPLES.md root.
+  const { ARCHITECTURE_DIAGNOSTIC_RULE_IDS, ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID } =
+    await import("../analyzer/rule-ids.js");
+  const allRuleIds = [
+    ...ARCHITECTURE_DIAGNOSTIC_RULE_IDS,
+    ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID,
+  ];
+  for (const ruleId of allRuleIds) {
     const lsp = toLspDiagnostic({
       ruleId,
       file: "/proj/x.ts",
       severity: "error",
       message: "msg",
     });
-    expect(lsp.codeDescription?.href).toMatch(/^https:\/\/github\.com\/.*PRINCIPLES\.md#/);
+    expect(lsp.codeDescription?.href).toMatch(/^https:\/\/github\.com\/.*PRINCIPLES\.md#./);
   }
 });
 

--- a/lsp/architecture/tests/lsp-server.test.ts
+++ b/lsp/architecture/tests/lsp-server.test.ts
@@ -1,0 +1,137 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { Effect } from "effect";
+import { afterEach, expect, it } from "vitest";
+import {
+  cleanupFixtures,
+  makeFixtureProject,
+} from "../server/test-support/fixtures.js";
+import { clearArchitectureCache } from "../analyzer/project/cache/index.js";
+import { groupByUri, toLspDiagnostic } from "../server/diagnostic-converter.js";
+import { makeDocumentStore } from "../server/document-store.js";
+import { makeWorkspaceRegistry } from "../server/workspace-registry.js";
+
+afterEach(() => {
+  cleanupFixtures();
+  clearArchitectureCache();
+});
+
+it("diagnostic-converter: groups findings by URI and maps severity", () => {
+  const findings = [
+    {
+      ruleId: "no-folder-cycle" as const,
+      file: "/proj/src/a.ts",
+      severity: "error" as const,
+      message: "cycle",
+    },
+    {
+      ruleId: "no-large-folder" as const,
+      file: "/proj/src/a.ts",
+      severity: "warn" as const,
+      message: "large",
+    },
+    {
+      ruleId: "no-folder-cycle" as const,
+      file: "/proj/src/b.ts",
+      severity: "error" as const,
+      message: "cycle",
+    },
+  ];
+  const grouped = groupByUri(findings);
+  expect(grouped.size).toBe(2);
+  const aUri = pathToFileURL("/proj/src/a.ts").toString();
+  const bUri = pathToFileURL("/proj/src/b.ts").toString();
+  expect(grouped.get(aUri)?.length).toBe(2);
+  expect(grouped.get(bUri)?.length).toBe(1);
+  const aDiagnostics = grouped.get(aUri) ?? [];
+  expect(aDiagnostics[0].severity).toBe(1); // Error
+  expect(aDiagnostics[1].severity).toBe(2); // Warning
+  expect(aDiagnostics.every((d) => d.source === "agent-code-guard")).toBe(true);
+});
+
+it("diagnostic-converter: maps single finding to LSP diagnostic at file head", () => {
+  const lsp = toLspDiagnostic({
+    ruleId: "no-folder-cycle",
+    file: "/proj/x.ts",
+    severity: "error",
+    message: "cycle detected",
+  });
+  expect(lsp.range.start.line).toBe(0);
+  expect(lsp.range.start.character).toBe(0);
+  expect(lsp.code).toBe("no-folder-cycle");
+  expect(lsp.message).toBe("cycle detected");
+});
+
+it("diagnostic-converter: every diagnostic carries a codeDescription.href to PRINCIPLES.md", () => {
+  const ruleIds = [
+    "no-inventory-barrel",
+    "no-public-vendor-type-leak",
+    "no-folder-cycle",
+    "no-large-public-surface",
+    "shared-kernel-cohesion",
+    "architecture-directive-parse-error",
+  ] as const;
+  for (const ruleId of ruleIds) {
+    const lsp = toLspDiagnostic({
+      ruleId,
+      file: "/proj/x.ts",
+      severity: "error",
+      message: "msg",
+    });
+    expect(lsp.codeDescription?.href).toMatch(/^https:\/\/github\.com\/.*PRINCIPLES\.md#/);
+  }
+});
+
+it("document-store: open/update/close round-trip", () =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* makeDocumentStore();
+      yield* store.open({ uri: "f:///a.ts", version: 1, text: "x", languageId: "typescript" });
+      const after = yield* store.get("f:///a.ts");
+      expect(after?.text).toBe("x");
+
+      yield* store.update("f:///a.ts", 2, "y");
+      const updated = yield* store.get("f:///a.ts");
+      expect(updated?.text).toBe("y");
+      expect(updated?.version).toBe(2);
+
+      const uris = yield* store.listUris();
+      expect(uris).toEqual(["f:///a.ts"]);
+
+      yield* store.close("f:///a.ts");
+      const gone = yield* store.get("f:///a.ts");
+      expect(gone).toBeNull();
+    }),
+  ));
+
+it("workspace-registry: register memoizes engines per projectRoot", () => {
+  const root = makeFixtureProject();
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const registry = yield* makeWorkspaceRegistry();
+        const first = yield* registry.register(root);
+        const second = yield* registry.register(root);
+        expect(second).toBe(first);
+        expect(first.projectRoot).toBe(root);
+
+        const lookup = yield* registry.findByProjectRoot(root);
+        expect(lookup).toBe(first);
+
+        const allRoots = yield* registry.listProjectRoots();
+        expect(allRoots).toEqual([root]);
+      }),
+    ),
+  );
+});
+
+it("workspace-registry: findByProjectRoot returns null for unknown roots", () =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const registry = yield* makeWorkspaceRegistry();
+        const lookup = yield* registry.findByProjectRoot(path.join("/non", "existent"));
+        expect(lookup).toBeNull();
+      }),
+    ),
+  ));

--- a/lsp/architecture/tests/workspace-engine.test.ts
+++ b/lsp/architecture/tests/workspace-engine.test.ts
@@ -1,0 +1,114 @@
+import path from "node:path";
+import { Duration, Effect, Either, Stream } from "effect";
+import { afterEach, expect, it } from "vitest";
+import { resolveArchitectureOptions } from "../analyzer/project/api/index.js";
+import { clearArchitectureCache } from "../analyzer/project/cache/index.js";
+import { cleanupFixtures, makeFixtureProject, writeFile } from "../server/test-support/fixtures.js";
+import {
+  WorkspaceEngineError,
+  makeWorkspaceEngine,
+  withWorkspaceEngine,
+} from "../server/workspace-engine.js";
+
+afterEach(() => {
+  cleanupFixtures();
+  clearArchitectureCache();
+});
+
+function makeOptions(root: string): ReturnType<typeof resolveArchitectureOptions> {
+  return resolveArchitectureOptions({
+    projectRoot: root,
+    minExportedSiblingModules: 1,
+    maxExportedSiblingRatio: 0,
+    cacheTtlMs: Infinity,
+  });
+}
+
+it("lintPaths returns diagnostics scoped to the requested files", () => {
+  const root = makeFixtureProject();
+  const indexPath = path.join(root, "src", "index.ts");
+
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const engine = yield* makeWorkspaceEngine(makeOptions(root));
+        const findings = yield* engine.lintPaths([indexPath]);
+        expect(findings.length).toBeGreaterThan(0);
+        expect(findings.every((d) => d.file === indexPath)).toBe(true);
+      }),
+    ),
+  );
+});
+
+it("invalidations stream emits when a watched file changes on disk", { timeout: 15_000 }, () => {
+  const root = makeFixtureProject();
+
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const engine = yield* makeWorkspaceEngine(makeOptions(root));
+        yield* engine.lintPaths([path.join(root, "src", "index.ts")]);
+
+        const fiber = yield* Effect.fork(
+          Stream.runHead(engine.invalidations).pipe(
+            Effect.timeoutOption(Duration.seconds(10)),
+          ),
+        );
+
+        // Give the forked fiber time to actually subscribe to the
+        // PubSub before we publish. With unbounded PubSub, messages
+        // emitted before a subscriber attaches are dropped.
+        yield* Effect.sleep(Duration.seconds(1));
+        yield* Effect.sync(() => writeFile(root, "src/m0.ts", "export const M0 = 99;\n"));
+
+        const result = yield* fiber.await;
+        if (result._tag !== "Success") {
+          expect.fail(`fiber failed: ${JSON.stringify(result)}`);
+        }
+        expect(result.value._tag).toBe("Some");
+      }),
+    ),
+  );
+});
+
+it("withWorkspaceEngine scopes the engine to one usage and releases on exit", () => {
+  const root = makeFixtureProject();
+
+  // Use the engine for one Effect chain. If the watcher leaked,
+  // vitest's --detect-open-handles surfaces it as a failure at exit.
+  return Effect.runPromise(
+    withWorkspaceEngine(makeOptions(root), (engine) =>
+      Effect.gen(function* () {
+        const findings = yield* engine.lintPaths([path.join(root, "src", "index.ts")]);
+        expect(findings.length).toBeGreaterThan(0);
+      }),
+    ),
+  );
+});
+
+it("lintPaths surfaces WorkspaceEngineError when the analyzer call throws", () =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const root = makeFixtureProject();
+        const engine = yield* makeWorkspaceEngine(makeOptions(root));
+        // Force a failure by passing a programProvider that throws.
+        const result = yield* engine
+          .lintPaths(
+            [path.join(root, "src", "index.ts")],
+            () => {
+              throw new Error("provider boom");
+            },
+            "fingerprint-test",
+          )
+          .pipe(Effect.either);
+        Either.match(result, {
+          onLeft: (err) => {
+            expect(err).toBeInstanceOf(WorkspaceEngineError);
+            expect(err.message).toContain("lintPaths failed");
+          },
+          onRight: () => expect.fail("expected Left/error"),
+        });
+      }),
+    ),
+  ));

--- a/lsp/architecture/tsconfig.json
+++ b/lsp/architecture/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": [
+    "analyzer/**/*",
+    "server/**/*",
+    "check.ts",
+    "dogfood.ts",
+    "index.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests",
+    "analyzer/**/*.test.ts",
+    "analyzer/**/test-support/**/*"
+  ]
+}


### PR DESCRIPTION
Closes #287
Parent epic: https://github.com/chughtapan/agent-code-guard/issues/71
Plan gist: https://gist.github.com/chughtapan/dd6eb6eba5da3c061dd98aedb6f46abb (Phase 3 section)

## What changed

Phase 3 of the ACG↔SFD reorganization. SFD gains a `lsp/architecture/` self-contained package housing the architecture analyzer (recovered from acg pre-Phase-1 SHA `5b678b4`) plus the LSP server (ported from acg's `dogfood/server-architecture-cleanup` branch, which folds in PRs #66–#70). Tests convert from ESLint rule-tester to direct `analyzeWorkspace()` API. Every architecture diagnostic now carries `codeDescription.href` pointing at the rule's PRINCIPLES.md anchor — PR #70 did not include this; the port adds it.

## Traceability

| New artifact | Kind | Spec anchor | Plan anchor |
|---|---|---|---|
| `lsp/architecture/analyzer/` (73 files) | module | Sub-issue Step 2 "Port the analyzer" | Plan §3 Step 2 |
| `lsp/architecture/server/` (8 files + new `rule-docs.ts`) | module | Sub-issue Step 3 "Port the LSP server" | Plan §3 Step 3 |
| `analyzeWorkspace(opts)` | public fn | Sub-issue Step 6 | Plan §3 Step 6 |
| Suppression-directive parser (`analyzer/architecture-exceptions.ts`) | preserved | Sub-issue Step 4 | Plan §3 Step 3a |
| `codeDescription.href` per diagnostic via `server/rule-docs.ts` | public fn | Sub-issue Step 5 + acceptance bullet | Plan §3 Step 5 |
| `lsp/architecture/check.ts` (CI shim) | new | Sub-issue Step 9 | Plan §3 Step 9 |
| `lsp/architecture/dogfood.ts` (smoke test) | preserved | Sub-issue Step 3 | Plan §3 Step 3 |
| `lsp/architecture/docs/lsp.md` | docs | Sub-issue Step 10 | Plan §3 Step 10 |
| `lsp/architecture/package.json` (effect, typescript, vscode-languageserver, chokidar) | dep | Sub-issue Step 7 | Plan §3 Step 7 |
| `lsp/architecture/tsconfig.json` | config | Sub-issue Step 7 | Plan §3 Step 7 |
| `.github/workflows/lsp-architecture.yml` | CI | Sub-issue Step 12 | Plan §3 Step 12 |
| `tests/check.test.ts`, `tests/lsp-server.test.ts`, `tests/workspace-engine.test.ts`, `analyzer/module-shape/boundary-shapes.test.ts` | tests | Sub-issue Step 8 | Plan §3 Step 8 |
| `.gitignore` — exclude `lsp/*/node_modules/` and `lsp/*/dist/` | infra | Step 11 (workable repo) | n/a |

## Scope

- New modules: `lsp/architecture/analyzer/`, `lsp/architecture/server/`, `lsp/architecture/` (top-level package wrapper)
- New public exports: `analyzeWorkspace`, `ARCHITECTURE_DIAGNOSTIC_RULE_IDS`, `ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID`, `ArchitectureRuleId`, `ArchitectureDiagnostic`, `ArchitectureReport`, plus types. Server-internal: `ruleCodeDescription`, `toLspDiagnostic`, `groupByUri`, `makeLspServer`, `makeWorkspaceEngine`, `makeWorkspaceRegistry`, `makeDocumentStore`.
- New deps: `chokidar@^5.0.0`, `effect@^3.21.1`, `typescript@^5.4.0`, `vscode-languageserver@^9.0.1`. Local to `lsp/architecture/`; sfd root unchanged.
- Tier (sub-issue label): `safer:implement-staff`.

## Dependencies

| Name | Version | License | Justification |
|---|---|---|---|
| chokidar | ^5.0.0 | MIT | File-system watcher for the workspace engine. Same dep PR #66 used in acg. |
| effect | ^3.21.1 | MIT | Effect runtime — the engine and LSP server are Effect-shaped. Same dep PR #67 used. |
| typescript | ^5.4.0 | Apache-2.0 | The analyzer runs against a `ts.Program`. |
| vscode-languageserver | ^9.0.1 | MIT | LSP protocol implementation. Same dep PR #67 used. |

## Tests

`cd lsp/architecture && pnpm test` → **23 files, 139 tests pass**. Coverage:

- `analyzer/**/*.test.ts` — every architecture rule family (folder-shape, imports, module-shape, package-api, type-surface, project, exports, architecture-exceptions). Property-based tests via fast-check.
- `tests/workspace-engine.test.ts` — LSP workspace engine (lintPaths, invalidations stream, scope-bound resource cleanup).
- `tests/lsp-server.test.ts` — diagnostic converter (severity mapping, URI grouping, **codeDescription.href coverage for every rule id**), document store, workspace registry.
- `tests/check.test.ts` — CI shim exits 0 on clean fixtures and exits 1 on a fixture firing `no-internal-subpath-export` (error-severity).

## Simplify skips

- Did not change the analyzer-internal behavior where a malformed suppression directive records the rule id in `attemptedSuppressions` and hides any real diagnostic for that rule alongside the parse error. Verbatim port semantics from acg; defer to a follow-up if the UX needs to change.

## Codex diff review

`/codex` ran on the diff (counts as one stamina pass). Applied each actionable P2:
- Added `pretest` hook so `pnpm test` rebuilds `dist/` before the check-test spawns `dist/check.js`.
- Dropped the redundant "infers projectRoot" test that claimed inference but passed `projectRoot` explicitly.

False positive (Codex flagged "lockfile not committed" — it is tracked in HEAD).

## Review skips

`/review` final pass: **no P1/P2 findings — ready to PR**. Informational notes (all deferred):
- Workflow has no `concurrency:` block (duplicate runs on push+PR events queue rather than dedupe). Only workflow in the repo; no precedent.
- `dogfood.ts` `LspClient` doesn't reject pending requests on subprocess `exit`. Dev-only smoke test.
- `lsp/architecture/tests/` excluded from `tsc`; vitest doesn't strict-typecheck. Pre-existing pattern.

## Confidence

HIGH — port fidelity verified by 139 passing tests (24 architecture rules + LSP server + CI shim), exhaustiveness on the `Record<ArchitectureRuleId, …>` rule-doc anchor map is enforced at compile time AND at runtime via the codeDescription coverage test, build green from a clean `pnpm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)