### PR TITLE
fix(lsp/architecture): expand workspace globs so monorepos publish diagnostics

### DIFF
--- a/lsp/architecture/check.ts
+++ b/lsp/architecture/check.ts
@@ -4,18 +4,29 @@
  * @file CI shim. Runs the architecture analyzer against the cwd's
  * project, prints each finding, and exits non-zero on any
  * error-severity diagnostic. Invocation: `node lsp/architecture/check.js`.
+ *
+ * Monorepo handling: if cwd declares pnpm/npm/yarn workspaces, the
+ * analyzer is run once per workspace package (each carries its own
+ * `tsconfig.json`); findings from every package are merged into the
+ * single output stream. Single-project repos fall through to the
+ * pre-fix single `analyzeWorkspace(cwd)` invocation.
  */
 
 import process from "node:process";
 import { analyzeWorkspace } from "./analyzer/index.js";
+import { discoverProjectRoots } from "./workspace-discovery.js";
 
 function main(): void {
-  const report = analyzeWorkspace({ projectRoot: process.cwd() });
+  const cwd = process.cwd();
+  const discovered = discoverProjectRoots(cwd);
   let hasError = false;
-  for (const finding of report.diagnostics) {
-    if (finding.severity === "error") hasError = true;
-    const line = `${finding.severity.toUpperCase()} ${finding.ruleId} ${finding.file}: ${finding.message}`;
-    process.stdout.write(`${line}\n`);
+  for (const projectRoot of discovered.projectRoots) {
+    const report = analyzeWorkspace({ projectRoot });
+    for (const finding of report.diagnostics) {
+      if (finding.severity === "error") hasError = true;
+      const line = `${finding.severity.toUpperCase()} ${finding.ruleId} ${finding.file}: ${finding.message}`;
+      process.stdout.write(`${line}\n`);
+    }
   }
   process.exit(hasError ? 1 : 0);
 }

--- a/lsp/architecture/index.ts
+++ b/lsp/architecture/index.ts
@@ -16,3 +16,9 @@ export {
   ARCHITECTURE_DIRECTIVE_PARSE_ERROR_RULE_ID,
   type ArchitectureRuleId,
 } from "./analyzer/rule-ids.js";
+export {
+  discoverProjectRoots,
+  parsePnpmWorkspacePackages,
+  type WorkspaceDiscoveryResult,
+  type WorkspaceDiscoverySource,
+} from "./workspace-discovery.js";

--- a/lsp/architecture/server/lsp-server.ts
+++ b/lsp/architecture/server/lsp-server.ts
@@ -25,6 +25,7 @@ import {
   TextDocumentSyncKind,
 } from "vscode-languageserver";
 import { clearWorkspaceCache } from "../analyzer/project/cache/index.js";
+import { discoverProjectRoots } from "../workspace-discovery.js";
 import { groupByUri } from "./diagnostic-converter.js";
 import { type DocumentStore, makeDocumentStore } from "./document-store.js";
 import { type WorkspaceEngine } from "./workspace-engine.js";
@@ -125,12 +126,20 @@ const registerInitialWorkspaces = (
   Effect.gen(function* () {
     const folders = params.workspaceFolders ?? [];
     for (const folder of folders) {
-      const root = fileURLToPath(folder.uri);
-      const engine = yield* deps.registry.register(root);
-      // Re-publish for any docs in this workspace when its watcher fires.
-      yield* Effect.forkScoped(
-        Stream.runForEach(engine.invalidations, () => publishAllOpen(deps, engine)),
-      );
+      const workspaceRoot = fileURLToPath(folder.uri);
+      // Monorepos (pnpm-workspace.yaml, package.json `workspaces`) carry
+      // one tsconfig per package, not one at the workspace root. Register
+      // an engine per discovered package so diagnostics actually publish
+      // when files inside `packages/*` are opened. Single-project repos
+      // fall through with `[workspaceRoot]` (pre-fix behaviour).
+      const discovered = discoverProjectRoots(workspaceRoot);
+      for (const root of discovered.projectRoots) {
+        const engine = yield* deps.registry.register(root);
+        // Re-publish for any docs in this workspace when its watcher fires.
+        yield* Effect.forkScoped(
+          Stream.runForEach(engine.invalidations, () => publishAllOpen(deps, engine)),
+        );
+      }
     }
   });
 

--- a/lsp/architecture/tests/check.test.ts
+++ b/lsp/architecture/tests/check.test.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, expect, it } from "vitest";
 import { clearArchitectureCache } from "../analyzer/project/cache/index.js";
@@ -40,4 +42,100 @@ it("check: exits 1 on a project with an error-severity finding", () => {
   });
   const result = spawnSync("node", [CHECK_SCRIPT], { cwd: root, encoding: "utf8" });
   expect(result.status).toBe(1);
+});
+
+const monorepoFixtureRoots = new Set<string>();
+
+afterEach(() => {
+  for (const root of monorepoFixtureRoots) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  monorepoFixtureRoots.clear();
+});
+
+function makeMonorepoFixture(packages: Record<string, Record<string, string>>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-check-monorepo-"));
+  monorepoFixtureRoots.add(root);
+  fs.writeFileSync(
+    path.join(root, "pnpm-workspace.yaml"),
+    "packages:\n  - 'packages/*'\n",
+  );
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "monorepo-fixture", private: true }, null, 2),
+  );
+  for (const [pkgName, files] of Object.entries(packages)) {
+    const pkgRoot = path.join(root, "packages", pkgName);
+    fs.mkdirSync(pkgRoot, { recursive: true });
+    for (const [rel, contents] of Object.entries(files)) {
+      const absolute = path.join(pkgRoot, rel);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, contents);
+    }
+  }
+  return root;
+}
+
+const MINIMAL_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    target: "ES2022",
+    module: "NodeNext",
+    moduleResolution: "NodeNext",
+    strict: true,
+    skipLibCheck: true,
+    declaration: true,
+    outDir: "./dist",
+    rootDir: "./src",
+  },
+  include: ["src/**/*"],
+});
+
+it("check: walks every workspace package when run from a pnpm monorepo root", () => {
+  // Clean child package — no error-severity findings.
+  const cleanPackage: Record<string, string> = {
+    "tsconfig.json": MINIMAL_TSCONFIG,
+    "package.json": JSON.stringify({
+      name: "clean",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+    }),
+    "src/index.ts": "export const x = 1;\n",
+  };
+  // Child package that fires `no-internal-subpath-export` (error).
+  const dirtyPackage: Record<string, string> = {
+    "tsconfig.json": MINIMAL_TSCONFIG,
+    "package.json": JSON.stringify({
+      name: "dirty",
+      version: "1.0.0",
+      type: "module",
+      exports: {
+        ".": { import: "./dist/index.js", types: "./dist/index.d.ts" },
+        "./*": { import: "./dist/*.js" },
+      },
+    }),
+    "src/index.ts": "export const x = 1;\n",
+  };
+  const root = makeMonorepoFixture({ clean: cleanPackage, dirty: dirtyPackage });
+  const result = spawnSync("node", [CHECK_SCRIPT], { cwd: root, encoding: "utf8" });
+  expect(result.status).toBe(1);
+  // The finding must be attributed to the dirty package, not the root.
+  expect(result.stdout).toMatch(/ERROR no-internal-subpath-export .*packages\/dirty/);
+  expect(result.stdout).not.toMatch(/ERROR no-internal-subpath-export .*packages\/clean/);
+});
+
+it("check: exits 0 when every monorepo package is clean", () => {
+  const cleanPackage: Record<string, string> = {
+    "tsconfig.json": MINIMAL_TSCONFIG,
+    "package.json": JSON.stringify({
+      name: "clean",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./dist/index.js" },
+    }),
+    "src/index.ts": "export const x = 1;\n",
+  };
+  const root = makeMonorepoFixture({ a: cleanPackage, b: cleanPackage });
+  const result = spawnSync("node", [CHECK_SCRIPT], { cwd: root, encoding: "utf8" });
+  expect(result.status).toBe(0);
 });

--- a/lsp/architecture/tests/workspace-discovery.test.ts
+++ b/lsp/architecture/tests/workspace-discovery.test.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  discoverProjectRoots,
+  parsePnpmWorkspacePackages,
+} from "../workspace-discovery.js";
+
+const tempDirs = new Set<string>();
+
+afterEach(() => {
+  for (const dir of tempDirs) fs.rmSync(dir, { recursive: true, force: true });
+  tempDirs.clear();
+});
+
+function makeTempTree(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "acg-workspace-discovery-"));
+  tempDirs.add(root);
+  for (const [rel, contents] of Object.entries(files)) {
+    const absolute = path.join(root, rel);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, contents);
+  }
+  return root;
+}
+
+const TSCONFIG = JSON.stringify({ compilerOptions: { target: "ES2022" } });
+
+describe("parsePnpmWorkspacePackages", () => {
+  it("parses a flat sequence of package patterns", () => {
+    const text = ["packages:", "  - 'packages/*'", "  - apps/*"].join("\n");
+    expect(parsePnpmWorkspacePackages(text)).toEqual(["packages/*", "apps/*"]);
+  });
+
+  it("ignores leading comments and blank lines", () => {
+    const text = [
+      "# pnpm workspace",
+      "",
+      "packages:",
+      "  # inline comment",
+      "  - \"packages/*\"",
+    ].join("\n");
+    expect(parsePnpmWorkspacePackages(text)).toEqual(["packages/*"]);
+  });
+
+  it("stops at the next top-level key", () => {
+    const text = [
+      "packages:",
+      "  - packages/*",
+      "catalog:",
+      "  - other-thing",
+    ].join("\n");
+    expect(parsePnpmWorkspacePackages(text)).toEqual(["packages/*"]);
+  });
+
+  it("returns an empty list when packages: is absent", () => {
+    expect(parsePnpmWorkspacePackages("catalog:\n  - x\n")).toEqual([]);
+  });
+});
+
+describe("discoverProjectRoots", () => {
+  it("expands pnpm-workspace.yaml globs and filters by tsconfig.json", () => {
+    const root = makeTempTree({
+      "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+      "packages/server/tsconfig.json": TSCONFIG,
+      "packages/server/package.json": JSON.stringify({ name: "server" }),
+      "packages/client/tsconfig.json": TSCONFIG,
+      "packages/client/package.json": JSON.stringify({ name: "client" }),
+      // No tsconfig — must be filtered out.
+      "packages/docs/package.json": JSON.stringify({ name: "docs" }),
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.source).toBe("pnpm-workspace");
+    expect(result.projectRoots).toEqual([
+      path.join(root, "packages/client"),
+      path.join(root, "packages/server"),
+    ]);
+  });
+
+  it("applies negative pnpm patterns", () => {
+    const root = makeTempTree({
+      "pnpm-workspace.yaml": [
+        "packages:",
+        "  - 'packages/*'",
+        "  - '!packages/legacy'",
+      ].join("\n"),
+      "packages/server/tsconfig.json": TSCONFIG,
+      "packages/legacy/tsconfig.json": TSCONFIG,
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.projectRoots).toEqual([path.join(root, "packages/server")]);
+  });
+
+  it("expands package.json workspaces array", () => {
+    const root = makeTempTree({
+      "package.json": JSON.stringify({
+        name: "monorepo",
+        private: true,
+        workspaces: ["packages/*"],
+      }),
+      "packages/api/tsconfig.json": TSCONFIG,
+      "packages/web/tsconfig.json": TSCONFIG,
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.source).toBe("package-json-workspaces");
+    expect(result.projectRoots).toEqual([
+      path.join(root, "packages/api"),
+      path.join(root, "packages/web"),
+    ]);
+  });
+
+  it("expands package.json workspaces object form", () => {
+    const root = makeTempTree({
+      "package.json": JSON.stringify({
+        name: "monorepo",
+        private: true,
+        workspaces: { packages: ["packages/*"], nohoist: [] },
+      }),
+      "packages/api/tsconfig.json": TSCONFIG,
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.source).toBe("package-json-workspaces");
+    expect(result.projectRoots).toEqual([path.join(root, "packages/api")]);
+  });
+
+  it("falls back to [workspaceRoot] for a single-project repo", () => {
+    const root = makeTempTree({
+      "tsconfig.json": TSCONFIG,
+      "package.json": JSON.stringify({ name: "single" }),
+      "src/index.ts": "export const x = 1;\n",
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.source).toBe("fallback");
+    expect(result.projectRoots).toEqual([root]);
+  });
+
+  it("falls back to [workspaceRoot] when a workspace declaration matches no tsconfig-bearing packages", () => {
+    const root = makeTempTree({
+      "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+      // Workspace child has no tsconfig — analyzer can't run on it.
+      "packages/docs/package.json": JSON.stringify({ name: "docs" }),
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.source).toBe("fallback");
+    expect(result.projectRoots).toEqual([root]);
+  });
+
+  it("prefers pnpm-workspace.yaml over package.json workspaces when both are present", () => {
+    const root = makeTempTree({
+      "pnpm-workspace.yaml": "packages:\n  - 'pnpm-pkgs/*'\n",
+      "package.json": JSON.stringify({
+        name: "mixed",
+        workspaces: ["npm-pkgs/*"],
+      }),
+      "pnpm-pkgs/a/tsconfig.json": TSCONFIG,
+      "npm-pkgs/b/tsconfig.json": TSCONFIG,
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.source).toBe("pnpm-workspace");
+    expect(result.projectRoots).toEqual([path.join(root, "pnpm-pkgs/a")]);
+  });
+
+  it("walks deeper globs with **", () => {
+    const root = makeTempTree({
+      "pnpm-workspace.yaml": "packages:\n  - 'packages/**'\n",
+      "packages/a/tsconfig.json": TSCONFIG,
+      "packages/group/b/tsconfig.json": TSCONFIG,
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.projectRoots).toEqual([
+      path.join(root, "packages/a"),
+      path.join(root, "packages/group/b"),
+    ]);
+  });
+
+  it("skips node_modules and dotted directories during expansion", () => {
+    const root = makeTempTree({
+      "pnpm-workspace.yaml": "packages:\n  - 'packages/*'\n",
+      "packages/server/tsconfig.json": TSCONFIG,
+      "packages/node_modules/pkg/tsconfig.json": TSCONFIG,
+      "packages/.cache/tsconfig.json": TSCONFIG,
+    });
+    const result = discoverProjectRoots(root);
+    expect(result.projectRoots).toEqual([path.join(root, "packages/server")]);
+  });
+});

--- a/lsp/architecture/workspace-discovery.ts
+++ b/lsp/architecture/workspace-discovery.ts
@@ -1,0 +1,279 @@
+/**
+ * @file Workspace-aware project-root discovery. The architecture
+ * analyzer is single-project: one `tsconfig.json` per
+ * `analyzeWorkspace` call. The LSP server (and the `check.ts` CI
+ * shim) need to map an opaque workspace root — what Claude Code
+ * sends in `initialize.workspaceFolders[].uri`, or whatever `cwd`
+ * the CI invocation happens to use — to the list of per-package
+ * project roots the analyzer should actually walk.
+ *
+ * Supported workspace declarations:
+ *   - `pnpm-workspace.yaml` with a top-level `packages:` list
+ *   - `package.json` with a `workspaces` field (npm/yarn-style array,
+ *     or `{ packages: […] }` object form)
+ *
+ * A workspace package counts only if it has its own
+ * `tsconfig.json`; the analyzer cannot run without one. Glob globbing
+ * supports the patterns that show up in real monorepos (`packages/*`,
+ * `apps/**`, leading `!` for negation); fancier minimatch syntax is
+ * not implemented and emits no findings beyond the literal directory
+ * walk. If no workspace declaration is found, the workspaceRoot is
+ * returned as a single-entry list — matching the pre-fix behaviour.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export type WorkspaceDiscoverySource =
+  | "pnpm-workspace"
+  | "package-json-workspaces"
+  | "fallback";
+
+export interface WorkspaceDiscoveryResult {
+  /** Absolute project-root paths the analyzer should be run against. */
+  readonly projectRoots: readonly string[];
+  /** Where the project roots came from. `fallback` means single-project. */
+  readonly source: WorkspaceDiscoverySource;
+}
+
+/**
+ * Resolve the analyzer project roots that live under `workspaceRoot`.
+ * @param workspaceRoot Absolute path to the LSP workspace folder / CLI cwd.
+ * @returns Project roots + the source of the discovery.
+ */
+export function discoverProjectRoots(
+  workspaceRoot: string,
+): WorkspaceDiscoveryResult {
+  const pnpmPatterns = readPnpmWorkspacePatterns(workspaceRoot);
+  if (pnpmPatterns !== null) {
+    const roots = expandAndFilter(workspaceRoot, pnpmPatterns);
+    if (roots.length > 0) {
+      return { projectRoots: roots, source: "pnpm-workspace" };
+    }
+  }
+  const npmPatterns = readPackageJsonWorkspacePatterns(workspaceRoot);
+  if (npmPatterns !== null) {
+    const roots = expandAndFilter(workspaceRoot, npmPatterns);
+    if (roots.length > 0) {
+      return { projectRoots: roots, source: "package-json-workspaces" };
+    }
+  }
+  return { projectRoots: [workspaceRoot], source: "fallback" };
+}
+
+function expandAndFilter(
+  workspaceRoot: string,
+  patterns: readonly string[],
+): readonly string[] {
+  const positive = patterns.filter((p) => !p.startsWith("!"));
+  const negative = patterns
+    .filter((p) => p.startsWith("!"))
+    .map((p) => p.slice(1));
+  const positiveDirs = new Set<string>();
+  for (const pattern of positive) {
+    for (const dir of expandPattern(workspaceRoot, pattern)) {
+      positiveDirs.add(dir);
+    }
+  }
+  const negativeDirs = new Set<string>();
+  for (const pattern of negative) {
+    for (const dir of expandPattern(workspaceRoot, pattern)) {
+      negativeDirs.add(dir);
+    }
+  }
+  const out: string[] = [];
+  for (const dir of positiveDirs) {
+    if (negativeDirs.has(dir)) continue;
+    if (!hasTsconfig(dir)) continue;
+    out.push(dir);
+  }
+  out.sort();
+  return out;
+}
+
+function readPnpmWorkspacePatterns(
+  workspaceRoot: string,
+): readonly string[] | null {
+  const file = path.join(workspaceRoot, "pnpm-workspace.yaml");
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  return parsePnpmWorkspacePackages(text);
+}
+
+/**
+ * Parse the `packages:` list out of a `pnpm-workspace.yaml`. The pnpm
+ * schema is broader (catalogs, overrides, etc.) but only the
+ * `packages:` list is load-bearing for project-root discovery, so this
+ * parser implements the minimum: top-level `packages:` key followed
+ * by a YAML sequence of strings, with `#` comments and optional
+ * quoting honoured. Anything else is ignored.
+ * @param text File contents of `pnpm-workspace.yaml`.
+ * @returns The declared `packages:` patterns (empty array if absent).
+ */
+export function parsePnpmWorkspacePackages(text: string): readonly string[] {
+  const lines = text.split(/\r?\n/);
+  const out: string[] = [];
+  let inPackages = false;
+  let packagesIndent = -1;
+  for (const raw of lines) {
+    const stripped = stripYamlComment(raw);
+    if (stripped.trim() === "") continue;
+    const indent = leadingSpaces(stripped);
+    if (indent === 0) {
+      inPackages = /^packages\s*:/.test(stripped);
+      packagesIndent = -1;
+      continue;
+    }
+    if (!inPackages) continue;
+    if (packagesIndent === -1) packagesIndent = indent;
+    if (indent < packagesIndent) {
+      inPackages = false;
+      continue;
+    }
+    const m = stripped.match(/^\s+-\s+(.+?)\s*$/);
+    if (m === null) continue;
+    out.push(stripYamlQuotes(m[1]));
+  }
+  return out;
+}
+
+function stripYamlComment(line: string): string {
+  // Pre-quote `#` is a comment; intra-quote `#` is data. The minimal
+  // form used in pnpm-workspace.yaml never embeds `#` inside quoted
+  // package patterns, so a literal-quote-aware split is overkill.
+  const idx = line.indexOf("#");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+function leadingSpaces(line: string): number {
+  let i = 0;
+  while (i < line.length && line[i] === " ") i += 1;
+  return i;
+}
+
+function stripYamlQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+function readPackageJsonWorkspacePatterns(
+  workspaceRoot: string,
+): readonly string[] | null {
+  const file = path.join(workspaceRoot, "package.json");
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return null;
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof json !== "object" || json === null) return null;
+  const ws = (json as Record<string, unknown>).workspaces;
+  if (Array.isArray(ws)) {
+    return ws.filter((x): x is string => typeof x === "string");
+  }
+  if (typeof ws === "object" && ws !== null) {
+    const pkgs = (ws as Record<string, unknown>).packages;
+    if (Array.isArray(pkgs)) {
+      return pkgs.filter((x): x is string => typeof x === "string");
+    }
+  }
+  return null;
+}
+
+function expandPattern(
+  workspaceRoot: string,
+  pattern: string,
+): readonly string[] {
+  const normalised = pattern.replace(/\/+$/, "");
+  if (normalised === "" || normalised === ".") {
+    return isDirectory(workspaceRoot) ? [workspaceRoot] : [];
+  }
+  const segments = normalised.split("/").filter((s) => s !== "" && s !== ".");
+  return walkSegments(workspaceRoot, segments);
+}
+
+function walkSegments(
+  base: string,
+  segments: readonly string[],
+): readonly string[] {
+  if (segments.length === 0) {
+    return isDirectory(base) ? [base] : [];
+  }
+  const [head, ...rest] = segments;
+  if (head === "**") {
+    const out = new Set<string>(walkSegments(base, rest));
+    for (const child of listChildDirs(base)) {
+      for (const dir of walkSegments(path.join(base, child), segments)) {
+        out.add(dir);
+      }
+    }
+    return [...out];
+  }
+  if (head.includes("*")) {
+    const matcher = wildcardMatcher(head);
+    const out: string[] = [];
+    for (const child of listChildDirs(base)) {
+      if (!matcher(child)) continue;
+      out.push(...walkSegments(path.join(base, child), rest));
+    }
+    return out;
+  }
+  const next = path.join(base, head);
+  if (!isDirectory(next)) return [];
+  return walkSegments(next, rest);
+}
+
+function wildcardMatcher(segment: string): (name: string) => boolean {
+  const re = new RegExp(
+    "^" +
+      segment
+        .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+        .replace(/\*/g, "[^/]*") +
+      "$",
+  );
+  return (name) => re.test(name);
+}
+
+function listChildDirs(dir: string): readonly string[] {
+  try {
+    return fs
+      .readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .filter((entry) => entry.name !== "node_modules" && !entry.name.startsWith("."))
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+function isDirectory(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function hasTsconfig(dir: string): boolean {
+  try {
+    return fs.statSync(path.join(dir, "tsconfig.json")).isFile();
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

The architecture analyzer is single-project: one `tsconfig.json` per `analyzeWorkspace` call. In a pnpm/npm/yarn workspace the LSP receives `rootUri = repo root`, finds no source `tsconfig.json` there, and silently publishes nothing — so squiggles never appear on any file in `packages/*`. The CI shim (`check.ts`) had the same blind spot.

This patch adds a workspace-discovery layer that resolves a workspace root to the list of per-package project roots, then wires it into both the LSP server and the CI shim.

### Repro (pre-fix)

Run `node lsp/architecture/check.js` from the root of any pnpm monorepo with `packages/*`:

- The analyzer can't find a `tsconfig.json` at the workspace root.
- The CI shim prints nothing and exits 0 — even when individual packages have hundreds of findings.
- The LSP server registers one engine for the workspace root; that engine's analyzer report is empty, so `publishDiagnostics` never fires for any file in `packages/*`.

Verified against the moltzap monorepo (7 TS packages): pre-fix shows 0 findings from the root; post-fix shows **417** (390 WARN, 27 ERROR) and exits 1.

## Changes

- **New** `lsp/architecture/workspace-discovery.ts` — pure-Node module that parses workspace declarations and expands globs:
  - `pnpm-workspace.yaml` via a minimal `packages:` parser (no YAML dep added)
  - `package.json` `workspaces` array, plus the `{ packages: [...] }` object form
  - Globs: literal segments, `*`, `**`, leading `!` negation
  - Filters to directories that own a `tsconfig.json` (the analyzer requires one)
  - No declaration found → fallback to `[workspaceRoot]` (pre-fix behaviour)
- **`server/lsp-server.ts`** — `registerInitialWorkspaces` now expands each `workspaceFolder` via `discoverProjectRoots` and registers one engine per discovered package. `findEngineForUri`'s longest-prefix match routes opens to the right package without changes.
- **`check.ts`** — CI shim walks every discovered package and aggregates findings.
- **`index.ts`** — exports `discoverProjectRoots` + types on the public surface.

## Tests

- **13 new** unit tests in `tests/workspace-discovery.test.ts` — pnpm/npm parsing, glob expansion (`*`, `**`), negation, `tsconfig.json` filter, single-project fallback, `node_modules` / dotted-dir skipping.
- **2 new** end-to-end tests in `tests/check.test.ts` — pnpm monorepo fixture with one clean + one dirty package (asserts the dirty finding fires, exit 1, attribution is per-package); all-clean monorepo (exit 0).
- Full suite: **153 passing** (was 138).

## Out of scope

- Lazy per-file resolution for bespoke layouts (lerna-only, nx, manually-nested projects). The eager workspace-globs path covers the common case; lazy resolution can subsume this in a follow-up.
- The harness LSP tool surface still has no `pullDiagnostics` operation, so an agent talking to the proxy via Claude Code's LSP tool can't fetch architecture findings programmatically — diagnostics still flow through `publishDiagnostics` (IDE-squiggle channel) and the CI shim only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)