### PR TITLE
chore: sync marketplace.json to 0.1.5 + add version-sync guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "safer",
       "source": "./",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "description": "16 skills (architect, diagnose, docs-reader, dogfood, implement-{junior,senior,staff}, orchestrate, research, review-senior, setup, spec, spike, stamina, ux-audit, verify) plus 14 bin/ utilities. Composes with eslint-plugin-agent-code-guard (lint floor) and zapbot (publish).",
       "author": {
         "name": "Tapan Chugh"

--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,0 +1,37 @@
+name: version-sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "VERSION"
+      - ".claude-plugin/plugin.json"
+      - ".claude-plugin/marketplace.json"
+      - ".github/workflows/version-sync.yml"
+  pull_request:
+    paths:
+      - "VERSION"
+      - ".claude-plugin/plugin.json"
+      - ".claude-plugin/marketplace.json"
+      - ".github/workflows/version-sync.yml"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Versions agree across VERSION, plugin.json, marketplace.json
+        # `/plugin update` reads marketplace.json; if it lags plugin.json,
+        # consumers silently stay on the prior version.
+        run: |
+          set -euo pipefail
+          file_version=$(tr -d '[:space:]' < VERSION)
+          plugin_version=$(jq -r '.version' .claude-plugin/plugin.json)
+          marketplace_version=$(jq -r '.plugins[] | select(.name == "safer") | .version' .claude-plugin/marketplace.json)
+          echo "VERSION:                                $file_version"
+          echo ".claude-plugin/plugin.json .version:    $plugin_version"
+          echo ".claude-plugin/marketplace.json safer:  $marketplace_version"
+          if [ "$file_version" != "$plugin_version" ] || [ "$file_version" != "$marketplace_version" ]; then
+            echo "::error::version drift; bump all three files together"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Bump `.claude-plugin/marketplace.json` safer plugin to `0.1.5` — the 0.1.5 release commit moved `VERSION` and `plugin.json` but missed this file, so `/plugin update safer@safer-by-default` kept reporting "already at 0.1.4" for every consumer.
- Add `.github/workflows/version-sync.yml`: fails any PR (and any push to `main`) where `VERSION`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` versions disagree.

## Test plan
- [ ] CI passes (the new `version-sync` job should be green; all three sources are at 0.1.5).
- [ ] After merge, run `/plugin marketplace update safer-by-default` then `/plugin update safer@safer-by-default` locally — should pull 0.1.5 into the cache.
- [ ] Restart Claude Code and confirm both LSPs (`agent-code-guard-syntax` + architecture) spawn against a `.ts` file in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)