### PR TITLE
fix(bin): guard empty-array expansions under set -u (bash 3.2)

### DIFF
--- a/bin/safer-diff-scope
+++ b/bin/safer-diff-scope
@@ -47,7 +47,7 @@ if [ -n "$PR" ]; then
   fi
   REPO_FLAG=()
   [ -n "$REPO" ] && REPO_FLAG=(--repo "$REPO")
-  gh pr diff "$PR" "${REPO_FLAG[@]}" > "$TMP" 2>/dev/null || {
+  gh pr diff "$PR" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} > "$TMP" 2>/dev/null || {
     echo '{"error":"gh pr diff failed"}' >&2; exit 1
   }
 elif [ -n "$DIFF_FILE" ]; then

--- a/bin/safer-load-context
+++ b/bin/safer-load-context
@@ -32,7 +32,7 @@ fi
 REPO_FLAG=()
 [ -n "$REPO" ] && REPO_FLAG=(--repo "$REPO")
 
-OUT=$(gh issue view "$ISSUE" "${REPO_FLAG[@]}" --json number,title,body,labels,comments,state,url 2>&1)
+OUT=$(gh issue view "$ISSUE" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --json number,title,body,labels,comments,state,url 2>&1)
 RC=$?
 if [ $RC -ne 0 ]; then
   printf '{"error":"gh issue view failed","detail":"%s"}\n' "$(printf '%s' "$OUT" | head -1 | sed 's/"/\\"/g')"
@@ -42,7 +42,7 @@ fi
 if [ "$INCLUDE_PARENT" -eq 1 ]; then
   PARENT_NUM=$(printf '%s' "$OUT" | grep -oE 'Parent: #[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
   if [ -n "$PARENT_NUM" ]; then
-    PARENT_OUT=$(gh issue view "$PARENT_NUM" "${REPO_FLAG[@]}" --json number,title,body,labels,state,url 2>/dev/null || echo 'null')
+    PARENT_OUT=$(gh issue view "$PARENT_NUM" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --json number,title,body,labels,state,url 2>/dev/null || echo 'null')
     printf '{"issue":%s,"parent":%s}\n' "$OUT" "$PARENT_OUT"
   else
     printf '{"issue":%s,"parent":null}\n' "$OUT"

--- a/bin/safer-publish
+++ b/bin/safer-publish
@@ -243,7 +243,7 @@ if [ "${SAFER_PUBLISH_SOURCE:-0}" = "1" ]; then
 fi
 
 handle_fallback_flags "$@" || exit $?
-set -- "${SAFER_RESIDUAL_ARGS[@]}"
+set -- ${SAFER_RESIDUAL_ARGS[@]+"${SAFER_RESIDUAL_ARGS[@]}"}
 
 # ── Existing arg parser (unchanged below) ───────────────────────────
 
@@ -391,17 +391,17 @@ RC=0
 case "$KIND" in
   epic|issue)
     [ -z "$TITLE" ] && { echo "ERROR: --title required for $KIND" >&2; exit 1; }
-    OUT=$(_run_gh issue create "${REPO_FLAG[@]}" --title "$TITLE" "${body_args[@]}" "${label_args[@]}" 2>&1)
+    OUT=$(_run_gh issue create ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --title "$TITLE" ${body_args[@]+"${body_args[@]}"} ${label_args[@]+"${label_args[@]}"} 2>&1)
     RC=$?
     ;;
   comment)
     [ -z "$ISSUE" ] && { echo "ERROR: --issue required for comment" >&2; exit 1; }
-    OUT=$(_run_gh issue comment "$ISSUE" "${REPO_FLAG[@]}" "${body_args[@]}" 2>&1)
+    OUT=$(_run_gh issue comment "$ISSUE" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} ${body_args[@]+"${body_args[@]}"} 2>&1)
     RC=$?
     ;;
   pr-comment)
     [ -z "$PR" ] && { echo "ERROR: --pr required for pr-comment" >&2; exit 1; }
-    OUT=$(_run_gh pr comment "$PR" "${REPO_FLAG[@]}" "${body_args[@]}" 2>&1)
+    OUT=$(_run_gh pr comment "$PR" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} ${body_args[@]+"${body_args[@]}"} 2>&1)
     RC=$?
     ;;
   *)

--- a/bin/safer-transition-label
+++ b/bin/safer-transition-label
@@ -37,13 +37,13 @@ fi
 REPO_FLAG=()
 [ -n "$REPO" ] && REPO_FLAG=(--repo "$REPO")
 
-if gh issue edit "$ISSUE" "${REPO_FLAG[@]}" --remove-label "$FROM" --add-label "$TO" >/dev/null 2>&1; then
+if gh issue edit "$ISSUE" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --remove-label "$FROM" --add-label "$TO" >/dev/null 2>&1; then
   echo "TRANSITIONED #$ISSUE: $FROM → $TO"
   exit 0
 fi
 
 # Retry path: maybe the FROM label wasn't set. Try add-only.
-if gh issue edit "$ISSUE" "${REPO_FLAG[@]}" --add-label "$TO" >/dev/null 2>&1; then
+if gh issue edit "$ISSUE" ${REPO_FLAG[@]+"${REPO_FLAG[@]}"} --add-label "$TO" >/dev/null 2>&1; then
   echo "TRANSITIONED #$ISSUE: (no $FROM) → $TO"
   exit 0
 fi

--- a/tests/test-bin/test-empty-array-guards.sh
+++ b/tests/test-bin/test-empty-array-guards.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Regression: optional-flag arrays (REPO_FLAG, body_args, label_args,
+# SAFER_RESIDUAL_ARGS) must expand safely when empty. On bash 3.2 under
+# `set -u`, expanding an empty array as "${arr[@]}" aborts with
+# "unbound variable"; the bin scripts guard every such site with
+# ${arr[@]+"${arr[@]}"}. Each case invokes an affected script WITHOUT its
+# optional flags and asserts the abort message never surfaces.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/../test-helpers.sh"
+
+PLUGIN_DIR="$(cd "$HERE/../.." && pwd)"
+BIN_DIR="$PLUGIN_DIR/bin"
+
+UNBOUND="unbound variable"
+
+# assert_not_contains <haystack> <needle> [label] — inverse of assert_contains.
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="${3:-not contains}"
+  if printf '%s' "$haystack" | grep -qF "$needle"; then
+    echo "    FAIL ($label)"
+    echo "      unexpected substring: $needle"
+    echo "      actual: $haystack"
+    return 1
+  fi
+  return 0
+}
+
+# isolated_home — a HOME staged with the minimal ~/.zapbot/config.json the
+# zapbot-env helper requires. Combined with --attribute-to-user, safer-publish
+# resolves to plain-gh "user" mode and reaches its dispatch (no broker).
+isolated_home() {
+  local h
+  h=$(mktemp -d)
+  mkdir -p "$h/.zapbot"
+  printf '{"apiKey": "test-key"}' > "$h/.zapbot/config.json"
+  echo "$h"
+}
+
+test_transition_label_no_repo() {
+  # safer-transition-label sources the zapbot-env helper, which requires a
+  # staged config.json; isolate HOME so the test reaches the REPO_FLAG guard.
+  local home fake out rc
+  home=$(isolated_home)
+  fake=$(mock_gh_dir 0 "")
+  out=$(HOME="$home" PATH="$fake:$PATH" "$BIN_DIR/safer-transition-label" \
+    --issue 1 --from a --to b 2>&1); rc=$?
+  rm -rf "$fake" "$home"
+  assert_not_contains "$out" "$UNBOUND" "no unbound-variable abort" || return 1
+  assert_zero "$rc" "empty REPO_FLAG → exit 0" || return 1
+  assert_contains "$out" "TRANSITIONED" "transition succeeds"
+}
+
+test_load_context_no_repo() {
+  local fake out rc
+  fake=$(mock_gh_dir 0 '{"number":1,"title":"t","body":"","labels":[],"comments":[],"state":"OPEN","url":"u"}')
+  out=$(PATH="$fake:$PATH" "$BIN_DIR/safer-load-context" --issue 1 2>&1); rc=$?
+  rm -rf "$fake"
+  assert_not_contains "$out" "$UNBOUND" "no unbound-variable abort" || return 1
+  assert_zero "$rc" "empty REPO_FLAG → exit 0"
+}
+
+test_diff_scope_no_repo() {
+  local fake out rc
+  fake=$(mock_gh_dir 0 'diff --git a/x b/x')
+  out=$(PATH="$fake:$PATH" "$BIN_DIR/safer-diff-scope" --pr 1 2>&1); rc=$?
+  rm -rf "$fake"
+  assert_not_contains "$out" "$UNBOUND" "no unbound-variable abort" || return 1
+  assert_zero "$rc" "empty REPO_FLAG on --pr path → exit 0"
+}
+
+test_publish_residual_args_guard() {
+  # Only an identity flag: SAFER_RESIDUAL_ARGS ends up empty and is expanded
+  # at `set -- ...` before arg validation runs.
+  local home out rc
+  home=$(isolated_home)
+  out=$(HOME="$home" "$BIN_DIR/safer-publish" --attribute-to-user 2>&1); rc=$?
+  rm -rf "$home"
+  assert_not_contains "$out" "$UNBOUND" "empty SAFER_RESIDUAL_ARGS guarded" || return 1
+  # Missing --kind is the expected failure here, not an array abort.
+  assert_nonzero "$rc" "missing --kind still errors"
+}
+
+test_publish_issue_create_no_repo_no_labels() {
+  local home fake out rc
+  home=$(isolated_home)
+  fake=$(mock_gh_dir 0 'https://github.com/o/r/issues/1')
+  out=$(HOME="$home" PATH="$fake:$PATH" "$BIN_DIR/safer-publish" \
+    --attribute-to-user --kind issue --title T --body B 2>&1); rc=$?
+  rm -rf "$fake" "$home"
+  assert_not_contains "$out" "$UNBOUND" "empty REPO_FLAG/label_args guarded" || return 1
+  assert_zero "$rc" "issue create without --repo/--label → exit 0"
+}
+
+test_publish_comment_no_repo_no_body() {
+  local home fake out rc
+  home=$(isolated_home)
+  fake=$(mock_gh_dir 0 'https://github.com/o/r/issues/5#comment')
+  out=$(HOME="$home" PATH="$fake:$PATH" "$BIN_DIR/safer-publish" \
+    --attribute-to-user --kind comment --issue 5 2>&1); rc=$?
+  rm -rf "$fake" "$home"
+  assert_not_contains "$out" "$UNBOUND" "empty REPO_FLAG/body_args guarded" || return 1
+  assert_zero "$rc" "comment without --repo/--body → exit 0"
+}
+
+run_test "safer-transition-label: no --repo → no unbound abort" test_transition_label_no_repo
+run_test "safer-load-context: no --repo → no unbound abort" test_load_context_no_repo
+run_test "safer-diff-scope: --pr without --repo → no unbound abort" test_diff_scope_no_repo
+run_test "safer-publish: empty residual args → no unbound abort" test_publish_residual_args_guard
+run_test "safer-publish: issue create without --repo/--label → no unbound abort" test_publish_issue_create_no_repo_no_labels
+run_test "safer-publish: comment without --repo/--body → no unbound abort" test_publish_comment_no_repo_no_body
+report

--- a/tests/test-bin/test-escalate.sh
+++ b/tests/test-bin/test-escalate.sh
@@ -7,6 +7,11 @@ source "$HERE/../test-helpers.sh"
 PLUGIN_DIR="$(cd "$HERE/../.." && pwd)"
 BIN="$PLUGIN_DIR/bin/safer-escalate"
 
+# safer-escalate sources _safer-zapbot-env.sh, which requires a staged
+# ~/.zapbot/config.json; isolate HOME so tests do not depend on the
+# developer's real zapbot config.
+stage_zapbot_home
+
 test_requires_args() {
   local rc
   "$BIN" >/dev/null 2>&1; rc=$?

--- a/tests/test-bin/test-publish.sh
+++ b/tests/test-bin/test-publish.sh
@@ -10,6 +10,11 @@ source "$HERE/../test-helpers.sh"
 PLUGIN_DIR="$(cd "$HERE/../.." && pwd)"
 BIN="$PLUGIN_DIR/bin/safer-publish"
 
+# safer-publish sources _safer-zapbot-env.sh, which requires a staged
+# ~/.zapbot/config.json; isolate HOME so the negative arg-validation tests
+# exercise the parser rather than aborting in the env helper.
+stage_zapbot_home
+
 test_requires_kind() {
   local rc
   "$BIN" >/dev/null 2>&1; rc=$?

--- a/tests/test-bin/test-safer-peer-message.sh
+++ b/tests/test-bin/test-safer-peer-message.sh
@@ -21,7 +21,7 @@ run_cli() {
     shift 2
   done
   local rc=0
-  env -i HOME="$HOME" PATH="$PATH" "${env_args[@]}" "$CLI" "$@" >/dev/null 2>&1 <<< "test body" || rc=$?
+  env -i HOME="$HOME" PATH="$PATH" ${env_args[@]+"${env_args[@]}"} "$CLI" "$@" >/dev/null 2>&1 <<< "test body" || rc=$?
   echo "$rc"
 }
 

--- a/tests/test-bin/test-transition-label.sh
+++ b/tests/test-bin/test-transition-label.sh
@@ -8,6 +8,11 @@ source "$HERE/../test-helpers.sh"
 PLUGIN_DIR="$(cd "$HERE/../.." && pwd)"
 BIN="$PLUGIN_DIR/bin/safer-transition-label"
 
+# safer-transition-label sources _safer-zapbot-env.sh, which requires a
+# staged ~/.zapbot/config.json; isolate HOME so tests do not depend on the
+# developer's real zapbot config.
+stage_zapbot_home
+
 # mock_gh_dir_sequence <rc1> <rc2> — first gh call returns rc1, second returns rc2.
 mock_gh_dir_sequence() {
   local rc1="$1"

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -101,6 +101,21 @@ GHEOF
   echo "$dir"
 }
 
+# stage_zapbot_home
+# Exports HOME to a fresh temp dir holding the minimal ~/.zapbot/config.json
+# that _safer-zapbot-env.sh requires, so suites invoking helper-sourcing bins
+# (safer-escalate, safer-transition-label, safer-publish) run without the
+# developer's real zapbot config. Registers cleanup on EXIT; call once before
+# the run_test block.
+stage_zapbot_home() {
+  local dir
+  dir=$(mktemp -d)
+  mkdir -p "$dir/.zapbot"
+  printf '{"apiKey": "test-key"}' > "$dir/.zapbot/config.json"
+  export HOME="$dir"
+  trap "rm -rf '$dir'" EXIT
+}
+
 report() {
   echo ""
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Problem

On macOS **bash 3.2.57** (the system bash), expanding an empty array as `"${arr[@]}"` under `set -u` aborts the script with `unbound variable`. Several `bin/` utilities set `set -uo pipefail` and build optional-flag arrays that stay **empty whenever the optional flag is omitted**, so they abort before ever calling `gh`.

Two observed failures:

- **`safer-publish`** — `REPO_FLAG` (built at lines 287–288, expanded at **line 394**): `issue create "${REPO_FLAG[@]}" …` aborts when `--repo` is not passed.
- **`safer-transition-label`** — `REPO_FLAG` expanded at **line 40** (and 46): `gh issue edit "$ISSUE" "${REPO_FLAG[@]}" …` aborts when `--repo` is not passed.

Repro one-liner (exit 127, `unbound variable`):

```
bash -uc 'a=(); printf "%s" "${a[@]}"'
```

The existing test suite was already **red on bash 3.2** because of this: `test-transition-label` (3), `test-load-context` (3), and `test-publish-bot-routing` (3) all failed with `REPO_FLAG[@]: unbound variable`.

## Fix

Guard every possibly-empty array expansion with the portable idiom `${arr[@]+"${arr[@]}"}`, which expands to nothing when the array is empty and to the correctly word-split elements otherwise — on **bash 3.2 and 4+** alike. No shebang changes, no bash-4 requirement, no refactors — only the expansion sites.

### Fixed sites (full sweep of `bin/`)

| Script | Array | Line(s) |
|---|---|---|
| `safer-transition-label` | `REPO_FLAG` | 40, 46 |
| `safer-publish` | `SAFER_RESIDUAL_ARGS` | 246 |
| `safer-publish` | `REPO_FLAG`, `body_args`, `label_args` | 394 |
| `safer-publish` | `REPO_FLAG`, `body_args` | 399, 404 |
| `safer-load-context` | `REPO_FLAG` | 35, 45 |
| `safer-diff-scope` | `REPO_FLAG` | 50 |

`safer-publish:316` (`for L in "${LBL_ARR[@]}"`) is intentionally left unguarded: `LBL_ARR` is populated by `read -ra` inside an `[ -n "$LABELS" ]` guard, so it is provably non-empty at that expansion.

### Also fixed (same bug class, in the test harness)

`tests/test-bin/test-safer-peer-message.sh:24` had the identical empty-array abort on `env_args`, which masked **all** peer-message coverage on bash 3.2 (6 tests). Guarded with the same idiom.

## Tests

Added `tests/test-bin/test-empty-array-guards.sh` — a regression suite that invokes each affected script **with its optional flags omitted** and asserts the `unbound variable` abort never surfaces. It is hermetic (stages its own `HOME` for scripts that source the zapbot-env helper) and was verified to **fail against the unpatched scripts** (each unpatched scenario emits the abort).

Full unit suite on bash 3.2.57: **154 passed, 1 failed**, up from 138 passed / 16 failed before the fix. The one remaining failure (`test-orchestrate-auto-dispatch`: "idempotency marker extracts teammate + timestamp") is a pre-existing regex-extraction bug unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up: hermetic test suites (commit 2)

`safer-escalate`, `safer-transition-label`, and `safer-publish` source `_safer-zapbot-env.sh`, which hard-requires `$HOME/.zapbot/config.json`. Their suites only passed because the developer's real config happened to exist — on a clean CI HOME they aborted in the env helper before reaching the assertions (`test-transition-label` 2/6, `test-escalate` 3/4).

Added `stage_zapbot_home` to the shared harness (stages a temp `HOME` with a minimal `config.json`, cleans up on `EXIT`) and called it in the three affected suites. The full unit suite now passes **identically under a poisoned empty HOME** — 154 passed / 1 failed (the same pre-existing, unrelated `test-orchestrate-auto-dispatch` regex failure).
