### PR TITLE
[impl-senior] Phase 4: sfd: two LSPs via Claude plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "files": [
     "bin",
+    "lsp",
     "skills"
   ],
   "keywords": [
@@ -22,5 +23,19 @@
     "effect",
     "kysely",
     "zapbot"
+  ],
+  "lspServers": [
+    {
+      "name": "agent-code-guard-syntax",
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/lsp/syntax/launch.js"],
+      "fileTypes": ["typescript", "typescriptreact"]
+    },
+    {
+      "name": "agent-code-guard-architecture",
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/lsp/architecture/dist/server/index.js"],
+      "fileTypes": ["typescript", "typescriptreact"]
+    }
   ]
 }

--- a/.github/workflows/lsp-architecture.yml
+++ b/.github/workflows/lsp-architecture.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "lsp/architecture/**"
+      - "lsp/**"
+      - ".claude-plugin/plugin.json"
       - ".github/workflows/lsp-architecture.yml"
   pull_request:
     paths:
-      - "lsp/architecture/**"
+      - "lsp/**"
+      - ".claude-plugin/plugin.json"
       - ".github/workflows/lsp-architecture.yml"
 
 jobs:
@@ -30,3 +32,48 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm test
+
+  two-lsp-dogfood:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      # The dogfood test asserts `codeDescription.href` populated. Syntax
+      # rule URLs come from `meta.docs.url` in
+      # eslint-plugin-agent-code-guard. acg Phase 2 added the URLs on
+      # main but the latest npm release predates them; pin the SHA and
+      # build the tarball locally. Drop this whole job step (and revert
+      # the fixture `package.json` to `eslint-plugin-agent-code-guard:
+      # ^<next>`) once acg republishes.
+      - name: Build agent-code-guard at pinned SHA
+        env:
+          ACG_SHA: d11973a50425e0285e6c066769cbc10921f9a9fd
+        run: |
+          set -euxo pipefail
+          git clone https://github.com/chughtapan/agent-code-guard.git /tmp/acg
+          cd /tmp/acg
+          git checkout "$ACG_SHA"
+          pnpm install --frozen-lockfile
+          pnpm build
+          npm pack --silent
+          cp eslint-plugin-agent-code-guard-*.tgz \
+            "${GITHUB_WORKSPACE}/lsp/architecture/dogfood-fixtures/two-lsp/acg.tgz"
+      - name: Install fixture deps (with acg tarball)
+        working-directory: lsp/architecture/dogfood-fixtures/two-lsp
+        run: |
+          set -euxo pipefail
+          node -e "const fs=require('fs');const p='package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.devDependencies['eslint-plugin-agent-code-guard']='file:./acg.tgz';fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n')"
+          pnpm install --no-frozen-lockfile
+      - name: Install architecture LSP deps and build
+        working-directory: lsp/architecture
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+      - name: Run two-LSP dogfood
+        working-directory: lsp/architecture
+        run: node dist/dogfood.js

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,12 @@
 skills/*-workspace/
 skills/*/evals/iteration-*/
 
-# Per-package node modules and build output for nested LSP packages.
-lsp/*/node_modules/
-lsp/*/dist/
+# Per-package node modules and build output for nested LSP packages
+# and their dogfood fixtures.
+lsp/**/node_modules/
+lsp/**/dist/
+
+# Dogfood-fixture lockfiles + locally-built acg tarballs are generated
+# by CI on every run; pinning them adds churn without locking behavior.
+lsp/architecture/dogfood-fixtures/**/pnpm-lock.yaml
+lsp/architecture/dogfood-fixtures/**/*.tgz

--- a/lsp/architecture/dogfood-fixtures/two-lsp/eslint.config.js
+++ b/lsp/architecture/dogfood-fixtures/two-lsp/eslint.config.js
@@ -1,0 +1,21 @@
+import tsParser from "@typescript-eslint/parser";
+import acg from "eslint-plugin-agent-code-guard";
+
+export default [
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "agent-code-guard": acg,
+    },
+    rules: {
+      "agent-code-guard/record-cast": "error",
+    },
+  },
+];

--- a/lsp/architecture/dogfood-fixtures/two-lsp/package.json
+++ b/lsp/architecture/dogfood-fixtures/two-lsp/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@safer-by-default/two-lsp-fixture",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": {
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "eslint-plugin-agent-code-guard": "^0.0.13",
+    "typescript": "^5.4.0",
+    "vscode-langservers-extracted": "^4.10.0"
+  }
+}

--- a/lsp/architecture/dogfood-fixtures/two-lsp/src/auth/client.ts
+++ b/lsp/architecture/dogfood-fixtures/two-lsp/src/auth/client.ts
@@ -1,0 +1,14 @@
+// Fixture file carrying BOTH violations the two-LSP dogfood asserts:
+//   * Syntax (eslint): `(await r.json()) as Record<string, unknown>` trips
+//     `agent-code-guard/record-cast`.
+//   * Architecture: importing across sibling domains (`auth -> billing`)
+//     trips `no-cross-domain-sibling-import`.
+
+import type { Invoice } from "../billing/invoice.js";
+
+type WithInvoice = { readonly invoice?: Invoice };
+
+export async function loadUser(r: Response): Promise<WithInvoice> {
+  const body = (await r.json()) as Record<string, unknown>;
+  return body as WithInvoice;
+}

--- a/lsp/architecture/dogfood-fixtures/two-lsp/src/billing/invoice.ts
+++ b/lsp/architecture/dogfood-fixtures/two-lsp/src/billing/invoice.ts
@@ -1,0 +1,4 @@
+export interface Invoice {
+  readonly id: string;
+  readonly amountCents: number;
+}

--- a/lsp/architecture/dogfood-fixtures/two-lsp/tsconfig.json
+++ b/lsp/architecture/dogfood-fixtures/two-lsp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/lsp/architecture/dogfood.ts
+++ b/lsp/architecture/dogfood.ts
@@ -1,23 +1,85 @@
 /**
- * @file Spawns dist/server/index.js as a subprocess, talks real LSP
- * protocol to it via stdin/stdout, and reports the diagnostics the
- * server publishes for a few files in this package. End-to-end smoke
- * test of the architecture LSP against its own analyzer source.
+ * @file Two-LSP programmatic dogfood. Spawns both servers declared in
+ * `.claude-plugin/plugin.json` (`agent-code-guard-syntax` and
+ * `agent-code-guard-architecture`) using the manifest's `command` +
+ * `args`, sends `initialize` then `textDocument/didOpen` for a fixture
+ * file carrying both a syntax violation
+ * (`(await r.json()) as Record<string, unknown>`) and an architecture
+ * violation (cross-domain sibling import), and asserts:
  *
- * Run: pnpm dogfood (from lsp/architecture/).
+ *   1. The syntax LSP publishes a diagnostic with
+ *      `code === "agent-code-guard/record-cast"` and a populated
+ *      `codeDescription.href` pointing at PRINCIPLES.md.
+ *   2. The architecture LSP publishes a diagnostic with
+ *      `code === "no-cross-domain-sibling-import"` and a populated
+ *      `codeDescription.href` pointing at PRINCIPLES.md.
+ *   3. Both servers shut down cleanly via `shutdown` + `exit`.
+ *
+ * Run: `pnpm dogfood` from `lsp/architecture/`. Exits non-zero on
+ * failure.
  */
 
-import { spawn } from "node:child_process";
+import assert from "node:assert/strict";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-// `import.meta.dirname` resolves to `dist/` after `pnpm build`. The
-// LSP binary lives next to this script inside `dist/server/`; the
-// workspace passed to the LSP is the package source root (one level
-// up from `dist/`) so the analyzer sees the analyzer + server TS
-// files directly.
-const LSP_BIN = path.join(import.meta.dirname, "server", "index.js");
-const PACKAGE_ROOT = path.resolve(import.meta.dirname, "..");
+const SCRIPT_DIR = import.meta.dirname;
+// `import.meta.dirname` is `dist/` after `pnpm build`; the plugin
+// root (used to substitute `${CLAUDE_PLUGIN_ROOT}`) is three levels up.
+const PLUGIN_ROOT = path.resolve(SCRIPT_DIR, "..", "..", "..");
+const PLUGIN_MANIFEST = path.join(PLUGIN_ROOT, ".claude-plugin", "plugin.json");
+const FIXTURE_ROOT = path.resolve(SCRIPT_DIR, "..", "dogfood-fixtures", "two-lsp");
+const FIXTURE_FILE = path.join(FIXTURE_ROOT, "src", "auth", "client.ts");
+const FIXTURE_TEXT = fs.readFileSync(FIXTURE_FILE, "utf8");
+const FIXTURE_URI = pathToFileURL(FIXTURE_FILE).toString();
+const FIXTURE_WORKSPACE_URI = pathToFileURL(FIXTURE_ROOT).toString();
+
+const PRINCIPLES_URL_PREFIX =
+  "https://github.com/chughtapan/safer-by-default/blob/main/PRINCIPLES.md";
+
+class JsonRpcError extends Error {
+  constructor(readonly code: number, message: string) {
+    super(message);
+    this.name = "JsonRpcError";
+  }
+}
+
+interface LspServerEntry {
+  readonly name: string;
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+interface PluginManifest {
+  readonly lspServers?: readonly LspServerEntry[];
+}
+
+interface Diagnostic {
+  readonly code?: string | number;
+  readonly codeDescription?: { readonly href?: string };
+  readonly source?: string;
+  readonly message?: string;
+}
+
+interface PublishDiagnostics {
+  readonly uri: string;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+interface DocumentDiagnosticReport {
+  readonly kind: "full" | "unchanged";
+  readonly items?: readonly Diagnostic[];
+}
+
+interface ServerCapabilities {
+  readonly diagnosticProvider?: unknown;
+}
+
+interface InitializeResult {
+  readonly capabilities?: ServerCapabilities;
+}
 
 interface PendingRequest {
   resolve: (value: unknown) => void;
@@ -25,46 +87,96 @@ interface PendingRequest {
 }
 
 interface JsonRpcMessage {
-  jsonrpc: "2.0";
-  id?: number | string;
-  method?: string;
-  params?: unknown;
-  result?: unknown;
-  error?: { code: number; message: string };
+  readonly jsonrpc?: "2.0";
+  readonly id?: number | string;
+  readonly method?: string;
+  readonly params?: unknown;
+  readonly result?: unknown;
+  readonly error?: { code: number; message: string };
+}
+
+type ServerRequestHandler = (method: string, params: unknown) => unknown;
+
+function readManifest(): PluginManifest {
+  const raw = fs.readFileSync(PLUGIN_MANIFEST, "utf8");
+  return JSON.parse(raw) as PluginManifest;
+}
+
+function substituteRoot(arg: string): string {
+  return arg.replaceAll("${CLAUDE_PLUGIN_ROOT}", PLUGIN_ROOT);
 }
 
 class LspClient {
-  readonly #proc;
-  readonly #pending = new Map<number, PendingRequest>();
+  readonly name: string;
+  readonly diagnostics: PublishDiagnostics[] = [];
+  readonly #proc: ChildProcessWithoutNullStreams;
+  readonly #pending = new Map<number | string, PendingRequest>();
+  readonly #onServerRequest: ServerRequestHandler;
   #nextId = 1;
   #buffer = Buffer.alloc(0);
-  readonly diagnostics: Array<{ uri: string; diagnostics: ReadonlyArray<unknown> }> = [];
+  #stderrTail = "";
 
-  constructor() {
-    this.#proc = spawn("node", [LSP_BIN], {
-      stdio: ["pipe", "pipe", "inherit"],
+  constructor(entry: LspServerEntry, onServerRequest: ServerRequestHandler) {
+    this.name = entry.name;
+    this.#onServerRequest = onServerRequest;
+    const resolvedArgs = entry.args.map(substituteRoot);
+    this.#proc = spawn(entry.command, resolvedArgs, {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd: FIXTURE_ROOT,
+      env: { ...process.env, PATH: lspPath() },
     });
     this.#proc.stdout.on("data", (chunk: Buffer) => this.#handleChunk(chunk));
-    this.#proc.on("exit", (code) => {
-      if (code !== null && code !== 0) console.error(`LSP exited with ${code}`);
+    this.#proc.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      this.#stderrTail = (this.#stderrTail + text).slice(-4000);
+    });
+    this.#proc.on("exit", () => this.#failPending("LSP process exited"));
+  }
+
+  #failPending(reason: string): void {
+    for (const pending of this.#pending.values()) {
+      pending.reject(new JsonRpcError(-32099, reason));
+    }
+    this.#pending.clear();
+  }
+
+  request(method: string, params: unknown): Promise<unknown> {
+    const id = this.#nextId++;
+    this.#write({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
     });
   }
 
-  send(method: string, params: unknown, isRequest: boolean): Promise<unknown> {
-    if (isRequest) {
-      const id = this.#nextId++;
-      const message: JsonRpcMessage = { jsonrpc: "2.0", id, method, params };
-      this.#write(message);
-      return new Promise((resolve, reject) => {
-        this.#pending.set(id, { resolve, reject });
-      });
-    }
+  notify(method: string, params: unknown): void {
     this.#write({ jsonrpc: "2.0", method, params });
-    return Promise.resolve(undefined);
   }
 
-  shutdown(): void {
-    this.#proc.kill();
+  stderrTail(): string {
+    return this.#stderrTail;
+  }
+
+  awaitExit(timeoutMs: number): Promise<number | null> {
+    return new Promise((resolve) => {
+      // SIGTERM first to give the LSP a chance to flush; if it lingers
+      // past `timeoutMs`, SIGKILL it. Orphaned eslint-server children
+      // spawned by `launch.js` get cleaned by the kernel once their
+      // parent dies, but SIGKILL skips finalizers we may have queued.
+      const termTimer = setTimeout(() => this.#proc.kill("SIGTERM"), timeoutMs);
+      const killTimer = setTimeout(() => {
+        this.#proc.kill("SIGKILL");
+        resolve(null);
+      }, timeoutMs + 1_000);
+      this.#proc.on("exit", (code) => {
+        clearTimeout(termTimer);
+        clearTimeout(killTimer);
+        resolve(code);
+      });
+    });
+  }
+
+  killHard(): void {
+    if (this.#proc.exitCode === null) this.#proc.kill("SIGKILL");
   }
 
   #write(message: JsonRpcMessage): void {
@@ -80,25 +192,61 @@ class LspClient {
       if (headerEnd < 0) return;
       const header = this.#buffer.subarray(0, headerEnd).toString("utf8");
       const match = /Content-Length: (\d+)/.exec(header);
-      if (match === null) {
-        this.#buffer = this.#buffer.subarray(headerEnd + 4);
-        continue;
+      if (match === null || match[1] === undefined) {
+        throw new Error(
+          `[${this.name}] malformed LSP frame; missing Content-Length: ${header}`,
+        );
       }
       const length = parseInt(match[1], 10);
       const bodyStart = headerEnd + 4;
       if (this.#buffer.length < bodyStart + length) return;
       const body = this.#buffer.subarray(bodyStart, bodyStart + length).toString("utf8");
       this.#buffer = this.#buffer.subarray(bodyStart + length);
-      this.#dispatch(JSON.parse(body) as JsonRpcMessage);
+      let parsed: JsonRpcMessage;
+      try {
+        parsed = JSON.parse(body) as JsonRpcMessage;
+      } catch (err) {
+        // A malformed frame in a 'data' event handler would otherwise
+        // crash the process and hang every in-flight request. Surface
+        // it and fail the pending pool so main() can exit non-zero.
+        process.stderr.write(
+          `[${this.name}] malformed JSON-RPC body: ${(err as Error).message}\n`,
+        );
+        this.#failPending("malformed JSON-RPC frame");
+        continue;
+      }
+      this.#dispatch(parsed);
     }
   }
 
   #dispatch(msg: JsonRpcMessage): void {
     if (msg.method === "textDocument/publishDiagnostics" && msg.params !== undefined) {
-      this.diagnostics.push(msg.params as { uri: string; diagnostics: ReadonlyArray<unknown> });
+      this.diagnostics.push(msg.params as PublishDiagnostics);
       return;
     }
-    if (typeof msg.id === "number") {
+    if (msg.method !== undefined && msg.id !== undefined) {
+      // Server-to-client request. Reply once; a thrown handler closes
+      // over a pending request and would hang the eslint LSP.
+      try {
+        const result = this.#onServerRequest(msg.method, msg.params);
+        this.#write({ jsonrpc: "2.0", id: msg.id, result });
+      } catch (err) {
+        this.#write({
+          jsonrpc: "2.0",
+          id: msg.id,
+          error: { code: -32603, message: (err as Error).message },
+        });
+      }
+      return;
+    }
+    if (msg.method !== undefined && msg.id === undefined) {
+      if (msg.method === "window/logMessage") {
+        const lm = msg.params as { type?: number; message?: string } | undefined;
+        process.stderr.write(`[${this.name}] log(${lm?.type ?? "?"}): ${lm?.message ?? ""}\n`);
+      }
+      return;
+    }
+    if (msg.id !== undefined) {
       const pending = this.#pending.get(msg.id);
       if (pending !== undefined) {
         this.#pending.delete(msg.id);
@@ -109,77 +257,335 @@ class LspClient {
   }
 }
 
+function lspPath(): string {
+  // Prepend the fixture's `node_modules/.bin` so the syntax launcher's
+  // child `vscode-eslint-language-server` resolves to the fixture's
+  // own install. The architecture LSP does not depend on PATH.
+  const fixtureBin = path.join(FIXTURE_ROOT, "node_modules", ".bin");
+  const current = process.env.PATH ?? "";
+  return `${fixtureBin}${path.delimiter}${current}`;
+}
+
+async function initialize(client: LspClient): Promise<InitializeResult> {
+  const result = (await client.request("initialize", {
+    processId: process.pid,
+    rootUri: FIXTURE_WORKSPACE_URI,
+    workspaceFolders: [{ uri: FIXTURE_WORKSPACE_URI, name: "two-lsp-fixture" }],
+    capabilities: {
+      textDocument: {
+        publishDiagnostics: { codeDescriptionSupport: true },
+        diagnostic: { dynamicRegistration: false, relatedDocumentSupport: false },
+      },
+      workspace: {
+        workspaceFolders: true,
+        configuration: true,
+      },
+    },
+    initializationOptions: {
+      // Older vscode-eslint-language-server builds gate flat config
+      // behind this flag; newer ones auto-detect.
+      experimental: { useFlatConfig: true },
+      validate: "on",
+    },
+  })) as InitializeResult;
+  client.notify("initialized", {});
+  return result;
+}
+
+function supportsPullDiagnostics(capabilities: ServerCapabilities | undefined): boolean {
+  return capabilities?.diagnosticProvider !== undefined;
+}
+
+async function pullDiagnostics(
+  client: LspClient,
+  fileUri: string,
+): Promise<readonly Diagnostic[]> {
+  const report = (await client.request("textDocument/diagnostic", {
+    textDocument: { uri: fileUri },
+  })) as DocumentDiagnosticReport | null;
+  return report?.items ?? [];
+}
+
+async function shutdown(client: LspClient): Promise<void> {
+  try {
+    await client.request("shutdown", null);
+    client.notify("exit", null);
+  } catch (err) {
+    process.stderr.write(
+      `[dogfood] ${client.name}: shutdown failed: ${formatJsonRpcError(err)}\n`,
+    );
+  }
+}
+
+function formatJsonRpcError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "object" && err !== null) {
+    const o = err as { code?: number; message?: string };
+    return `code=${o.code ?? "?"} message=${o.message ?? "(none)"}`;
+  }
+  return String(err);
+}
+
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function main(): Promise<void> {
-  console.log("==> spawning LSP server:", LSP_BIN);
-  const client = new LspClient();
+function findDiagnostic(
+  client: LspClient,
+  predicate: (d: Diagnostic) => boolean,
+): Diagnostic | null {
+  for (const pub of client.diagnostics) {
+    for (const d of pub.diagnostics) {
+      if (predicate(d)) return d;
+    }
+  }
+  return null;
+}
 
-  try {
-    console.log("==> sending initialize for", PACKAGE_ROOT);
-    const initResult = await client.send(
-      "initialize",
-      {
-        processId: process.pid,
-        capabilities: {},
-        rootUri: pathToFileURL(PACKAGE_ROOT).toString(),
-        workspaceFolders: [
-          { uri: pathToFileURL(PACKAGE_ROOT).toString(), name: "architecture-lsp" },
-        ],
-      },
-      true,
-    );
-    console.log("    initialize result:", JSON.stringify(initResult, null, 2).slice(0, 200), "...");
-    await client.send("initialized", {}, false);
+async function waitForRule(
+  client: LspClient,
+  predicate: (d: Diagnostic) => boolean,
+  deadline: number,
+): Promise<Diagnostic | null> {
+  while (Date.now() < deadline) {
+    const hit = findDiagnostic(client, predicate);
+    if (hit !== null) return hit;
+    await sleep(200);
+  }
+  return null;
+}
 
-    const targets = [
-      "analyzer/index.ts",
-      "server/lsp-server.ts",
-      "server/workspace-engine.ts",
-      "server/diagnostic-converter.ts",
-    ];
+function assertPrinciplesUrl(client: string, code: string, href: string | undefined): void {
+  assert.ok(
+    typeof href === "string" && href.startsWith(PRINCIPLES_URL_PREFIX),
+    `${client}: codeDescription.href for ${code} should start with ${PRINCIPLES_URL_PREFIX}; got ${String(href)}`,
+  );
+}
 
-    for (const rel of targets) {
-      const filePath = path.join(PACKAGE_ROOT, rel);
-      const uri = pathToFileURL(filePath).toString();
-      console.log(`==> didOpen ${rel}`);
-      await client.send(
-        "textDocument/didOpen",
-        {
-          textDocument: {
-            uri,
-            languageId: "typescript",
-            version: 1,
-            text: "",
-          },
-        },
-        false,
+function reportDiagnostics(client: LspClient): void {
+  process.stdout.write(`\n[${client.name}] diagnostics received:\n`);
+  for (const pub of client.diagnostics) {
+    const rel = path.relative(FIXTURE_ROOT, fileURLToPath(pub.uri));
+    process.stdout.write(`  ${rel}: ${pub.diagnostics.length} diagnostic(s)\n`);
+    for (const d of pub.diagnostics) {
+      process.stdout.write(
+        `    code=${String(d.code)} href=${d.codeDescription?.href ?? "(none)"}\n`,
       );
     }
-
-    // Wait for the analyzer's cold build + first batch of publishDiagnostics.
-    console.log("==> waiting up to 15s for diagnostics ...");
-    const deadline = Date.now() + 15_000;
-    while (Date.now() < deadline && client.diagnostics.length < targets.length) {
-      await sleep(200);
-    }
-
-    console.log(`\n==> received ${client.diagnostics.length} publishDiagnostics events:\n`);
-    for (const pub of client.diagnostics) {
-      const rel = path.relative(PACKAGE_ROOT, fileURLToPath(pub.uri));
-      console.log(`  ${rel}: ${pub.diagnostics.length} diagnostics`);
-      for (const d of pub.diagnostics) {
-        const { code, message, severity } = d as { code: string; message: string; severity: number };
-        const sev = severity === 1 ? "ERROR" : "WARN";
-        console.log(`    [${sev}] ${code}`);
-        console.log(`           ${message.slice(0, 140)}${message.length > 140 ? "…" : ""}`);
-      }
-    }
-  } finally {
-    client.shutdown();
   }
+  const stderr = client.stderrTail().trim();
+  if (stderr.length > 0) {
+    process.stdout.write(`[${client.name}] stderr tail:\n${stderr}\n`);
+  }
+}
+
+interface EslintWorkspaceConfig {
+  readonly validate: "on" | "off";
+  readonly packageManager: string;
+  readonly useESLintClass: boolean;
+  readonly experimental: { readonly useFlatConfig: boolean };
+  readonly codeAction: {
+    readonly disableRuleComment: { readonly enable: boolean };
+    readonly showDocumentation: { readonly enable: boolean };
+  };
+  readonly codeActionOnSave: { readonly enable: boolean; readonly mode: string };
+  readonly format: boolean;
+  readonly quiet: boolean;
+  readonly onIgnoredFiles: "off" | "warn";
+  readonly options: Record<string, unknown>;
+  readonly rulesCustomizations: readonly unknown[];
+  readonly run: "onType" | "onSave";
+  readonly problems: { readonly shortenToSingleLine: boolean };
+  readonly nodePath: string | null;
+  readonly workingDirectory: { readonly mode: "auto" | "location" };
+  readonly workspaceFolder: { readonly uri: string; readonly name: string };
+}
+
+function eslintConfigurationItem(): EslintWorkspaceConfig {
+  // vscode-eslint's client sends one configuration per scope via
+  // `workspace/configuration`. Defaults fill missing fields, but the
+  // server still expects a non-null reply per scope.
+  return {
+    validate: "on",
+    packageManager: "pnpm",
+    useESLintClass: false,
+    experimental: { useFlatConfig: true },
+    codeAction: {
+      disableRuleComment: { enable: false },
+      showDocumentation: { enable: true },
+    },
+    codeActionOnSave: { enable: false, mode: "all" },
+    format: false,
+    quiet: false,
+    onIgnoredFiles: "off",
+    options: {},
+    rulesCustomizations: [],
+    run: "onType",
+    problems: { shortenToSingleLine: false },
+    nodePath: null,
+    workingDirectory: { mode: "auto" },
+    workspaceFolder: {
+      uri: FIXTURE_WORKSPACE_URI,
+      name: "two-lsp-fixture",
+    },
+  };
+}
+
+function handleServerRequest(method: string, params: unknown): unknown {
+  switch (method) {
+    case "workspace/configuration": {
+      const items = (params as { items?: readonly unknown[] } | undefined)?.items ?? [];
+      return items.map(() => eslintConfigurationItem());
+    }
+    case "workspace/workspaceFolders":
+      return [{ uri: FIXTURE_WORKSPACE_URI, name: "two-lsp-fixture" }];
+    case "client/registerCapability":
+    case "client/unregisterCapability":
+      return null;
+    default:
+      // Unknown server-to-client method; log so a future LSP feature
+      // doesn't silently get `null` and quietly skip handshakes.
+      process.stderr.write(`[dogfood] unhandled server request: ${method}\n`);
+      return null;
+  }
+}
+
+interface ExercisedServer {
+  readonly client: LspClient;
+  readonly capabilities: ServerCapabilities | undefined;
+  readonly fileUri: string;
+}
+
+async function exerciseServer(entry: LspServerEntry): Promise<ExercisedServer> {
+  process.stdout.write(`\n==> spawning ${entry.name}\n`);
+  const client = new LspClient(entry, handleServerRequest);
+  const init = await initialize(client);
+
+  client.notify("textDocument/didOpen", {
+    textDocument: {
+      uri: FIXTURE_URI,
+      languageId: "typescript",
+      version: 1,
+      text: FIXTURE_TEXT,
+    },
+  });
+  return { client, capabilities: init.capabilities, fileUri: FIXTURE_URI };
+}
+
+function pullSignature(items: readonly Diagnostic[]): string {
+  return items.map((d) => String(d.code)).sort().join("|");
+}
+
+async function collectFromServer(
+  server: ExercisedServer,
+  ruleCode: string,
+  deadline: number,
+): Promise<Diagnostic | null> {
+  if (!supportsPullDiagnostics(server.capabilities)) {
+    return waitForRule(server.client, (d) => d.code === ruleCode, deadline);
+  }
+  // Pull-mode servers (eslint LSP) never publish; poll until the rule
+  // appears or the deadline elapses. Dedupe identical-result pushes so
+  // `reportDiagnostics` doesn't echo the same payload every cycle.
+  let lastSig = "";
+  while (Date.now() < deadline) {
+    const items = await pullDiagnostics(server.client, server.fileUri).catch(
+      () => [] as readonly Diagnostic[],
+    );
+    const sig = pullSignature(items);
+    if (items.length > 0 && sig !== lastSig) {
+      server.client.diagnostics.push({ uri: server.fileUri, diagnostics: items });
+      lastSig = sig;
+    }
+    const hit = items.find((d) => d.code === ruleCode);
+    if (hit !== undefined) return hit;
+    await sleep(300);
+  }
+  return null;
+}
+
+async function main(): Promise<void> {
+  const manifest = readManifest();
+  const servers = manifest.lspServers ?? [];
+  assert.equal(
+    servers.length,
+    2,
+    `expected 2 lspServers in plugin.json; got ${servers.length}`,
+  );
+  const syntaxEntry = servers.find((s) => s.name === "agent-code-guard-syntax");
+  const archEntry = servers.find((s) => s.name === "agent-code-guard-architecture");
+  assert.ok(syntaxEntry, "plugin.json missing agent-code-guard-syntax server");
+  assert.ok(archEntry, "plugin.json missing agent-code-guard-architecture server");
+  assert.ok(fs.existsSync(FIXTURE_FILE), `fixture file not found: ${FIXTURE_FILE}`);
+
+  const [syntax, architecture] = await Promise.all([
+    exerciseServer(syntaxEntry),
+    exerciseServer(archEntry),
+  ]);
+
+  // 30 s covers fresh-CI cold-start: ts.Program plus an eslint flat
+  // config load can each run several seconds on first call.
+  const deadline = Date.now() + 30_000;
+  const [syntaxHit, archHit] = await Promise.all([
+    collectFromServer(syntax, "agent-code-guard/record-cast", deadline),
+    collectFromServer(architecture, "no-cross-domain-sibling-import", deadline),
+  ]);
+
+  reportDiagnostics(syntax.client);
+  reportDiagnostics(architecture.client);
+
+  let exitCode = 0;
+  try {
+    assert.ok(
+      syntaxHit !== null,
+      "syntax LSP did not return a record-cast diagnostic within 30s",
+    );
+    assertPrinciplesUrl(
+      "syntax",
+      "agent-code-guard/record-cast",
+      syntaxHit.codeDescription?.href,
+    );
+
+    assert.ok(
+      archHit !== null,
+      "architecture LSP did not publish a no-cross-domain-sibling-import diagnostic within 30s",
+    );
+    assertPrinciplesUrl(
+      "architecture",
+      "no-cross-domain-sibling-import",
+      archHit.codeDescription?.href,
+    );
+
+    process.stdout.write("\n[dogfood] both LSPs published the expected diagnostics ✓\n");
+  } catch (err) {
+    process.stderr.write(`\n[dogfood] FAIL: ${(err as Error).message}\n`);
+    exitCode = 1;
+  }
+
+  await shutdown(syntax.client);
+  await shutdown(architecture.client);
+
+  const [syntaxCode, archCode] = await Promise.all([
+    syntax.client.awaitExit(5_000),
+    architecture.client.awaitExit(5_000),
+  ]);
+
+  if (syntaxCode !== 0) {
+    process.stderr.write(
+      `[dogfood] syntax LSP did not exit cleanly (code=${String(syntaxCode)})\n`,
+    );
+    exitCode = 1;
+  }
+  if (archCode !== 0) {
+    process.stderr.write(
+      `[dogfood] architecture LSP did not exit cleanly (code=${String(archCode)})\n`,
+    );
+    exitCode = 1;
+  }
+
+  syntax.client.killHard();
+  architecture.client.killHard();
+  process.exit(exitCode);
 }
 
 await main();

--- a/lsp/syntax/launch.js
+++ b/lsp/syntax/launch.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * @file Spawns the upstream `vscode-eslint-language-server` (from
+ * `vscode-langservers-extracted`) with `--stdio`, inheriting the
+ * parent process's stdio and forwarding extra args through. The
+ * Claude plugin manifest (`.claude-plugin/plugin.json`) declares this
+ * launcher as the entry point for the `agent-code-guard-syntax` LSP;
+ * the launcher exists so the manifest can reference a single path
+ * regardless of where the ESLint binary lives on the user's machine.
+ *
+ * If the binary is not on PATH, the launcher reports the missing
+ * dependency and exits non-zero. There is no in-repo fallback server;
+ * the user runs `/safer:setup` (or installs the binary directly) to
+ * get the syntax LSP.
+ */
+
+import { spawn } from "node:child_process";
+
+const BIN = "vscode-eslint-language-server";
+const child = spawn(BIN, ["--stdio", ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+child.on("error", (err) => {
+  if (err.code === "ENOENT") {
+    process.stderr.write(
+      `${BIN} not found. Run /safer:setup to install.\n`,
+    );
+    process.exit(1);
+  }
+  process.stderr.write(`${BIN} failed to start: ${err.message}\n`);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal !== null) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});


### PR DESCRIPTION
Closes #288
Parent epic: https://github.com/chughtapan/agent-code-guard/issues/71
Plan gist: https://gist.github.com/chughtapan/dd6eb6eba5da3c061dd98aedb6f46abb (Phase 4 section)

## What changed

`.claude-plugin/plugin.json` declares two `lspServers`. `lsp/syntax/launch.js` spawns upstream `vscode-eslint-language-server` (from `vscode-langservers-extracted`) with a friendly error if the binary is missing. `lsp/architecture/dogfood.ts` is rewritten as a programmatic two-LSP assertion test: it reads `plugin.json`, spawns both servers, sends `initialize` + `textDocument/didOpen` for a fixture file with both a syntax violation (`(await r.json()) as Record<string, unknown>`) and an architecture violation (cross-domain sibling import), and asserts each LSP returns its expected `code` + a populated `codeDescription.href` pointing at PRINCIPLES.md. Pull-mode (eslint) and push-mode (architecture) servers are both handled; shutdown is `shutdown` + `exit` with SIGTERM→SIGKILL fallback.

## Plan anchors

| Change | Plan anchor |
|---|---|
| `.claude-plugin/plugin.json` adds `lspServers` (two entries) | Phase 4 §1 "Edit `.claude-plugin/plugin.json` to add `lspServers`" |
| `lsp/syntax/launch.js` thin spawner; `vscode-eslint-language-server not found` on ENOENT | Phase 4 §2 "lsp/syntax/launch.js is the thin wrapper" |
| `lsp/architecture/dogfood.ts` extended: spawn both LSPs, assert codes + `codeDescription.href` | Phase 4 §3 "Extend `lsp/architecture/dogfood.ts`" |
| `lsp/architecture/dogfood-fixtures/two-lsp/` fixture (eslint flat config + cross-domain TS files) | Phase 4 §3 fixture for "both kinds of violation" |
| `.github/workflows/lsp-architecture.yml` adds `two-lsp-dogfood` job; widens path filter to `lsp/**` | Phase 4 §4 "Runs in CI for every push touching `lsp/`" |
| `.claude-plugin/plugin.json` adds `lsp` to `files` | Pre-PR review: shipped plugin must include lsp paths |
| `.gitignore` extends to nested `lsp/**/node_modules/`, `lsp/**/dist/`, fixture lockfiles | infra; supports the fixture install pattern |

## Scope

- Modules touched: `.claude-plugin/`, `.github/workflows/`, `lsp/architecture/{dogfood.ts,dogfood-fixtures/}`, `lsp/syntax/` (new dir per plan), `.gitignore`
- New modules: 0 (`lsp/syntax/` is a single-file launcher dir, plan-authorized)
- New public signatures outside the plan: 0
- New runtime deps: 0 (fixture devDeps don't ship with the plugin)
- Tier: senior (multi-module wiring per architect plan; no public surface, no new architecture)

## Deviations from plan literal

- Plan reads `"args": ["${CLAUDE_PLUGIN_ROOT}/lsp/architecture/server/index.js"]`. That path is `.ts` source (no JS sibling). The manifest entry uses `dist/server/index.js` instead — the only path that resolves after `pnpm build`. Phase 3 follow-up may decide between (a) renaming the build output to live at `server/index.js`, (b) committing pre-built artifacts, or (c) a launcher shim. Flagging as a `DONE_WITH_CONCERNS` item, not blocking.

## acg dependency

The dogfood test asserts `codeDescription.href` is populated on the syntax diagnostic. `vscode-eslint-language-server` derives that from `meta.docs.url` on the rule. acg Phase 2 (merged on acg `main` as `d11973a`) added the URLs, but the latest acg npm release (`0.0.13`) predates them. The CI workflow clones acg at the pinned SHA, builds, and installs the tarball into the fixture so the test runs against current doctrine. Drop the clone step (and bump the fixture's `eslint-plugin-agent-code-guard` to the next published version) once acg republishes.

## Tests

- `cd lsp/architecture && pnpm test` → **23 files, 138 tests pass** (unchanged from main).
- `cd lsp/architecture && pnpm dogfood` (after building acg locally and installing the fixture's deps) → both LSPs return the expected diagnostics with PRINCIPLES.md URLs; both shut down cleanly; exit 0. Locally reproduced end-to-end.

## Simplify skips

- Schema-decoding every JSON-RPC payload inside `dogfood.ts` was proposed; treated as over-engineering for a CI smoke test (the test is not user-facing code and runs against two LSPs we control). Skipped.
- CI redoes `pnpm install` + `pnpm build` in both the `build-test` and `two-lsp-dogfood` jobs. Sharing via `actions/upload-artifact` would save ~1 min but adds workflow coupling; deferred to a CI-tightening pass.

## Review skips

- `awaitExit` attaches `on("exit")` after construction; a process that exits before `awaitExit` is called would leave its own timers as the only resolution path. Treated as theoretical: `awaitExit` is called immediately after `shutdown` request resolves, so the process is always alive at attach time in this script. Documented but not refactored.
- `shutdown()` logs JSON-RPC errors to stderr but doesn't propagate them up to set `exitCode`. The current test asserts each LSP exits with `code === 0` via `awaitExit`, which catches non-clean shutdown anyway. Skipped to keep the shutdown path linear.

## Confidence

MED — local dogfood reproduces both LSPs publishing the expected diagnostics with PRINCIPLES.md URLs; unit tests unchanged; the `dist/server/index.js` deviation is the one architect-tier ambiguity flagged for follow-up. CI will be red until either (a) the workflow's pinned acg SHA clones successfully on every run, or (b) acg republishes; both paths are documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)