### PR TITLE
docs: surface the two LSPs from the ACG↔SFD reorg

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,6 +40,9 @@ safer-by-default/
 │   └── setup/
 ├── bin/                       ← 14 CLI helpers; auto-PATH at session start (see "CLI helpers" below)
 ├── lib/                       ← shell modules sourced by bin/ scripts
+├── lsp/                       ← two LSP servers declared in plugin.json (see "LSP integration" below)
+│   ├── syntax/                ← thin launcher around upstream vscode-eslint-language-server
+│   └── architecture/          ← custom architecture analyzer + LSP server, runs via bun
 ├── docs/contracts/            ← worked-example contract templates
 ├── scenarios/                 ← cc-judge calibration suite
 ├── tests/                     ← test-bin/, test-integration/
@@ -88,6 +91,21 @@ Each helper is a standalone bash script. The plugin marketplace install auto-pre
 | `safer-gen-skills` | Render `skills/<name>/SKILL.md` from `SKILL.tmpl + PRINCIPLES.md` | `[--check]` |
 
 Conventions: helpers exit non-zero on missing required args; skills wrap calls with `2>/dev/null || true` only when the helper is optional plumbing (telemetry, update-check), never when it's load-bearing. `safer-publish` routes through zapbot's bot-token broker when zapbot is detected on the host; absent zapbot, falls back to the user's `gh auth`.
+
+## LSP integration
+
+The plugin manifest (`.claude-plugin/plugin.json`) declares two `lspServers`. Both auto-start when Claude Code (or any LSP-aware editor wired to this plugin) opens a TypeScript file:
+
+| Server | What it does | Runtime |
+|---|---|---|
+| `agent-code-guard-syntax` | Wraps upstream `vscode-eslint-language-server`. Surfaces every `eslint-plugin-agent-code-guard` rule violation with a one-line rationale and a link to the relevant `PRINCIPLES.md` heading via `codeDescription.href`. | `node lsp/syntax/launch.js` (thin wrapper) |
+| `agent-code-guard-architecture` | Custom Effect-shaped server backed by the architecture analyzer (folder graph, public surface, vendor type leaks, cycle detection). Reads file-header `// @agent-code-guard/architecture-exception: <rule>` directives for per-file suppressions. Same rationale + `PRINCIPLES.md` link per diagnostic. | `bun lsp/architecture/server/index.ts` (runs TypeScript source directly) |
+
+Both servers populate `codeDescription.href` on every diagnostic so editor tooltips link directly to the doctrine. The architecture analyzer also exports a thin shim at `lsp/architecture/check.ts` that CI can invoke (`node lsp/architecture/check.js` post-build, or `bun lsp/architecture/check.ts` from source) to exit non-zero on error-severity findings without needing the full LSP protocol.
+
+Dependencies: the syntax LSP needs `vscode-eslint-language-server` on `PATH` (installed by `/safer:setup`). The architecture LSP needs `bun` on `PATH` (already a gstack dependency).
+
+A two-LSP programmatic integration test ships at `lsp/architecture/dogfood.ts` and runs in CI; it spawns both LSPs via the manifest's `command + args`, sends `didOpen` on a fixture file with syntax + architecture violations, and asserts both diagnostics arrive with `codeDescription.href` populated and the servers shut down cleanly.
 
 ## Install paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Skills load as `safer:NAME` in both Claude Code and Codex (e.g. `/safer:spec`, `
 - `scenarios/` — cc-judge calibration suite for evaluating doctrine adherence; see `scenarios/README.md`.
 - `bin/` — 14 standalone helpers (publish, telemetry, escalate, etc.). All are on `PATH` in any session that has the plugin enabled. See `ARCHITECTURE.md` → CLI helpers for the full list.
 - `lib/` — helper shell modules sourced by `bin/` scripts.
+- `lsp/` — two LSP servers declared in `.claude-plugin/plugin.json`'s `lspServers`. `lsp/syntax/launch.js` wraps upstream `vscode-eslint-language-server` for the ACG syntax rules; `lsp/architecture/` is the custom Effect-shaped architecture analyzer + server (runs via `bun` directly on TypeScript source). Both fire diagnostics with `codeDescription.href` links to `PRINCIPLES.md` anchors. See `ARCHITECTURE.md` → LSP integration.
 
 ## Skill routing
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,9 +92,19 @@ Covers `bin/` helpers and the Codex compatibility layer. Each test runs in an is
 
 ## Requirements
 
-- `gh` (authenticated with `repo` scope), `git`, `bash`, `bun` (for the template generator).
+- `gh` (authenticated with `repo` scope), `git`, `bash`, `bun` (template generator + the architecture LSP runtime).
 - [gstack](https://github.com/garrytan/gstack) installed at `~/.claude/skills/gstack/`. safer-by-default treats gstack as a hard dependency — every safer skill calls gstack tools (`/simplify`, `/review`, `/codex`, `/plan-eng-review`, `/security-review`, `/ship`, etc.) inline. `/safer:setup` fails fast if gstack is absent.
+- `vscode-eslint-language-server` (from `vscode-langservers-extracted`) on `PATH` for the syntax LSP. `/safer:setup` installs it in the target repo as part of the standard ESLint setup.
 - **Optional:** [`zapbot`](https://github.com/chughtapan/zapbot) for richer publish paths (falls back to `gh` cleanly if absent).
+
+## LSP behavior at install time
+
+The plugin manifest declares two `lspServers` (see `ARCHITECTURE.md` → LSP integration). When Claude Code (or an LSP-aware editor wired to this plugin) opens a TypeScript file, both servers auto-start:
+
+- `agent-code-guard-syntax` → `node lsp/syntax/launch.js` (spawns upstream `vscode-eslint-language-server`).
+- `agent-code-guard-architecture` → `bun lsp/architecture/server/index.ts` (runs TypeScript source directly; no build step).
+
+If `bun` isn't on `PATH`, the architecture LSP fails to start with a visible `bun: command not found`. If `vscode-eslint-language-server` isn't on `PATH`, the syntax LSP prints a friendly pointer at `/safer:setup`. Either way, the rest of the plugin (skills, bins) keeps working.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Creates the GitHub issue labels skills publish under. Idempotent.
 
 For dependency requirements, source-resolution detail, working from source, and troubleshooting, see [INSTALL.md](./INSTALL.md).
 
+## Editor diagnostics (two LSPs)
+
+The plugin manifest auto-registers two language servers that fire diagnostics in editor and in agent context. Every diagnostic carries a one-line rationale plus a `codeDescription.href` link to the relevant `PRINCIPLES.md` heading, so reading the error reads the doctrine.
+
+- **`agent-code-guard-syntax`** wraps upstream `vscode-eslint-language-server`. It surfaces every `eslint-plugin-agent-code-guard` rule violation: bare casts, `throw new Error`, `Promise<T>` that erases the error channel, raw SQL, manual enums, mocks in integration tests, the lot.
+- **`agent-code-guard-architecture`** runs a custom architecture analyzer: folder dependency graph, public surface curation, vendor type leaks, cross-domain sibling imports, cycles. File-header directives (`// @agent-code-guard/architecture-exception: <rule>`) provide per-file suppressions when needed.
+
+Both servers run via `bun` (architecture) or `node` (the thin syntax launcher); no build step at install time. Dependencies: `vscode-eslint-language-server` for the syntax LSP (installed by `/safer:setup`) and `bun` for the architecture LSP (already a gstack dependency).
+
 ## Four parts
 
 The doctrine factors into four orthogonal axes. The first two govern *what code looks like*; the third governs *when it earns done*; the fourth governs *how work hands off*. Each safer skill projects from these four into one modality. The full text lives in [PRINCIPLES.md](./PRINCIPLES.md); the catalog of bullet points below is the operational summary.


### PR DESCRIPTION
Doc-only update. Follow-up to the closed ACG↔SFD reorg epic (chughtapan/agent-code-guard#71) + PR #297 (bun runtime).

## What this fixes

The 9-phase reorg + bun-runtime fix all merged today, but the docs didn't mention the new editor-integration capability at all. A reader landing on README would have no idea two LSPs auto-register on plugin install.

## Changes

- **README.md** — new `## Editor diagnostics (two LSPs)` section between Quick start and Four parts. Names both servers, what each catches, what each links to.
- **ARCHITECTURE.md** — `lsp/` added to the repo layout block; new `## LSP integration` section between CLI helpers and Install paths. Table of both servers + runtime + dependencies + dogfood test pointer.
- **CLAUDE.md** — `lsp/` added to `Non-skill assets worth knowing about`.
- **INSTALL.md** — bun called out as both template-generator AND architecture-LSP runtime dep; new `## LSP behavior at install time` section explaining auto-start + failure modes.

## What I deliberately did not touch

- **VERSION** (0.1.4). Per orchestrator memory rule, version bumps require explicit user authorization. After this PR + the reorg PRs merge, a 0.1.5 release covering everything since 0.1.4 makes sense — pending your call.
- **CHANGELOG.md**. Same memory rule. A CHANGELOG entry covering the reorg + LSP capabilities is the right shape but I'm holding for your authorization.

## Test plan

Doc-only. No CI affected. Sanity checks:
- [x] Repo layout in ARCHITECTURE.md matches actual `ls -la` (skills/=16 subdirs ✓, lsp/ has syntax/ + architecture/ ✓).
- [x] LSP description matches `.claude-plugin/plugin.json` actual lspServers entries.
- [x] No references to deleted typescript skill anywhere (Phase 8 cleanup was thorough).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>