### PR TITLE
fix(lsp): architecture LSP runs .ts directly via bun (closes dist/ install-time gap)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -33,8 +33,8 @@
     },
     {
       "name": "agent-code-guard-architecture",
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/lsp/architecture/dist/server/index.js"],
+      "command": "bun",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/lsp/architecture/server/index.ts"],
       "fileTypes": ["typescript", "typescriptreact"]
     }
   ]

--- a/.github/workflows/lsp-architecture.yml
+++ b/.github/workflows/lsp-architecture.yml
@@ -43,6 +43,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.12"
       # The dogfood test asserts `codeDescription.href` populated. Syntax
       # rule URLs come from `meta.docs.url` in
       # eslint-plugin-agent-code-guard. acg Phase 2 added the URLs on
@@ -69,11 +72,9 @@ jobs:
           set -euxo pipefail
           node -e "const fs=require('fs');const p='package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.devDependencies['eslint-plugin-agent-code-guard']='file:./acg.tgz';fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n')"
           pnpm install --no-frozen-lockfile
-      - name: Install architecture LSP deps and build
+      - name: Install architecture LSP deps
         working-directory: lsp/architecture
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
-      - name: Run two-LSP dogfood
+        run: pnpm install --frozen-lockfile
+      - name: Run two-LSP dogfood (bun runs .ts directly; matches plugin.json runtime)
         working-directory: lsp/architecture
-        run: node dist/dogfood.js
+        run: bun dogfood.ts

--- a/lsp/architecture/dogfood.ts
+++ b/lsp/architecture/dogfood.ts
@@ -26,11 +26,23 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const SCRIPT_DIR = import.meta.dirname;
-// `import.meta.dirname` is `dist/` after `pnpm build`; the plugin
-// root (used to substitute `${CLAUDE_PLUGIN_ROOT}`) is three levels up.
-const PLUGIN_ROOT = path.resolve(SCRIPT_DIR, "..", "..", "..");
+// Walk up from SCRIPT_DIR until we find `.claude-plugin/plugin.json`.
+// Works whether this file runs from source (bun dogfood.ts) or from
+// the compiled dist/ tree (legacy `node dist/dogfood.js`).
+function findPluginRoot(start: string): string {
+  let cur = start;
+  const root = path.parse(cur).root;
+  while (cur !== root) {
+    if (fs.existsSync(path.join(cur, ".claude-plugin", "plugin.json"))) {
+      return cur;
+    }
+    cur = path.dirname(cur);
+  }
+  throw new Error(`plugin root (containing .claude-plugin/plugin.json) not found above ${start}`);
+}
+const PLUGIN_ROOT = findPluginRoot(SCRIPT_DIR);
 const PLUGIN_MANIFEST = path.join(PLUGIN_ROOT, ".claude-plugin", "plugin.json");
-const FIXTURE_ROOT = path.resolve(SCRIPT_DIR, "..", "dogfood-fixtures", "two-lsp");
+const FIXTURE_ROOT = path.join(PLUGIN_ROOT, "lsp", "architecture", "dogfood-fixtures", "two-lsp");
 const FIXTURE_FILE = path.join(FIXTURE_ROOT, "src", "auth", "client.ts");
 const FIXTURE_TEXT = fs.readFileSync(FIXTURE_FILE, "utf8");
 const FIXTURE_URI = pathToFileURL(FIXTURE_FILE).toString();

--- a/lsp/architecture/package.json
+++ b/lsp/architecture/package.json
@@ -14,7 +14,7 @@
     "build": "pnpm clean && tsc",
     "pretest": "pnpm build",
     "test": "vitest run",
-    "dogfood": "pnpm build && node dist/dogfood.js"
+    "dogfood": "bun dogfood.ts"
   },
   "dependencies": {
     "chokidar": "^5.0.0",


### PR DESCRIPTION
Follow-up to the ACG↔SFD reorg epic (chughtapan/agent-code-guard#71). Addresses the `dist/` distribution gap flagged by review-senior-phase-3 and review-senior-phase-4.

## Problem

Phase 4 declared the architecture LSP as:
```json
"command": "node",
"args": ["${CLAUDE_PLUGIN_ROOT}/lsp/architecture/dist/server/index.js"]
```

That path requires `pnpm build` to materialize, but `.gitignore` excludes `lsp/*/dist`. End users who `/plugin install` from the marketplace get a manifest pointing at a file that doesn't exist. CI worked because CI runs `pnpm build` before tests; user installs do not.

## Fix

Switch architecture LSP runtime to **bun**, which executes TypeScript sources directly. Manifest points at `server/index.ts` (checked-in source).

## Changes

- `.claude-plugin/plugin.json`: `command: node` + `dist/server/index.js` → `command: bun` + `server/index.ts`.
- `lsp/architecture/package.json`: `dogfood` script uses `bun dogfood.ts` (drops `pnpm build` prereq). `build` and `pretest` stay for typecheck + vitest.
- CI: adds `oven-sh/setup-bun@v2` to the two-lsp-dogfood job; runs `bun dogfood.ts` directly.

## What didn't change

- Syntax LSP (`lsp/syntax/launch.js` is handwritten JS, no compilation issue).
- build-test CI job (still does `pnpm build && pnpm test` for typecheck + vitest).
- Source code under `lsp/architecture/\*\*/*.ts` — no logic changes.

## Tradeoff

Users now need `bun` on PATH. Since sfd is a gstack-based plugin and gstack already requires bun for its `browse` skill, the user base almost certainly has bun. If absent, the LSP fails with `bun: command not found` — visible error vs the current silent miss.

## Test plan

- [x] Local: `bun server/index.ts` starts cleanly (LSP awaits stdio as expected).
- [x] Local: `bun dogfood.ts` loads (fixture install required for full run).
- [ ] CI build-test: green (no change to that job).
- [ ] CI two-lsp-dogfood: green with new bun setup step.