### PR TITLE
chore(ci): drop the acg pinned-SHA bridge — npm 0.0.14 has meta.docs.url

### DIFF
--- a/.github/workflows/lsp-architecture.yml
+++ b/.github/workflows/lsp-architecture.yml
@@ -75,32 +75,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.12"
-      # The dogfood test asserts `codeDescription.href` populated. Syntax
-      # rule URLs come from `meta.docs.url` in
-      # eslint-plugin-agent-code-guard. acg Phase 2 added the URLs on
-      # main but the latest npm release predates them; pin the SHA and
-      # build the tarball locally. Drop this whole job step (and revert
-      # the fixture `package.json` to `eslint-plugin-agent-code-guard:
-      # ^<next>`) once acg republishes.
-      - name: Build agent-code-guard at pinned SHA
-        env:
-          ACG_SHA: d11973a50425e0285e6c066769cbc10921f9a9fd
-        run: |
-          set -euxo pipefail
-          git clone https://github.com/chughtapan/agent-code-guard.git /tmp/acg
-          cd /tmp/acg
-          git checkout "$ACG_SHA"
-          pnpm install --frozen-lockfile
-          pnpm build
-          npm pack --silent
-          cp eslint-plugin-agent-code-guard-*.tgz \
-            "${GITHUB_WORKSPACE}/lsp/architecture/dogfood-fixtures/two-lsp/acg.tgz"
-      - name: Install fixture deps (with acg tarball)
+      - name: Install fixture deps
         working-directory: lsp/architecture/dogfood-fixtures/two-lsp
-        run: |
-          set -euxo pipefail
-          node -e "const fs=require('fs');const p='package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));j.devDependencies['eslint-plugin-agent-code-guard']='file:./acg.tgz';fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n')"
-          pnpm install --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
       - name: Install architecture LSP deps
         working-directory: lsp/architecture
         run: pnpm install --frozen-lockfile

--- a/lsp/architecture/dogfood-fixtures/two-lsp/package.json
+++ b/lsp/architecture/dogfood-fixtures/two-lsp/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^9.0.0",
-    "eslint-plugin-agent-code-guard": "^0.0.13",
+    "eslint-plugin-agent-code-guard": "^0.0.14",
     "typescript": "^5.4.0",
     "vscode-langservers-extracted": "^4.10.0"
   }


### PR DESCRIPTION
Cleanup follow-up to v0.1.5. Now that `eslint-plugin-agent-code-guard@0.0.14` is on npm with Phase 2's `meta.docs.url` populated, the dogfood-fixture's clone+build+pack workaround is dead weight.

## Changes

- `lsp/architecture/dogfood-fixtures/two-lsp/package.json`: `^0.0.13` → `^0.0.14`.
- `.github/workflows/lsp-architecture.yml`: drop the 3-step bridge (clone acg at pinned SHA, build, pack, rewrite fixture package.json to use the tarball). Fixture install reverts to the standard `pnpm install --no-frozen-lockfile`.

## Test plan

- [x] Local: `pnpm install` in the fixture pulls 0.0.14 from npm; `node_modules/eslint-plugin-agent-code-guard/dist/rules/utils/principles.js` present (confirms Phase 2 work shipped).
- [ ] CI: all three jobs (`build-test`, `bun-runtime-smoke`, `two-lsp-dogfood`) stay green. The dogfood test asserts `codeDescription.href` populated — that's exactly what 0.0.14 provides.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>